### PR TITLE
[Feat] 첫 로그인 후 온보딩 절차

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -27,6 +27,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-webmvc")
     implementation ("org.springframework.boot:spring-boot-starter-restclient")
+    implementation("org.springframework.boot:spring-boot-flyway")
+    implementation("org.flywaydb:flyway-database-postgresql")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("tools.jackson.module:jackson-module-kotlin")
     implementation("com.google.api-client:google-api-client:2.7.0")

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthController.kt
@@ -45,7 +45,8 @@ class AuthController(
             id = requireNotNull(meUser.id),
             nickname = meUser.nickname,
             email = meUser.email,
-            profileImageUrl = meUser.profileImageUrl
+            profileImageUrl = meUser.profileImageUrl,
+            bio = meUser.bio,
         )
     }
 

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthController.kt
@@ -89,13 +89,18 @@ class AuthController(
 
         val verified = authService.verifyGoogleIdToken(idToken)
 
-        val (sub, email, picture) = authService.getGoogleUserInfo(accessToken)
+        val (sub, name, email, picture) = authService.getGoogleUserInfo(accessToken)
 
         if (verified.payload.subject != sub) {
             throw OAuthAuthenticationException()
         }
 
-        val currentUser = authService.findOrCreateGoogleUser(sub,picture,email)
+        val currentUser = authService.findOrCreateGoogleUser(
+            sub = sub,
+            name = name,
+            picture = picture,
+            email = email,
+        )
         val issuedJwt = jwtTokenService.createAccessToken(currentUser)
         val authCookie = ResponseCookie.from(accessTokenCookieName, issuedJwt)
             .httpOnly(true)

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthController.kt
@@ -1,7 +1,10 @@
 package io.github.kitae9999.openlog.auth
 
+import io.github.kitae9999.openlog.auth.dto.CompleteOnboardingRequest
 import io.github.kitae9999.openlog.auth.dto.MeResponse
 import io.github.kitae9999.openlog.auth.exception.OAuthAuthenticationException
+import io.github.kitae9999.openlog.user.entity.User
+import jakarta.validation.Valid
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
@@ -10,6 +13,8 @@ import org.springframework.http.ResponseCookie
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.CookieValue
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -32,22 +37,22 @@ class AuthController(
     fun getMe(
         request: HttpServletRequest
     ): MeResponse {
-        val accessToken = request.cookies
-            ?. firstOrNull { it. name == accessTokenCookieName }
-            ?. value
-            ?: throw OAuthAuthenticationException() // 체인 전체를 보고 처리
+        val meUser = authService.getCurrentUser(resolveCurrentUserId(request))
 
-        val userId = jwtTokenService.parseUserId(accessToken)
+        return meUser.toMeResponse() // 코틀린 확장 함수 (메서드 아님)
+    }
 
-        val meUser = authService.getCurrentUser(userId)
-
-        return MeResponse(
-            id = requireNotNull(meUser.id),
-            nickname = meUser.nickname,
-            email = meUser.email,
-            profileImageUrl = meUser.profileImageUrl,
-            bio = meUser.bio,
+    @PostMapping("onboarding")
+    fun completeOnboarding(
+        request: HttpServletRequest,
+        @Valid @RequestBody onboardingRequest: CompleteOnboardingRequest,
+    ): MeResponse {
+        val currentUser = authService.completeOnboarding(
+            userId = resolveCurrentUserId(request),
+            request = onboardingRequest,
         )
+
+        return currentUser.toMeResponse()
     }
 
     @GetMapping("google")
@@ -89,7 +94,7 @@ class AuthController(
 
         val verified = authService.verifyGoogleIdToken(idToken)
 
-        val (sub, name, email, picture) = authService.getGoogleUserInfo(accessToken)
+        val (sub, email, picture) = authService.getGoogleUserInfo(accessToken)
 
         if (verified.payload.subject != sub) {
             throw OAuthAuthenticationException()
@@ -97,7 +102,6 @@ class AuthController(
 
         val currentUser = authService.findOrCreateGoogleUser(
             sub = sub,
-            name = name,
             picture = picture,
             email = email,
         )
@@ -112,8 +116,37 @@ class AuthController(
 
         return ResponseEntity.status(HttpStatus.FOUND)
             .header(HttpHeaders.SET_COOKIE, deleteCookie.toString(), authCookie.toString())
-            .location(URI.create(frontendHomeUrl))
+            .location(
+                URI.create(
+                    if (currentUser.isOnboardingComplete()) {
+                        frontendHomeUrl
+                    } else {
+                        URI.create(frontendHomeUrl).resolve("/onboarding").toString()
+                    },
+                )
+            )
             .build()
+    }
+
+    private fun resolveCurrentUserId(request: HttpServletRequest): Long {
+        val accessToken = request.cookies
+            ?.firstOrNull { it.name == accessTokenCookieName }
+            ?.value
+            ?: throw OAuthAuthenticationException()
+
+        return jwtTokenService.parseUserId(accessToken)
+    }
+
+    private fun User.toMeResponse(): MeResponse {
+        return MeResponse(
+            id = requireNotNull(id),
+            username = username,
+            nickname = nickname,
+            email = email,
+            profileImageUrl = profileImageUrl,
+            bio = bio,
+            isOnboardingComplete = isOnboardingComplete(),
+        )
     }
 
 //    @GetMapping("github")

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthService.kt
@@ -6,9 +6,11 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier
 import com.google.api.client.http.javanet.NetHttpTransport
 import com.google.api.client.json.gson.GsonFactory
 import io.github.kitae9999.openlog.auth.entity.OauthAccount
+import io.github.kitae9999.openlog.auth.dto.CompleteOnboardingRequest
 import io.github.kitae9999.openlog.auth.exception.InvalidOAuthStateException
 import io.github.kitae9999.openlog.auth.exception.OAuthAuthenticationException
 import io.github.kitae9999.openlog.auth.repository.OauthAccountRepository
+import io.github.kitae9999.openlog.common.exception.UsernameAlreadyTakenException
 import io.github.kitae9999.openlog.user.entity.User
 import io.github.kitae9999.openlog.user.repository.UserRepository
 import jakarta.transaction.Transactional
@@ -50,7 +52,6 @@ class AuthService(
 
     data class GoogleUserInfoResponse(
         val sub: String,
-        val name: String? = null,
         val email: String? = null,
         val picture: String? = null,
     )
@@ -153,7 +154,6 @@ class AuthService(
     @Transactional
     fun findOrCreateGoogleUser(
         sub: String,
-        name: String?,
         picture: String?,
         email: String?,
     ): User {
@@ -166,7 +166,6 @@ class AuthService(
 
         val user = userRepository.save(
             User(
-                nickname = name,
                 profileImageUrl = picture,
                 email = email,
             )
@@ -178,6 +177,29 @@ class AuthService(
                 provider = "google",
                 providerUserId = sub,
             )
+        )
+
+        return user
+    }
+
+    @Transactional
+    fun completeOnboarding(
+        userId: Long,
+        request: CompleteOnboardingRequest,
+    ): User {
+        val user = getCurrentUser(userId)
+        val normalizedNickname = request.nickname.trim()
+        val normalizedUsername = request.username.trim()
+        val normalizedBio = request.bio?.trim()?.takeIf { it.isNotEmpty() }
+
+        if (user.username != normalizedUsername && userRepository.existsByUsername(normalizedUsername)) {
+            throw UsernameAlreadyTakenException()
+        }
+
+        user.completeOnboarding(
+            nickname = normalizedNickname,
+            username = normalizedUsername,
+            bio = normalizedBio,
         )
 
         return user

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthService.kt
@@ -50,6 +50,7 @@ class AuthService(
 
     data class GoogleUserInfoResponse(
         val sub: String,
+        val name: String? = null,
         val email: String? = null,
         val picture: String? = null,
     )
@@ -150,7 +151,12 @@ class AuthService(
     }
 
     @Transactional
-    fun findOrCreateGoogleUser(sub: String, picture: String?, email: String?): User {
+    fun findOrCreateGoogleUser(
+        sub: String,
+        name: String?,
+        picture: String?,
+        email: String?,
+    ): User {
         val existingAccount = oauthAccountRepository
             .findByProviderAndProviderUserId("google", sub)
 
@@ -160,6 +166,7 @@ class AuthService(
 
         val user = userRepository.save(
             User(
+                nickname = name,
                 profileImageUrl = picture,
                 email = email,
             )

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthService.kt
@@ -1,5 +1,6 @@
 package io.github.kitae9999.openlog.auth
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier
 import com.google.api.client.http.javanet.NetHttpTransport
@@ -71,8 +72,10 @@ class AuthService(
 
 
     data class  GoogleTokenResponse(
+        @JsonProperty("access_token")
         val accessToken: String,
         val scope: String,
+        @JsonProperty("id_token")
         val idToken: String,
     )
 

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/dto/CompleteOnboardingRequest.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/dto/CompleteOnboardingRequest.kt
@@ -1,0 +1,22 @@
+package io.github.kitae9999.openlog.auth.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+
+data class CompleteOnboardingRequest(
+    @field:NotBlank(message = "닉네임은 필수입니다.")
+    @field:Size(max = 40, message = "닉네임은 40자 이하로 입력해주세요.")
+    val nickname: String,
+
+    @field:NotBlank(message = "username은 필수입니다.")
+    @field:Size(min = 3, max = 20, message = "username은 3자 이상 20자 이하로 입력해주세요.")
+    @field:Pattern(
+        regexp = "^[a-z0-9]+$",
+        message = "username은 영어 소문자와 숫자만 사용할 수 있습니다.",
+    )
+    val username: String,
+
+    @field:Size(max = 160, message = "bio는 160자 이하로 입력해주세요.")
+    val bio: String? = null,
+)

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/dto/MeResponse.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/dto/MeResponse.kt
@@ -2,8 +2,10 @@ package io.github.kitae9999.openlog.auth.dto
 
 data class MeResponse(
     val id : Long,
+    val username: String?,
     val nickname: String?,
     val profileImageUrl: String?,
     val email: String?,
     val bio: String?,
+    val isOnboardingComplete: Boolean,
 )

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/dto/MeResponse.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/dto/MeResponse.kt
@@ -5,4 +5,5 @@ data class MeResponse(
     val nickname: String?,
     val profileImageUrl: String?,
     val email: String?,
+    val bio: String?,
 )

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/common/exception/GlobalExceptionHandler.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/common/exception/GlobalExceptionHandler.kt
@@ -5,6 +5,7 @@ import io.github.kitae9999.openlog.auth.exception.OAuthAuthenticationException
 import io.github.kitae9999.openlog.auth.exception.UnauthorizedException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
@@ -30,6 +31,19 @@ class GlobalExceptionHandler {
         )
     }
 
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleMethodArgumentNotValidException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
+        val message = e.bindingResult.fieldErrors.firstOrNull()?.defaultMessage
+            ?: "입력값을 다시 확인해주세요."
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+            ErrorResponse(
+                code = "VALIDATION_ERROR",
+                message = message,
+            )
+        )
+    }
+
     @ExceptionHandler(OAuthAuthenticationException::class)
     fun handleOAuthAuthenticationException(e: OAuthAuthenticationException): ResponseEntity<ErrorResponse> {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
@@ -46,6 +60,16 @@ class GlobalExceptionHandler {
             ErrorResponse(
                 code="NOT_LOGGED_ IN",
                 message = e.message ?: "로그인이 필요합니다."
+            )
+        )
+    }
+
+    @ExceptionHandler(UsernameAlreadyTakenException::class)
+    fun handleUsernameAlreadyTakenException(e: UsernameAlreadyTakenException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(
+            ErrorResponse(
+                code = "USERNAME_TAKEN",
+                message = e.message ?: "이미 사용 중인 username입니다.",
             )
         )
     }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/common/exception/UsernameAlreadyTakenException.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/common/exception/UsernameAlreadyTakenException.kt
@@ -1,0 +1,3 @@
+package io.github.kitae9999.openlog.common.exception
+
+class UsernameAlreadyTakenException : RuntimeException("이미 사용 중인 username입니다.")

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/entity/User.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/entity/User.kt
@@ -15,6 +15,8 @@ class User(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
 
+    username: String? = null,
+
     nickname: String? = null,
 
     profileImageUrl: String? = null,
@@ -23,6 +25,10 @@ class User(
 
     email: String? = null,
 ){
+    @Column(unique = true)
+    var username: String? = username
+        protected set
+
     @Column()
     var nickname: String? = nickname
         protected set
@@ -46,4 +52,18 @@ class User(
     @Column(name = "updated_at", nullable = false)
     var updatedAt: LocalDateTime = LocalDateTime.now()
         protected set
+
+    fun completeOnboarding(
+        nickname: String,
+        username: String,
+        bio: String?,
+    ) {
+        this.nickname = nickname
+        this.username = username
+        this.bio = bio
+        this.updatedAt = LocalDateTime.now()
+    }
+
+    fun isOnboardingComplete(): Boolean =
+        !nickname.isNullOrBlank() && !username.isNullOrBlank()
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/repository/UserRepository.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/repository/UserRepository.kt
@@ -4,4 +4,5 @@ import io.github.kitae9999.openlog.user.entity.User
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserRepository: JpaRepository<User, Long> {
+    fun existsByUsername(username: String): Boolean
 }

--- a/backend/src/main/resources/db/migration/V20260403__restore_users_username_for_onboarding.sql
+++ b/backend/src/main/resources/db/migration/V20260403__restore_users_username_for_onboarding.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE public.users
+    ADD COLUMN IF NOT EXISTS username VARCHAR;
+
+CREATE UNIQUE INDEX IF NOT EXISTS users_username_key
+    ON public.users (username);
+
+COMMIT;

--- a/frontend/app/onboarding/actions.ts
+++ b/frontend/app/onboarding/actions.ts
@@ -1,0 +1,99 @@
+"use server";
+
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { API_CONFIG } from "@/shared/api";
+
+const USERNAME_PATTERN = /^[a-z0-9]+$/;
+
+export type OnboardingFormValues = {
+  nickname: string;
+  username: string;
+  bio: string;
+};
+
+export type OnboardingActionState = {
+  values: OnboardingFormValues;
+  errors: Partial<Record<"nickname" | "username" | "bio" | "form", string>>;
+};
+
+export async function submitOnboarding(
+  _prevState: OnboardingActionState,
+  formData: FormData,
+): Promise<OnboardingActionState> {
+  const values = {
+    nickname: String(formData.get("nickname") ?? "").trim(),
+    username: String(formData.get("username") ?? "").trim(),
+    bio: String(formData.get("bio") ?? "").trim(),
+  };
+  const errors: OnboardingActionState["errors"] = {};
+
+  if (!values.nickname) {
+    errors.nickname = "닉네임은 필수입니다.";
+  } else if (values.nickname.length > 40) {
+    errors.nickname = "닉네임은 40자 이하로 입력해주세요.";
+  }
+
+  if (!values.username) {
+    errors.username = "username은 필수입니다.";
+  } else if (values.username.length < 3 || values.username.length > 20) {
+    errors.username = "username은 3자 이상 20자 이하로 입력해주세요.";
+  } else if (!USERNAME_PATTERN.test(values.username)) {
+    errors.username = "username은 영어 소문자와 숫자만 사용할 수 있습니다.";
+  }
+
+  if (values.bio.length > 160) {
+    errors.bio = "bio는 160자 이하로 입력해주세요.";
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return { values, errors };
+  }
+
+  const headerStore = await headers();
+  const response = await fetch(`${API_CONFIG.baseURL}/auth/onboarding`, {
+    method: "POST",
+    cache: "no-store",
+    headers: {
+      "content-type": "application/json",
+      cookie: headerStore.get("cookie") ?? "",
+    },
+    body: JSON.stringify({
+      nickname: values.nickname,
+      username: values.username,
+      bio: values.bio || null,
+    }),
+  });
+
+  if (response.ok) {
+    redirect("/");
+  }
+
+  let errorBody: { code?: string; message?: string } | null = null;
+
+  try {
+    errorBody = (await response.json()) as { code?: string; message?: string };
+  } catch {
+    errorBody = null;
+  }
+
+  if (response.status === 401) {
+    redirect("/");
+  }
+
+  if (response.status === 409 && errorBody?.code === "USERNAME_TAKEN") {
+    return {
+      values,
+      errors: {
+        username: errorBody.message ?? "이미 사용 중인 username입니다.",
+      },
+    };
+  }
+
+  return {
+    values,
+    errors: {
+      form: errorBody?.message ?? "온보딩 저장 중 문제가 발생했습니다.",
+    },
+  };
+}

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import { getIncompleteUserOrRedirectHome } from "@/features/auth/api/requireOnboarding";
+import { HomeFeed } from "@/widgets/home-feed/ui";
+import { OnboardingView } from "@/widgets/onboarding/ui";
+
+export const metadata: Metadata = {
+  title: "Onboarding | OpenLog",
+  description: "Finish setting up your OpenLog profile.",
+};
+
+export default async function OnboardingPage() {
+  const user = await getIncompleteUserOrRedirectHome();
+
+  return (
+    <>
+      <HomeFeed viewer={user} />
+      <OnboardingView user={user} />
+    </>
+  );
+}

--- a/frontend/app/posts/[slug]/page.tsx
+++ b/frontend/app/posts/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { getUser } from "@/features/auth/api/getUser";
+import { getUserOrRedirectToOnboarding } from "@/features/auth/api/requireOnboarding";
 import { Footer, Header } from "@/widgets/chrome/ui";
 import { PostArticle } from "@/widgets/post/ui";
 import {
@@ -19,14 +19,17 @@ export default async function PostPage({
 
   const entry = getPostEntry(slug);
   if (!entry) notFound();
-  const viewer = await getUser();
+  const viewer = await getUserOrRedirectToOnboarding();
 
   const articleHref = `/posts/${slug}`;
   const suggestsHref = `${articleHref}/suggests`;
 
   return (
     <div className="min-h-dvh bg-white text-zinc-950">
-      <Header isLoggedIn={!!viewer} />
+      <Header
+        isLoggedIn={!!viewer}
+        profileImageUrl={viewer?.profileImageUrl}
+      />
 
       <main className="mx-auto w-full max-w-[1083px] pb-16 pt-6 sm:px-8">
         <PostArticle

--- a/frontend/app/posts/[slug]/suggests/[suggestId]/page.tsx
+++ b/frontend/app/posts/[slug]/suggests/[suggestId]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { getUser } from "@/features/auth/api/getUser";
+import { getUserOrRedirectToOnboarding } from "@/features/auth/api/requireOnboarding";
 import { Footer, Header } from "@/widgets/chrome/ui";
 import {
   getPostEntry,
@@ -26,14 +26,17 @@ export default async function PostSuggestionDetailPage({
   const suggestion = getSuggestion(slug, suggestId);
 
   if (!entry || !suggestion) notFound();
-  const viewer = await getUser();
+  const viewer = await getUserOrRedirectToOnboarding();
 
   const articleHref = `/posts/${slug}`;
   const suggestsHref = `${articleHref}/suggests`;
 
   return (
     <div className="min-h-dvh bg-white text-zinc-950">
-      <Header isLoggedIn={!!viewer} />
+      <Header
+        isLoggedIn={!!viewer}
+        profileImageUrl={viewer?.profileImageUrl}
+      />
 
       <main className="mx-auto w-full max-w-[1083px] px-4 pb-16 pt-6 sm:px-8">
         <SuggestionDetail

--- a/frontend/app/posts/[slug]/suggests/page.tsx
+++ b/frontend/app/posts/[slug]/suggests/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { getUser } from "@/features/auth/api/getUser";
+import { getUserOrRedirectToOnboarding } from "@/features/auth/api/requireOnboarding";
 import { Footer, Header } from "@/widgets/chrome/ui";
 import { getPostEntry } from "@/entities/post/model";
 import { PostSuggests } from "@/widgets/post/ui";
@@ -16,14 +16,17 @@ export default async function PostSuggestsPage({
 
   const entry = getPostEntry(slug);
   if (!entry) notFound();
-  const viewer = await getUser();
+  const viewer = await getUserOrRedirectToOnboarding();
 
   const articleHref = `/posts/${slug}`;
   const suggestsHref = `${articleHref}/suggests`;
 
   return (
     <div className="min-h-dvh bg-white text-zinc-950">
-      <Header isLoggedIn={!!viewer} />
+      <Header
+        isLoggedIn={!!viewer}
+        profileImageUrl={viewer?.profileImageUrl}
+      />
 
       <main className="mx-auto w-full max-w-[1083px] px-4 pb-16 pt-6 sm:px-8">
         <PostSuggests

--- a/frontend/app/write/page.tsx
+++ b/frontend/app/write/page.tsx
@@ -10,5 +10,10 @@ export const metadata: Metadata = {
 export default async function WritePage() {
   const data = await getUser();
 
-  return <WriteView isLoggedIn={!!data} />;
+  return (
+    <WriteView
+      isLoggedIn={!!data}
+      profileImageUrl={data?.profileImageUrl}
+    />
+  );
 }

--- a/frontend/app/write/page.tsx
+++ b/frontend/app/write/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { getUser } from "@/features/auth/api/getUser";
+import { getUserOrRedirectToOnboarding } from "@/features/auth/api/requireOnboarding";
 import { WriteView } from "@/widgets/write/ui";
 
 export const metadata: Metadata = {
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 };
 
 export default async function WritePage() {
-  const data = await getUser();
+  const data = await getUserOrRedirectToOnboarding();
 
   return (
     <WriteView

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,5 +1,14 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/frontend/public/common/default-avatar.svg
+++ b/frontend/public/common/default-avatar.svg
@@ -1,0 +1,6 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="160" height="160" rx="80" fill="#F4F4F5"/>
+  <circle cx="80" cy="60" r="26" fill="#A1A1AA"/>
+  <path d="M36 128C36 103.699 55.6995 84 80 84C104.301 84 124 103.699 124 128V130H36V128Z" fill="#A1A1AA"/>
+  <circle cx="80" cy="80" r="78" stroke="#E4E4E7" stroke-width="4"/>
+</svg>

--- a/frontend/public/demo/default-avatar.svg
+++ b/frontend/public/demo/default-avatar.svg
@@ -1,0 +1,6 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="160" height="160" rx="80" fill="#F4F4F5"/>
+  <circle cx="80" cy="60" r="26" fill="#A1A1AA"/>
+  <path d="M36 128C36 103.699 55.6995 84 80 84C104.301 84 124 103.699 124 128V130H36V128Z" fill="#A1A1AA"/>
+  <circle cx="80" cy="80" r="78" stroke="#E4E4E7" stroke-width="4"/>
+</svg>

--- a/frontend/src/01_widgets/chrome/ui/Header.tsx
+++ b/frontend/src/01_widgets/chrome/ui/Header.tsx
@@ -9,15 +9,14 @@ import { SearchBar } from "./SearchBar";
 
 export function Header({
   isLoggedIn,
+  profileImageUrl,
   showWriteAction = true,
 }: {
   isLoggedIn: boolean;
+  profileImageUrl?: string;
   showWriteAction?: boolean;
 }) {
-  // const currentUser = await getUser();
-  // const profileImageUrl = currentUser?.profileImageUrl ?? assets.defaultAvatar;
-
-  const profileImageUrl = assets.defaultAvatar;
+  const resolvedProfileImageUrl = profileImageUrl ?? assets.defaultAvatar;
 
   return (
     <header className="sticky top-0 z-40 border-b border-zinc-200/70 bg-white/80 backdrop-blur">
@@ -94,7 +93,7 @@ export function Header({
                 className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
               >
                 <Image
-                  src={profileImageUrl}
+                  src={resolvedProfileImageUrl}
                   alt="Profile avatar"
                   width={32}
                   height={32}

--- a/frontend/src/01_widgets/chrome/ui/Header.tsx
+++ b/frontend/src/01_widgets/chrome/ui/Header.tsx
@@ -5,14 +5,18 @@ import { cn } from "@/shared/lib/cn";
 import { GuestActions } from "@/features/auth/ui";
 import { logoMarkClassName, logoWordmarkClassName, navLinks } from "./brand";
 import { SearchBar } from "./SearchBar";
+import { getUser } from "@/features/auth/api/getUser";
 
-export function Header({
+export async function Header({
   isLoggedIn,
   showWriteAction = true,
 }: {
   isLoggedIn: boolean;
   showWriteAction?: boolean;
 }) {
+  const currentUser = await getUser();
+  const profileImageUrl = currentUser?.profileImageUrl ?? assets.defaultAvatar;
+
   return (
     <header className="sticky top-0 z-40 border-b border-zinc-200/70 bg-white/80 backdrop-blur">
       <div className="mx-auto flex h-16 w-full max-w-[1083px] items-center justify-between gap-4 px-4 sm:px-8">
@@ -88,7 +92,7 @@ export function Header({
                 className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
               >
                 <Image
-                  src={assets.avatarA}
+                  src={profileImageUrl}
                   alt="Profile avatar"
                   width={32}
                   height={32}

--- a/frontend/src/01_widgets/chrome/ui/Header.tsx
+++ b/frontend/src/01_widgets/chrome/ui/Header.tsx
@@ -5,17 +5,19 @@ import { cn } from "@/shared/lib/cn";
 import { GuestActions } from "@/features/auth/ui";
 import { logoMarkClassName, logoWordmarkClassName, navLinks } from "./brand";
 import { SearchBar } from "./SearchBar";
-import { getUser } from "@/features/auth/api/getUser";
+// import { getUser } from "@/features/auth/api/getUser";
 
-export async function Header({
+export function Header({
   isLoggedIn,
   showWriteAction = true,
 }: {
   isLoggedIn: boolean;
   showWriteAction?: boolean;
 }) {
-  const currentUser = await getUser();
-  const profileImageUrl = currentUser?.profileImageUrl ?? assets.defaultAvatar;
+  // const currentUser = await getUser();
+  // const profileImageUrl = currentUser?.profileImageUrl ?? assets.defaultAvatar;
+
+  const profileImageUrl = assets.defaultAvatar;
 
   return (
     <header className="sticky top-0 z-40 border-b border-zinc-200/70 bg-white/80 backdrop-blur">

--- a/frontend/src/01_widgets/chrome/ui/Header.tsx
+++ b/frontend/src/01_widgets/chrome/ui/Header.tsx
@@ -13,7 +13,7 @@ export function Header({
   showWriteAction = true,
 }: {
   isLoggedIn: boolean;
-  profileImageUrl?: string;
+  profileImageUrl?: string | null;
   showWriteAction?: boolean;
 }) {
   const resolvedProfileImageUrl = profileImageUrl ?? assets.defaultAvatar;

--- a/frontend/src/01_widgets/home-feed/ui/HomeFeed.tsx
+++ b/frontend/src/01_widgets/home-feed/ui/HomeFeed.tsx
@@ -23,7 +23,7 @@ export async function HomeFeed({
 
   return (
     <div className="min-h-dvh bg-white text-zinc-950">
-      <Header isLoggedIn={isLoggedIn} />
+      <Header isLoggedIn={isLoggedIn} profileImageUrl={data?.profileImageUrl} />
       <main className="mx-auto w-full max-w-[1083px] px-4 pb-16 pt-6 sm:px-8">
         <div className="grid grid-cols-1 gap-10 lg:grid-cols-[minmax(0,1fr)_340px]">
           <section aria-label="Feed" className="min-w-0">

--- a/frontend/src/01_widgets/home-feed/ui/HomeFeed.tsx
+++ b/frontend/src/01_widgets/home-feed/ui/HomeFeed.tsx
@@ -7,14 +7,18 @@ import { PostRow } from "./PostRow";
 import { RecommendedTopics } from "./RecommendedTopics";
 import { TopContributors } from "./TopContributors";
 import type { TabKey } from "./data";
-import { getUser } from "@/features/auth/api/getUser";
+import { getUserOrRedirectToOnboarding } from "@/features/auth/api/requireOnboarding";
+import type { User } from "@/entities/user/model/User";
 
 export async function HomeFeed({
   activeTab = "trending",
+  viewer,
 }: {
   activeTab?: TabKey;
+  viewer?: User | null;
 }) {
-  const data = await getUser();
+  const data =
+    viewer === undefined ? await getUserOrRedirectToOnboarding() : viewer;
 
   const isLoggedIn = !!data; // data 있으면 true, 없으면 false
 

--- a/frontend/src/01_widgets/onboarding/ui/OnboardingView.tsx
+++ b/frontend/src/01_widgets/onboarding/ui/OnboardingView.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import Image from "next/image";
+import { useActionState, useEffect, useState, type FormEvent } from "react";
+import { useFormStatus } from "react-dom";
+import type { User } from "@/entities/user/model/User";
+import {
+  submitOnboarding,
+  type OnboardingActionState,
+} from "@/app/onboarding/actions";
+
+const USERNAME_PATTERN = /^[a-z0-9]+$/;
+
+type FieldName = "nickname" | "username" | "bio";
+
+export function OnboardingView({ user }: { user: User }) {
+  const initialState: OnboardingActionState = {
+    values: {
+      nickname: user.nickname ?? "",
+      username: user.username ?? "",
+      bio: user.bio ?? "",
+    },
+    errors: {},
+  };
+  const [actionState, formAction] = useActionState(
+    submitOnboarding,
+    initialState,
+  );
+  const [values, setValues] = useState(actionState.values);
+  const [clientErrors, setClientErrors] = useState<
+    Partial<Record<FieldName, string>>
+  >({});
+  const [serverErrors, setServerErrors] = useState(actionState.errors);
+
+  useEffect(() => {
+    setValues(actionState.values);
+    setServerErrors(actionState.errors);
+  }, [actionState]);
+
+  function validateField(name: FieldName, value: string) {
+    if (name === "nickname") {
+      if (!value.trim()) {
+        return "닉네임은 필수입니다.";
+      }
+      if (value.trim().length > 40) {
+        return "닉네임은 40자 이하로 입력해주세요.";
+      }
+      return undefined;
+    }
+
+    if (name === "username") {
+      const trimmed = value.trim();
+
+      if (!trimmed) {
+        return "username은 필수입니다.";
+      }
+      if (trimmed.length < 3 || trimmed.length > 20) {
+        return "username은 3자 이상 20자 이하로 입력해주세요.";
+      }
+      if (!USERNAME_PATTERN.test(trimmed)) {
+        return "username은 영어 소문자와 숫자만 사용할 수 있습니다.";
+      }
+      return undefined;
+    }
+
+    if (value.trim().length > 160) {
+      return "bio는 160자 이하로 입력해주세요.";
+    }
+
+    return undefined;
+  }
+
+  function handleFieldChange(name: FieldName, nextValue: string) {
+    setValues((current) => ({
+      ...current,
+      [name]: nextValue,
+    }));
+
+    setClientErrors((current) => ({
+      ...current,
+      [name]: undefined,
+    }));
+
+    setServerErrors((current) => ({
+      ...current,
+      [name]: undefined,
+      form: undefined,
+    }));
+  }
+
+  function handleFieldBlur(name: FieldName) {
+    const nextError = validateField(name, values[name]);
+
+    setClientErrors((current) => ({
+      ...current,
+      [name]: nextError,
+    }));
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    const nextErrors: Partial<Record<FieldName, string>> = {
+      nickname: validateField("nickname", values.nickname),
+      username: validateField("username", values.username),
+      bio: validateField("bio", values.bio),
+    };
+
+    setClientErrors(nextErrors);
+
+    if (Object.values(nextErrors).some(Boolean)) {
+      event.preventDefault();
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-[80] grid place-items-center p-4">
+      <div className="absolute inset-0 bg-zinc-950/12 backdrop-blur-[10px] backdrop-saturate-150" />
+
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="onboarding-title"
+        className="relative z-10 w-full max-w-[520px] overflow-hidden rounded-2xl border border-[#f3f4f6] bg-white p-8 shadow-[0px_25px_50px_-12px_rgba(0,0,0,0.25)]"
+      >
+        <div className="flex flex-col items-center gap-8 pt-3">
+          <div className="flex w-full max-w-[382px] flex-col items-center">
+            <div className="grid size-12 place-items-center rounded-[14px] bg-black text-[24px] font-bold leading-none text-white [font-family:Georgia,serif]">
+              O
+            </div>
+
+            <h1
+              id="onboarding-title"
+              className="mt-4 text-center text-[24px] leading-8 text-[#101828] [font-family:Georgia,serif]"
+            >
+              Welcome.
+            </h1>
+
+            <p className="mt-2 max-w-[360px] text-center text-[14px] leading-5 tracking-[-0.01em] text-[#6a7282]">
+              OpenLog에서 사용할 프로필 정보를 먼저 완성해 주세요.
+            </p>
+            <p className="mt-1 max-w-[360px] break-all text-center text-[13px] leading-5 tracking-[-0.01em] text-[#98a2b3]">
+              {user.email ?? "OpenLog member"}
+            </p>
+          </div>
+
+          <form
+            action={formAction}
+            onSubmit={handleSubmit}
+            className="flex w-full max-w-[382px] flex-col gap-5"
+          >
+            <Field
+              name="nickname"
+              label="Nickname"
+              value={values.nickname}
+              placeholder="프로필과 활동 영역에 표시되는 이름입니다."
+              description=""
+              error={clientErrors.nickname ?? serverErrors.nickname}
+              onChange={handleFieldChange}
+              onBlur={handleFieldBlur}
+            />
+
+            <Field
+              name="username"
+              label="Username"
+              value={values.username}
+              placeholder="영어 소문자와 숫자만 사용할 수 있으며, 중복될 수 없습니다."
+              description=""
+              error={clientErrors.username ?? serverErrors.username}
+              onChange={handleFieldChange}
+              onBlur={handleFieldBlur}
+            />
+
+            <Field
+              name="bio"
+              label="Bio"
+              value={values.bio}
+              placeholder="What do you like to write about?"
+              description=""
+              error={clientErrors.bio ?? serverErrors.bio}
+              onChange={handleFieldChange}
+              onBlur={handleFieldBlur}
+              multiline
+            />
+
+            {serverErrors.form ? (
+              <p className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+                {serverErrors.form}
+              </p>
+            ) : null}
+
+            <div className="pt-1">
+              <SubmitButton />
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  name,
+  label,
+  value,
+  placeholder,
+  description,
+  error,
+  onChange,
+  onBlur,
+  multiline = false,
+}: {
+  name: FieldName;
+  label: string;
+  value: string;
+  placeholder: string;
+  description: string;
+  error?: string;
+  onChange: (name: FieldName, value: string) => void;
+  onBlur: (name: FieldName) => void;
+  multiline?: boolean;
+}) {
+  const commonClassName =
+    "mt-2 w-full rounded-xl border bg-white px-4 py-3 text-[15px] text-zinc-950 outline-none transition placeholder:text-zinc-400 focus:border-zinc-400 focus:ring-4 focus:ring-zinc-200/70";
+  const resolvedClassName = error
+    ? `${commonClassName} border-rose-300 bg-rose-50/40 focus:border-rose-400 focus:ring-rose-100`
+    : `${commonClassName} border-zinc-200`;
+
+  return (
+    <label className="block">
+      <span className="text-sm font-semibold text-zinc-900">{label}</span>
+      {multiline ? (
+        <textarea
+          name={name}
+          value={value}
+          placeholder={placeholder}
+          rows={5}
+          maxLength={160}
+          className={`${resolvedClassName} mt-2 min-h-[124px] resize-none`}
+          onChange={(event) => onChange(name, event.target.value)}
+          onBlur={() => onBlur(name)}
+        />
+      ) : (
+        <input
+          name={name}
+          value={value}
+          placeholder={placeholder}
+          maxLength={name === "nickname" ? 40 : 20}
+          autoCapitalize="none"
+          autoCorrect="off"
+          className={resolvedClassName}
+          onChange={(event) => onChange(name, event.target.value)}
+          onBlur={() => onBlur(name)}
+        />
+      )}
+
+      <p className={`mt-2 text-sm ${error ? "text-rose-600" : "text-zinc-500"}`}>
+        {error ?? description}
+      </p>
+    </label>
+  );
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className="inline-flex h-12 w-full items-center justify-center rounded-[14px] bg-zinc-950 px-6 text-[16px] font-medium tracking-[-0.02em] text-white transition hover:bg-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20 disabled:cursor-not-allowed disabled:bg-zinc-400"
+    >
+      {pending ? "Saving..." : "시작하기"}
+    </button>
+  );
+}

--- a/frontend/src/01_widgets/onboarding/ui/index.ts
+++ b/frontend/src/01_widgets/onboarding/ui/index.ts
@@ -1,0 +1,1 @@
+export { OnboardingView } from "./OnboardingView";

--- a/frontend/src/01_widgets/post/ui/SuggestionDetail.tsx
+++ b/frontend/src/01_widgets/post/ui/SuggestionDetail.tsx
@@ -275,7 +275,7 @@ function DiscussionSection({
 
       <div className="mt-6 flex items-start gap-4">
         <Image
-          src={assets.avatarA}
+          src={assets.defaultAvatar}
           alt="Current user avatar"
           width={40}
           height={40}

--- a/frontend/src/01_widgets/profile/ui/ProfileView.tsx
+++ b/frontend/src/01_widgets/profile/ui/ProfileView.tsx
@@ -77,7 +77,7 @@ export async function ProfileView() {
               <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
                 <div className="min-w-0">
                   <h1 className="font-[Georgia,serif] text-[40px] font-bold leading-none tracking-[-0.04em] text-zinc-950 sm:text-[48px]">
-                    {profile.name}
+                    {data?.nickname ?? "openlogger"}
                   </h1>
                   <p className="mt-4 max-w-3xl text-[18px] leading-8 text-zinc-600">
                     {data?.bio ?? "Hello, World!"}

--- a/frontend/src/01_widgets/profile/ui/ProfileView.tsx
+++ b/frontend/src/01_widgets/profile/ui/ProfileView.tsx
@@ -56,7 +56,6 @@ export async function ProfileView() {
   return (
     <div className="flex min-h-dvh flex-col bg-[#f9fafb] text-zinc-950">
       <Header
-        showWriteAction={false}
         isLoggedIn={isLoggedIn}
         profileImageUrl={data?.profileImageUrl}
       />

--- a/frontend/src/01_widgets/profile/ui/ProfileView.tsx
+++ b/frontend/src/01_widgets/profile/ui/ProfileView.tsx
@@ -55,10 +55,7 @@ export async function ProfileView() {
 
   return (
     <div className="flex min-h-dvh flex-col bg-[#f9fafb] text-zinc-950">
-      <Header
-        isLoggedIn={isLoggedIn}
-        profileImageUrl={data?.profileImageUrl}
-      />
+      <Header isLoggedIn={isLoggedIn} profileImageUrl={data?.profileImageUrl} />
 
       <main className="mx-auto w-full max-w-[1083px] flex-1 px-4 pb-20 pt-8 sm:px-8">
         <section className="rounded-[28px] border border-zinc-200/80 bg-white px-6 py-7 shadow-[0_1px_2px_rgba(16,24,40,0.04)] sm:px-8 sm:py-8">
@@ -66,7 +63,7 @@ export async function ProfileView() {
             <div className="mx-auto lg:mx-0">
               <div className="rounded-full border-4 border-zinc-50 bg-white p-1">
                 <Image
-                  src={profile.avatarSrc}
+                  src={data?.profileImageUrl ?? assets.defaultAvatar}
                   alt={`${profile.name} avatar`}
                   width={128}
                   height={128}
@@ -172,7 +169,11 @@ export async function ProfileView() {
               {recentActivity.map((activity, index) => (
                 <li
                   key={activity.id}
-                  className={index === recentActivity.length - 1 ? "relative" : "relative pb-8"}
+                  className={
+                    index === recentActivity.length - 1
+                      ? "relative"
+                      : "relative pb-8"
+                  }
                 >
                   <span className="absolute -left-[31px] top-2 size-3 rounded-full border-2 border-[#f9fafb] bg-zinc-300" />
                   <p className="text-[14px] leading-6 text-zinc-600">
@@ -219,13 +220,7 @@ function SectionHeading({
   );
 }
 
-function ProfileMeta({
-  iconSrc,
-  label,
-}: {
-  iconSrc: string;
-  label: string;
-}) {
+function ProfileMeta({ iconSrc, label }: { iconSrc: string; label: string }) {
   return (
     <div className="inline-flex items-center gap-2.5">
       <Image src={iconSrc} alt="" width={16} height={16} aria-hidden="true" />

--- a/frontend/src/01_widgets/profile/ui/ProfileView.tsx
+++ b/frontend/src/01_widgets/profile/ui/ProfileView.tsx
@@ -55,7 +55,11 @@ export async function ProfileView() {
 
   return (
     <div className="flex min-h-dvh flex-col bg-[#f9fafb] text-zinc-950">
-      <Header showWriteAction={false} isLoggedIn={isLoggedIn}/>
+      <Header
+        showWriteAction={false}
+        isLoggedIn={isLoggedIn}
+        profileImageUrl={data?.profileImageUrl}
+      />
 
       <main className="mx-auto w-full max-w-[1083px] flex-1 px-4 pb-20 pt-8 sm:px-8">
         <section className="rounded-[28px] border border-zinc-200/80 bg-white px-6 py-7 shadow-[0_1px_2px_rgba(16,24,40,0.04)] sm:px-8 sm:py-8">

--- a/frontend/src/01_widgets/profile/ui/ProfileView.tsx
+++ b/frontend/src/01_widgets/profile/ui/ProfileView.tsx
@@ -11,7 +11,7 @@ const profile = {
   location: "San Francisco, CA",
   website: "github.com/sarah",
   joinedLabel: "Joined March 2024",
-  avatarSrc: assets.profileAvatar,
+  avatarSrc: assets.defaultAvatar,
 } as const;
 
 const authoredPosts = [

--- a/frontend/src/01_widgets/profile/ui/ProfileView.tsx
+++ b/frontend/src/01_widgets/profile/ui/ProfileView.tsx
@@ -76,11 +76,11 @@ export async function ProfileView() {
             <div className="min-w-0 flex-1">
               <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
                 <div className="min-w-0">
-                  <h1 className="[font-family:Georgia,serif] text-[40px] font-bold leading-[1] tracking-[-0.04em] text-zinc-950 sm:text-[48px]">
+                  <h1 className="font-[Georgia,serif] text-[40px] font-bold leading-none tracking-[-0.04em] text-zinc-950 sm:text-[48px]">
                     {profile.name}
                   </h1>
                   <p className="mt-4 max-w-3xl text-[18px] leading-8 text-zinc-600">
-                    {profile.role}
+                    {data?.bio ?? "Hello, World!"}
                   </p>
                 </div>
 

--- a/frontend/src/01_widgets/profile/ui/ProfileView.tsx
+++ b/frontend/src/01_widgets/profile/ui/ProfileView.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { assets } from "@/shared/config/assets";
 import { GitPullRequestIcon } from "@/shared/ui/icons";
 import { Footer, Header } from "@/widgets/chrome/ui";
-import { getUser } from "@/features/auth/api/getUser";
+import { getUserOrRedirectToOnboarding } from "@/features/auth/api/requireOnboarding";
 
 const profile = {
   name: "Sarah Drasner",
@@ -49,7 +49,7 @@ const recentActivity = [
 ] as const;
 
 export async function ProfileView() {
-  const data = await getUser();
+  const data = await getUserOrRedirectToOnboarding();
 
   const isLoggedIn = !!data;
 

--- a/frontend/src/01_widgets/write/ui/WriteView.tsx
+++ b/frontend/src/01_widgets/write/ui/WriteView.tsx
@@ -40,7 +40,13 @@ const markdownCheatsheet = [
   { syntax: "# Heading", label: "H1" },
 ] as const;
 
-export function WriteView({ isLoggedIn }: { isLoggedIn: boolean }) {
+export function WriteView({
+  isLoggedIn,
+  profileImageUrl,
+}: {
+  isLoggedIn: boolean;
+  profileImageUrl?: string;
+}) {
   const [mode, setMode] = useState<ComposerMode>("edit");
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
@@ -172,7 +178,7 @@ export function WriteView({ isLoggedIn }: { isLoggedIn: boolean }) {
 
   return (
     <div className="min-h-dvh bg-zinc-50 text-zinc-950">
-      <Header isLoggedIn={isLoggedIn} />
+      <Header isLoggedIn={isLoggedIn} profileImageUrl={profileImageUrl} />
 
       <main className="mx-auto w-full max-w-[1083px] px-4 pb-16 pt-6 sm:px-8">
         <section className="flex flex-col gap-6">

--- a/frontend/src/01_widgets/write/ui/WriteView.tsx
+++ b/frontend/src/01_widgets/write/ui/WriteView.tsx
@@ -178,7 +178,11 @@ export function WriteView({
 
   return (
     <div className="min-h-dvh bg-zinc-50 text-zinc-950">
-      <Header isLoggedIn={isLoggedIn} profileImageUrl={profileImageUrl} />
+      <Header
+        isLoggedIn={isLoggedIn}
+        profileImageUrl={profileImageUrl}
+        showWriteAction={false}
+      />
 
       <main className="mx-auto w-full max-w-[1083px] px-4 pb-16 pt-6 sm:px-8">
         <section className="flex flex-col gap-6">

--- a/frontend/src/01_widgets/write/ui/WriteView.tsx
+++ b/frontend/src/01_widgets/write/ui/WriteView.tsx
@@ -45,7 +45,7 @@ export function WriteView({
   profileImageUrl,
 }: {
   isLoggedIn: boolean;
-  profileImageUrl?: string;
+  profileImageUrl?: string | null;
 }) {
   const [mode, setMode] = useState<ComposerMode>("edit");
   const [title, setTitle] = useState("");

--- a/frontend/src/02_features/auth/api/requireOnboarding.ts
+++ b/frontend/src/02_features/auth/api/requireOnboarding.ts
@@ -1,0 +1,22 @@
+import { redirect } from "next/navigation";
+import { getUser } from "@/features/auth/api/getUser";
+
+export async function getUserOrRedirectToOnboarding() {
+  const user = await getUser();
+
+  if (user && !user.isOnboardingComplete) {
+    redirect("/onboarding");
+  }
+
+  return user;
+}
+
+export async function getIncompleteUserOrRedirectHome() {
+  const user = await getUser();
+
+  if (!user || user.isOnboardingComplete) {
+    redirect("/");
+  }
+
+  return user;
+}

--- a/frontend/src/03_entities/user/model/User.ts
+++ b/frontend/src/03_entities/user/model/User.ts
@@ -3,4 +3,5 @@ export interface User {
   nickname?: string;
   email?: string;
   profileImageUrl?: string;
+  bio?: string;
 }

--- a/frontend/src/03_entities/user/model/User.ts
+++ b/frontend/src/03_entities/user/model/User.ts
@@ -1,7 +1,7 @@
 export interface User {
   id: number;
-  nickname?: string;
-  email?: string;
-  profileImageUrl?: string;
-  bio?: string;
+  nickname: string | null;
+  email: string | null;
+  profileImageUrl: string | null;
+  bio: string | null;
 }

--- a/frontend/src/03_entities/user/model/User.ts
+++ b/frontend/src/03_entities/user/model/User.ts
@@ -1,7 +1,9 @@
 export interface User {
   id: number;
+  username: string | null;
   nickname: string | null;
   email: string | null;
   profileImageUrl: string | null;
   bio: string | null;
+  isOnboardingComplete: boolean;
 }

--- a/frontend/src/04_shared/config/assets.ts
+++ b/frontend/src/04_shared/config/assets.ts
@@ -1,7 +1,7 @@
 export const assets = {
   featuredCover: "/demo/featured-cover.svg",
   postCover: "/demo/post-cover.svg",
-  profileAvatar: "/demo/profile-avatar.svg",
+  defaultAvatar: "/demo/default-avatar.svg",
   knowledgeGraph: "/demo/knowledge-graph.svg",
   avatarA: "/demo/avatar-a.svg",
   avatarB: "/demo/avatar-b.svg",

--- a/frontend/src/04_shared/config/assets.ts
+++ b/frontend/src/04_shared/config/assets.ts
@@ -1,7 +1,7 @@
 export const assets = {
   featuredCover: "/demo/featured-cover.svg",
   postCover: "/demo/post-cover.svg",
-  defaultAvatar: "/demo/default-avatar.svg",
+  defaultAvatar: "/common/default-avatar.svg",
   knowledgeGraph: "/demo/knowledge-graph.svg",
   avatarA: "/demo/avatar-a.svg",
   avatarB: "/demo/avatar-b.svg",


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #

---

## 1. PR 유형
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ✨ 새로운 기능 (New Feature)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 업데이트 (Documentation)
- [ ] ⚙️ 설정/빌드 변경 (Chore)

---

## 2. 작업 배경 및 목적
- **기존 상태:** Google OAuth 로그인 이후 `users` 레코드는 이메일과 프로필 이미지만으로도 생성될 수 있었고, 서비스 내부에서 사용할 `nickname`과 `username`을 강제하는 후속 단계가 없었습니다. 주요 화면은 로그인 여부만 확인하면 그대로 진입할 수 있었고, 헤더 프로필 이미지는 각 뷰가 서로 다른 fallback 자산과 전달 경로를 사용할 수 있는 상태였습니다.
- **문제점:** Google `name` 정보가 안정적으로 보장되지 않는 상황에서 신규 사용자는 `nickname = null`, `bio = null` 상태로 생성될 수 있었고, 고유 식별용 `username`도 DB와 API 계약에 존재하지 않아 프로필 완성 상태를 판별할 수 없었습니다. 그 결과 로그인 직후에도 홈, 글 상세, 제안 상세, 글쓰기, 프로필 화면으로 바로 진입할 수 있었고, 헤더/프로필 아바타 렌더링도 공용 기본 이미지 없이 분산되어 있었습니다.
- **해결 목표:** `users.username`을 유니크 nullable 컬럼으로 복구하고, OAuth 신규 사용자를 "미완성 프로필" 상태로 생성한 뒤 `/onboarding`에서 `nickname`, `username`, `bio`를 입력받아 완료시키는 파이프라인을 추가합니다. 동시에 주요 서버 라우트에서 미완성 사용자를 온보딩으로 강제 리다이렉트하고, 프로필 이미지와 기본 아바타 경로를 공용 자산 기준으로 정렬합니다.

---

## 3. 상세 변경 내역 및 동작 흐름

### A. 백엔드에 온보딩 완료 상태와 `username` 영속성 파이프라인 추가
- **진입점 및 초기 조건:** `backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthController.kt`의 `GET /auth/google/callback`, `GET /auth/me`, `POST /auth/onboarding`가 진입점입니다. OAuth 콜백은 Google code를 access token / id token으로 교환한 뒤 `AuthService.findOrCreateGoogleUser()`를 호출하고, 온보딩 완료 요청은 `CompleteOnboardingRequest` 검증을 통과한 JSON payload를 받습니다.

```kotlin
val currentUser = authService.findOrCreateGoogleUser(
    sub = sub,
    picture = picture,
    email = email,
)

val nextLocation =
    if (currentUser.isOnboardingComplete()) {
        frontendHomeUrl
    } else {
        URI.create(frontendHomeUrl).resolve("/onboarding").toString()
    }
```

- **단계별 제어 흐름:**
  1. `AuthController.hangleGoogleCallback()`가 Google code/state를 검증하고 access token, id token, userinfo를 순서대로 조회합니다.
  2. `AuthService.findOrCreateGoogleUser()`는 기존 `OauthAccount`를 찾지 못한 경우 `User(profileImageUrl = picture, email = email)`만 저장해 신규 사용자를 "미완성" 상태로 생성합니다.
  3. JWT 쿠키 발급 후 `currentUser.isOnboardingComplete()`를 평가해 완성 사용자는 `/`, 미완성 사용자는 `/onboarding`으로 302 리다이렉트합니다.
  4. `/auth/me`는 `MeResponse`에 `username`, `nickname`, `bio`, `isOnboardingComplete`를 포함해 현재 세션의 프로필 완성 상태를 반환합니다.
  5. `/auth/onboarding`는 `CompleteOnboardingRequest`의 Bean Validation을 통과한 뒤 trim된 `nickname`, `username`, `bio`를 만들고, `UserRepository.existsByUsername()` 중복 검사에 걸리면 `UsernameAlreadyTakenException`을 발생시켜 409로 종료합니다.
  6. 중복이 없으면 `User.completeOnboarding()`이 `nickname`, `username`, `bio`, `updatedAt`을 한 번에 갱신하고, 최신 사용자 상태를 다시 `MeResponse`로 반환합니다.
- **데이터 상태 변이:** `backend/src/main/resources/db/migration/V20260403__restore_users_username_for_onboarding.sql`가 `users.username` nullable 컬럼과 unique index를 추가합니다. `User` 엔티티 메모리 상태는 `(username = null, nickname = null, bio = null)`에서 `(username = <unique>, nickname = <required>, bio = <optional>)`로 변이되고, `GlobalExceptionHandler`는 validation/username 충돌을 `VALIDATION_ERROR` 또는 `USERNAME_TAKEN` 코드로 직렬화합니다.
- **최종 반환 및 종료 상태:** 백엔드는 "프로필 미완성 사용자"를 명시적으로 표현할 수 있게 되었고, OAuth 신규 가입자는 온보딩을 마치기 전까지 `isOnboardingComplete = false` 상태로 유지됩니다. `GET /auth/me`와 `POST /auth/onboarding`는 같은 DTO 계약을 공유하므로 프론트는 단일 사용자 모델 위에서 리다이렉트와 폼 제출을 처리할 수 있습니다.

### B. 서버 라우트 가드와 모달형 온보딩 UI를 프론트에 연결
- **진입점 및 초기 조건:** `frontend/src/02_features/auth/api/requireOnboarding.ts`의 `getUserOrRedirectToOnboarding()`와 `getIncompleteUserOrRedirectHome()`가 서버 라우트 진입점입니다. `/`, `/write`, `/posts/[slug]`, `/posts/[slug]/suggests`, `/posts/[slug]/suggests/[suggestId]`, `/profile`, `/onboarding`가 이 공용 가드를 호출합니다.

```ts
export async function getUserOrRedirectToOnboarding() {
  const user = await getUser();

  if (user && !user.isOnboardingComplete) {
    redirect("/onboarding");
  }

  return user;
}
```

- **단계별 제어 흐름:**
  1. 주요 페이지 서버 컴포넌트가 기존 `getUser()` 대신 `getUserOrRedirectToOnboarding()`를 호출해 현재 쿠키 세션을 읽습니다.
  2. 로그인 사용자가 `isOnboardingComplete = false`이면 Next.js 서버 리다이렉트가 즉시 `/onboarding`을 반환하고, 비로그인 사용자는 `null`, 완성 사용자는 `User` 객체를 그대로 통과시킵니다.
  3. `/onboarding` 페이지는 `getIncompleteUserOrRedirectHome()`로 완성 사용자/비로그인 사용자를 `/`로 돌려보낸 뒤, 배경으로 `HomeFeed viewer={user}`를 렌더링하고 전면에 `OnboardingView` 모달을 얹습니다.
  4. `frontend/app/onboarding/actions.ts`의 서버 액션 `submitOnboarding()`은 클라이언트 폼 입력을 1차 검증한 뒤 현재 요청의 cookie 헤더를 그대로 백엔드 `/auth/onboarding`에 전달합니다.
  5. 백엔드 응답이 `200`이면 서버 액션이 `/`로 리다이렉트하고, `409 USERNAME_TAKEN`이면 `useActionState` 상태에 username 필드 에러를 주입하며, 그 외 실패는 form-level 에러 메시지로 정규화합니다.
  6. `frontend/src/01_widgets/onboarding/ui/OnboardingView.tsx`는 blur backdrop이 있는 고정 모달 안에서 `nickname`, `username`, `bio` 입력과 클라이언트 blur validation을 수행합니다.
- **데이터 상태 변이:** `frontend/src/03_entities/user/model/User.ts`는 `username: string | null`, `isOnboardingComplete: boolean`을 포함하는 공용 모델로 확장됩니다. 폼 상태는 `useActionState`와 로컬 `useState`에서 `{ values, clientErrors, serverErrors }` 구조로 유지되고, 서버 액션은 입력 값을 JSON payload `{ nickname, username, bio }`로 재직렬화합니다.
- **최종 반환 및 종료 상태:** 온보딩 미완료 사용자는 주요 라우트 어디에서든 `/onboarding`으로 수렴되고, `/onboarding`에서는 홈 피드 배경 위에 blur 모달 형태의 온보딩 폼만 노출됩니다. 성공 시 세션을 유지한 채 `/`로 복귀하므로 별도 재로그인 없이 프로필 완성 상태가 즉시 서비스 전역에 반영됩니다.

### C. 헤더 프로필 이미지 전달 경로와 공용 기본 아바타를 정렬
- **진입점 및 초기 조건:** `frontend/src/01_widgets/chrome/ui/Header.tsx`는 더 이상 내부에서 사용자를 조회하지 않고 `isLoggedIn`, `profileImageUrl`, `showWriteAction` prop만 받습니다. `HomeFeed`, `ProfileView`, `WritePage -> WriteView`가 서버에서 조회한 사용자 정보를 `Header`에 전달합니다.

```tsx
<Header
  isLoggedIn={isLoggedIn}
  profileImageUrl={profileImageUrl}
  showWriteAction={false}
/>
```

- **단계별 제어 흐름:**
  1. `HomeFeed`는 `viewer` prop이 없을 때만 `getUserOrRedirectToOnboarding()`를 호출하고, 이미 사용자 객체를 받은 경우 그 값을 그대로 사용합니다.
  2. `Header`는 `profileImageUrl ?? assets.defaultAvatar`로 표시할 이미지를 한 번만 결정합니다.
  3. `WritePage`는 서버에서 받은 `data?.profileImageUrl`을 `WriteView`에 넘기고, `WriteView`는 같은 값을 `Header`로 forward 하면서 `showWriteAction={false}`만 추가 적용합니다.
  4. `ProfileView`와 `SuggestionDetail`도 동일한 `assets.defaultAvatar` 경로를 사용해 프로필 이미지 fallback을 통일합니다.
  5. `frontend/next.config.ts`는 `lh3.googleusercontent.com`을 `next/image` remotePatterns에 등록해 Google 프로필 이미지를 최적화 이미지 파이프라인으로 렌더링합니다.
- **데이터 상태 변이:** 프로필 이미지 URL은 더 이상 헤더 내부 fetch 결과가 아니라 서버에서 조회된 `User.profileImageUrl` 문자열 또는 `null`로 전달됩니다. 공용 자산 설정 `assets.defaultAvatar`는 `/common/default-avatar.svg`를 가리키며, 페이지별 fallback 분기 로직이 단일 경로 참조로 축소됩니다.
- **최종 반환 및 종료 상태:** 주요 화면의 헤더는 인증 상태와 동일한 사용자 객체에서 프로필 이미지를 읽고, 이미지가 없는 경우에도 공용 기본 아바타를 안정적으로 렌더링합니다. 글쓰기 페이지에서는 글쓰기 버튼이 숨겨지고, 프로필 페이지를 포함한 나머지 로그인 화면은 같은 헤더 컴포넌트를 공유하면서 동작만 prop으로 분기합니다.

---

## 4. 스크린샷 (선택)
- 없음

## 5. 테스트 및 검증 방법
- **테스트 환경:** macOS 로컬 환경에서 `backend/`와 `frontend/` 워크스페이스를 각각 검증했습니다. 백엔드는 Gradle 9 기반 Kotlin/Spring Boot 4 구성이며, 프론트는 Next.js `16.1.6` + npm 스크립트를 사용했습니다.
- **입력 시나리오:**
  1. `./gradlew :backend:compileKotlin`
  2. `cd frontend && npm run build`
- **출력 검증:** `:backend:compileKotlin`은 성공적으로 종료되어 `AuthController`, `AuthService`, DTO, 엔티티, Flyway 의존성 추가 이후 Kotlin 컴파일 정합성을 확인했습니다. `npm run build`도 성공했고 빌드 결과에 `/`, `/onboarding`, `/posts/[slug]`, `/posts/[slug]/suggests`, `/posts/[slug]/suggests/[suggestId]`, `/profile`, `/write`가 모두 동적 서버 경로(`ƒ`)로 출력되었습니다. 이는 온보딩 가드와 서버 액션 기반 세션 전달이 각 주요 화면의 렌더링 파이프라인에 정상 편입되었음을 의미합니다.

---

## 6. 리뷰어 참고 사항 (선택)
- **특이 구현 사항:** 로컬 개발 DB는 기존 `public` 스키마가 비어 있지 않은 상태에서 Flyway를 도입했기 때문에 `backend/src/main/resources/application-local.yaml`에 `baseline-on-migrate: true`, `baseline-version: 20260324`를 추가했습니다. 따라서 local profile에서는 기존 스키마를 기준선으로 간주한 뒤 `V20260403__restore_users_username_for_onboarding.sql`부터 적용합니다.
- **파급 효과:** 기존 `users` 테이블에 `username` 컬럼이 없던 로컬 DB는 새 백엔드 기동 시 Flyway가 먼저 실행되어야 합니다. 또한 현재 프로필 화면 본문은 `nickname`, `bio`, `profileImageUrl`만 실제 사용자 데이터로 치환되며, 공개 URL slug나 활동 히스토리까지 `username` 기반으로 연결하는 작업은 후속 PR에서 이어서 처리해야 합니다.

---

## 7. 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일 가이드를 준수합니다.
- [x] 변경 사항에 대한 테스트 코드를 작성하거나 통과했습니다.
- [ ] 관련된 문서(README, API 명세 등)를 업데이트했습니다.
