### PR TITLE
[Feat] 새 포스트 작성

### DIFF
--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthController.kt
@@ -25,6 +25,7 @@ import java.time.Duration
 @RequestMapping("auth")
 class AuthController(
     private val authService: AuthService,
+    private val currentUserResolver: CurrentUserResolver,
     private val jwtTokenService: JwtTokenService,
     @Value("\${auth.jwt.cookie-name:openlog_access_token}")
     private val accessTokenCookieName: String,
@@ -37,7 +38,7 @@ class AuthController(
     fun getMe(
         request: HttpServletRequest
     ): MeResponse {
-        val meUser = authService.getCurrentUser(resolveCurrentUserId(request))
+        val meUser = authService.getCurrentUser(currentUserResolver.resolveUserId(request))
 
         return meUser.toMeResponse() // 코틀린 확장 함수 (메서드 아님)
     }
@@ -48,7 +49,7 @@ class AuthController(
         @Valid @RequestBody onboardingRequest: CompleteOnboardingRequest,
     ): MeResponse {
         val currentUser = authService.completeOnboarding(
-            userId = resolveCurrentUserId(request),
+            userId = currentUserResolver.resolveUserId(request),
             request = onboardingRequest,
         )
 
@@ -126,15 +127,6 @@ class AuthController(
                 )
             )
             .build()
-    }
-
-    private fun resolveCurrentUserId(request: HttpServletRequest): Long {
-        val accessToken = request.cookies
-            ?.firstOrNull { it.name == accessTokenCookieName }
-            ?.value
-            ?: throw OAuthAuthenticationException()
-
-        return jwtTokenService.parseUserId(accessToken)
     }
 
     private fun User.toMeResponse(): MeResponse {

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthService.kt
@@ -35,7 +35,7 @@ class AuthService(
     @Value("\${oauth.google.client-secret}")
     private val clientSecret: String,
 
-    private val redisTemplate: StringRedisTemplate, // bean 주입
+    private val redisTemplate: StringRedisTemplate, // todo: non-blocking redis로 수정 (Reactive Redis Template)
     restClientBuilder: RestClient.Builder,
     private val userRepository: UserRepository,
     private val oauthAccountRepository: OauthAccountRepository,

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/CurrentUserResolver.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/CurrentUserResolver.kt
@@ -1,0 +1,22 @@
+package io.github.kitae9999.openlog.auth
+
+import io.github.kitae9999.openlog.auth.exception.OAuthAuthenticationException
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class CurrentUserResolver(
+    private val jwtTokenService: JwtTokenService,
+    @Value("\${auth.jwt.cookie-name:openlog_access_token}")
+    private val accessTokenCookieName: String,
+) {
+    fun resolveUserId(request: HttpServletRequest): Long {
+        val accessToken = request.cookies
+            ?.firstOrNull { it.name == accessTokenCookieName }
+            ?.value
+            ?: throw OAuthAuthenticationException()
+
+        return jwtTokenService.parseUserId(accessToken)
+    }
+}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/blog/Blog.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/blog/Blog.kt
@@ -29,7 +29,7 @@ class Blog (
         protected set
 
     @OneToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
     var user: User = user
         protected set
 

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/blog/Blog.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/blog/Blog.kt
@@ -1,0 +1,43 @@
+package io.github.kitae9999.openlog.blog
+
+import io.github.kitae9999.openlog.user.entity.User
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "blogs"
+)
+class Blog (
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    name: String,
+    user: User,
+){
+    @Column(unique = true, nullable = false)
+    var name: String = name
+        protected set
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    var user: User = user
+        protected set
+
+    @Column(name="created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now()
+        protected set
+
+    @Column(name="updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+        protected set
+}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/blog/entity/Blog.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/blog/entity/Blog.kt
@@ -1,4 +1,4 @@
-package io.github.kitae9999.openlog.blog
+package io.github.kitae9999.openlog.blog.entity
 
 import io.github.kitae9999.openlog.user.entity.User
 import jakarta.persistence.Column

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/blog/repository/BlogRepository.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/blog/repository/BlogRepository.kt
@@ -1,9 +1,8 @@
 package io.github.kitae9999.openlog.blog.repository
 
 import io.github.kitae9999.openlog.blog.entity.Blog
-import io.github.kitae9999.openlog.user.entity.User
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface BlogRepository: JpaRepository<Blog, Long > {
-    fun findByUser(user: User): MutableList<Blog>
+interface BlogRepository : JpaRepository<Blog, Long> {
+    fun findByUserId(userId: Long): Blog?
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/blog/repository/BlogRepository.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/blog/repository/BlogRepository.kt
@@ -1,0 +1,9 @@
+package io.github.kitae9999.openlog.blog.repository
+
+import io.github.kitae9999.openlog.blog.entity.Blog
+import io.github.kitae9999.openlog.user.entity.User
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface BlogRepository: JpaRepository<Blog, Long > {
+    fun findByUser(user: User): MutableList<Blog>
+}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/common/exception/GlobalExceptionHandler.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/common/exception/GlobalExceptionHandler.kt
@@ -31,6 +31,16 @@ class GlobalExceptionHandler {
         )
     }
 
+    @ExceptionHandler(NotFoundException::class)
+    fun handleNotFoundException(e: NotFoundException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+            ErrorResponse(
+                code = "NOT_FOUND",
+                message = e.message ?: "요청한 리소스를 찾을 수 없습니다.",
+            )
+        )
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleMethodArgumentNotValidException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
         val message = e.bindingResult.fieldErrors.firstOrNull()?.defaultMessage

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/common/exception/NotFoundException.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/common/exception/NotFoundException.kt
@@ -1,3 +1,3 @@
 package io.github.kitae9999.openlog.common.exception
 
-class NotFoundException : RuntimeException("요청한 리소스를 찾을 수 없습니다.")
+class NotFoundException(msg: String?) : RuntimeException(msg)

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/common/exception/NotFoundException.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/common/exception/NotFoundException.kt
@@ -1,0 +1,3 @@
+package io.github.kitae9999.openlog.common.exception
+
+class NotFoundException : RuntimeException("요청한 리소스를 찾을 수 없습니다.")

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/CreatePostRequest.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/CreatePostRequest.kt
@@ -1,8 +1,0 @@
-package io.github.kitae9999.openlog.post
-
-data class CreatePostRequest(
-
-    val title: String,
-    val description: String,
-    val content: String,
-)

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/CreatePostRequest.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/CreatePostRequest.kt
@@ -1,0 +1,8 @@
+package io.github.kitae9999.openlog.post
+
+data class CreatePostRequest(
+
+    val title: String,
+    val description: String,
+    val content: String,
+)

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostController.kt
@@ -1,9 +1,8 @@
 package io.github.kitae9999.openlog.post
 
-import jakarta.servlet.http.HttpServletRequest
+import io.github.kitae9999.openlog.post.dto.CreatePostRequest
 import jakarta.validation.Valid
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.web.bind.annotation.CookieValue
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -19,7 +18,7 @@ class PostController(
 
     @PostMapping()
     fun createPost(
-        @Valid @RequestBody
+        @Valid @RequestBody createPostRequest: CreatePostRequest
     ) {
 
     }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostController.kt
@@ -2,9 +2,12 @@ package io.github.kitae9999.openlog.post
 
 import io.github.kitae9999.openlog.auth.CurrentUserResolver
 import io.github.kitae9999.openlog.post.dto.CreatePostRequest
+import io.github.kitae9999.openlog.post.dto.PostDetailResponse
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -17,6 +20,13 @@ class PostController(
     private val postService: PostService,
     private val currentUserResolver: CurrentUserResolver,
 ) {
+    @GetMapping("{id}")
+    fun getPost(
+        @PathVariable id: Long,
+    ): PostDetailResponse {
+        return postService.getPostDetail(id)
+    }
+
     @PostMapping()
     fun createPost(
         request: HttpServletRequest,

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostController.kt
@@ -1,34 +1,30 @@
 package io.github.kitae9999.openlog.post
 
 import io.github.kitae9999.openlog.auth.CurrentUserResolver
-import io.github.kitae9999.openlog.blog.repository.BlogRepository
-import io.github.kitae9999.openlog.common.exception.NotFoundException
 import io.github.kitae9999.openlog.post.dto.CreatePostRequest
 import jakarta.servlet.http.HttpServletRequest
-import jakarta.transaction.Transactional
 import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.net.URI
 
 @RestController
 @RequestMapping("posts")
 class PostController(
-    val postService: PostService,
-    val currentUserResolver: CurrentUserResolver,
-    val blogRepository: BlogRepository
+    private val postService: PostService,
+    private val currentUserResolver: CurrentUserResolver,
 ) {
-    @Transactional
     @PostMapping()
     fun createPost(
         request: HttpServletRequest,
         @Valid @RequestBody createPostRequest: CreatePostRequest
-    ) {
+    ): ResponseEntity<Void> {
         val userId = currentUserResolver.resolveUserId(request)
-        val blog = blogRepository.findByUserId(userId) ?: throw NotFoundException("블로그를 찾을 수 없습니다.")
+        val savedPost = postService.createPost(userId, createPostRequest)
 
-        val (title, description, content) = createPostRequest
-
+        return ResponseEntity.created(URI.create("/posts/${requireNotNull(savedPost.id)}")).build()
     }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostController.kt
@@ -1,6 +1,8 @@
 package io.github.kitae9999.openlog.post
 
+import io.github.kitae9999.openlog.auth.CurrentUserResolver
 import io.github.kitae9999.openlog.post.dto.CreatePostRequest
+import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.web.bind.annotation.PostMapping
@@ -14,12 +16,15 @@ class PostController(
     val postService: PostService,
     @Value("\${auth.jwt.cookie-name:openlog_access_token}")
     private val accessTokenCookieName: String,
+    val currentUserResolver: CurrentUserResolver,
 ) {
 
     @PostMapping()
     fun createPost(
+        request: HttpServletRequest,
         @Valid @RequestBody createPostRequest: CreatePostRequest
     ) {
+        val userId = currentUserResolver.resolveUserId(request)
 
     }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostController.kt
@@ -2,26 +2,21 @@ package io.github.kitae9999.openlog.post
 
 import io.github.kitae9999.openlog.auth.CurrentUserResolver
 import io.github.kitae9999.openlog.blog.repository.BlogRepository
+import io.github.kitae9999.openlog.common.exception.NotFoundException
 import io.github.kitae9999.openlog.post.dto.CreatePostRequest
-import io.github.kitae9999.openlog.user.repository.UserRepository
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.transaction.Transactional
 import jakarta.validation.Valid
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import kotlin.jvm.optionals.getOrNull
 
 @RestController
 @RequestMapping("posts")
 class PostController(
     val postService: PostService,
-    @Value("\${auth.jwt.cookie-name:openlog_access_token}")
-    private val accessTokenCookieName: String,
     val currentUserResolver: CurrentUserResolver,
-    val userRepository: UserRepository,
     val blogRepository: BlogRepository
 ) {
     @Transactional
@@ -31,8 +26,8 @@ class PostController(
         @Valid @RequestBody createPostRequest: CreatePostRequest
     ) {
         val userId = currentUserResolver.resolveUserId(request)
-        val author = userRepository.findById(userId).getOrNull()
-        val blog = blogRepository.findByUser(author);
+        val blog = blogRepository.findByUserId(userId) ?: throw NotFoundException("블로그를 찾을 수 없습니다.")
+
         val (title, description, content) = createPostRequest
 
     }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostController.kt
@@ -1,0 +1,26 @@
+package io.github.kitae9999.openlog.post
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.Valid
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.web.bind.annotation.CookieValue
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("posts")
+class PostController(
+    val postService: PostService,
+    @Value("\${auth.jwt.cookie-name:openlog_access_token}")
+    private val accessTokenCookieName: String,
+) {
+
+    @PostMapping()
+    fun createPost(
+        @Valid @RequestBody
+    ) {
+
+    }
+}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostController.kt
@@ -1,14 +1,18 @@
 package io.github.kitae9999.openlog.post
 
 import io.github.kitae9999.openlog.auth.CurrentUserResolver
+import io.github.kitae9999.openlog.blog.repository.BlogRepository
 import io.github.kitae9999.openlog.post.dto.CreatePostRequest
+import io.github.kitae9999.openlog.user.repository.UserRepository
 import jakarta.servlet.http.HttpServletRequest
+import jakarta.transaction.Transactional
 import jakarta.validation.Valid
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import kotlin.jvm.optionals.getOrNull
 
 @RestController
 @RequestMapping("posts")
@@ -17,14 +21,19 @@ class PostController(
     @Value("\${auth.jwt.cookie-name:openlog_access_token}")
     private val accessTokenCookieName: String,
     val currentUserResolver: CurrentUserResolver,
+    val userRepository: UserRepository,
+    val blogRepository: BlogRepository
 ) {
-
+    @Transactional
     @PostMapping()
     fun createPost(
         request: HttpServletRequest,
         @Valid @RequestBody createPostRequest: CreatePostRequest
     ) {
         val userId = currentUserResolver.resolveUserId(request)
+        val author = userRepository.findById(userId).getOrNull()
+        val blog = blogRepository.findByUser(author);
+        val (title, description, content) = createPostRequest
 
     }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostService.kt
@@ -1,0 +1,7 @@
+package io.github.kitae9999.openlog.post
+
+import org.springframework.stereotype.Service
+
+@Service
+class PostService {
+}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostService.kt
@@ -1,7 +1,35 @@
 package io.github.kitae9999.openlog.post
 
+import io.github.kitae9999.openlog.blog.repository.BlogRepository
+import io.github.kitae9999.openlog.common.exception.NotFoundException
+import io.github.kitae9999.openlog.post.dto.CreatePostRequest
+import io.github.kitae9999.openlog.post.entity.Post
+import io.github.kitae9999.openlog.post.repository.PostRepository
+import io.github.kitae9999.openlog.user.repository.UserRepository
+import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
+import kotlin.jvm.optionals.getOrNull
 
 @Service
-class PostService {
+class PostService(
+    private val blogRepository: BlogRepository,
+    private val postRepository: PostRepository,
+    private val userRepository: UserRepository,
+) {
+    @Transactional
+    fun createPost(userId: Long, createPostRequest: CreatePostRequest): Post {
+        val user = userRepository.findById(userId).getOrNull() ?: throw NotFoundException("사용자를 찾을 수 없습니다.")
+        val blog = blogRepository.findByUserId(userId) ?: throw NotFoundException("블로그를 찾을 수 없습니다.")
+        val (title, description, content) = createPostRequest
+
+        return postRepository.save(
+            Post(
+                blog = blog,
+                author = user,
+                title = title,
+                description = description,
+                content = content,
+            )
+        )
+    }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostService.kt
@@ -3,26 +3,34 @@ package io.github.kitae9999.openlog.post
 import io.github.kitae9999.openlog.blog.repository.BlogRepository
 import io.github.kitae9999.openlog.common.exception.NotFoundException
 import io.github.kitae9999.openlog.post.dto.CreatePostRequest
+import io.github.kitae9999.openlog.post.dto.PostDetailResponse
 import io.github.kitae9999.openlog.post.entity.Post
 import io.github.kitae9999.openlog.post.repository.PostRepository
+import io.github.kitae9999.openlog.posttopic.entity.PostTopic
+import io.github.kitae9999.openlog.posttopic.repository.PostTopicRepository
+import io.github.kitae9999.openlog.topic.entity.Topic
+import io.github.kitae9999.openlog.topic.repository.TopicRepository
 import io.github.kitae9999.openlog.user.repository.UserRepository
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
+import java.time.format.DateTimeFormatter
 import kotlin.jvm.optionals.getOrNull
 
 @Service
 class PostService(
     private val blogRepository: BlogRepository,
     private val postRepository: PostRepository,
+    private val postTopicRepository: PostTopicRepository,
+    private val topicRepository: TopicRepository,
     private val userRepository: UserRepository,
 ) {
     @Transactional
     fun createPost(userId: Long, createPostRequest: CreatePostRequest): Post {
         val user = userRepository.findById(userId).getOrNull() ?: throw NotFoundException("사용자를 찾을 수 없습니다.")
         val blog = blogRepository.findByUserId(userId) ?: throw NotFoundException("블로그를 찾을 수 없습니다.")
-        val (title, description, content) = createPostRequest
+        val (title, description, content, topics) = createPostRequest
 
-        return postRepository.save(
+        val savedPost = postRepository.save(
             Post(
                 blog = blog,
                 author = user,
@@ -31,5 +39,85 @@ class PostService(
                 content = content,
             )
         )
+
+        val normalizedTopics = normalizeTopics(topics)
+        if (normalizedTopics.isEmpty()) {
+            return savedPost
+        }
+
+        val existingTopics = topicRepository.findByNameIn(normalizedTopics)
+        val existingNames = existingTopics.mapTo(mutableSetOf()) { it.name }
+        val newTopics = normalizedTopics
+            .filterNot(existingNames::contains)
+            .map { Topic(name = it) }
+        val savedTopics = existingTopics + topicRepository.saveAll(newTopics)
+
+        postTopicRepository.saveAll(
+            savedTopics.map { topic ->
+                PostTopic(
+                    post = savedPost,
+                    topic = topic,
+                )
+            }
+        )
+
+        return savedPost
+    }
+
+    @Transactional
+    fun getPostDetail(postId: Long): PostDetailResponse {
+        val post = postRepository.findById(postId).getOrNull() ?: throw NotFoundException("글을 찾을 수 없습니다.")
+        val topics = postTopicRepository.findAllByPostId(postId)
+            .map { it.topic.name }
+            .sorted()
+
+        return PostDetailResponse(
+            id = requireNotNull(post.id),
+            title = post.title,
+            description = post.description,
+            content = post.content,
+            authorName = resolveAuthorName(post),
+            authorAvatarSrc = post.author.profileImageUrl,
+            publishedAtLabel = post.createdAt.format(PUBLISHED_AT_FORMATTER),
+            readTimeLabel = estimateReadTimeLabel(post),
+            topics = topics,
+        )
+    }
+
+    private fun normalizeTopics(rawTopics: List<String>): List<String> {
+        return rawTopics.asSequence()
+            .map { it.trim().lowercase() }
+            .filter(String::isNotBlank)
+            .distinct()
+            .toList()
+    }
+
+    private fun resolveAuthorName(post: Post): String {
+        val author = post.author
+        return when {
+            !author.nickname.isNullOrBlank() -> author.nickname.orEmpty()
+            !author.username.isNullOrBlank() -> author.username.orEmpty()
+            !author.email.isNullOrBlank() -> author.email.orEmpty()
+            else -> "OpenLog member"
+        }
+    }
+
+    private fun estimateReadTimeLabel(post: Post): String {
+        val wordCount = countWords("${post.title} ${post.description} ${post.content}")
+        val minutes = if (wordCount == 0) 1 else maxOf(1, kotlin.math.ceil(wordCount / 220.0).toInt())
+        return "$minutes min read"
+    }
+
+    private fun countWords(value: String): Int {
+        val trimmed = value.trim()
+        if (trimmed.isEmpty()) {
+            return 0
+        }
+
+        return trimmed.split(Regex("\\s+")).size
+    }
+
+    companion object {
+        private val PUBLISHED_AT_FORMATTER = DateTimeFormatter.ofPattern("yyyy. M. d.")
     }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/dto/CreatePostRequest.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/dto/CreatePostRequest.kt
@@ -1,0 +1,14 @@
+package io.github.kitae9999.openlog.post.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class CreatePostRequest(
+    @field:NotBlank(message = "제목은 필수입니다.")
+    val title: String,
+
+    @field:NotBlank(message = "설명은 필수입니다.")
+    val description: String,
+
+    @field:NotBlank(message = "본문은 필수입니다.")
+    val content: String,
+)

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/dto/CreatePostRequest.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/dto/CreatePostRequest.kt
@@ -11,4 +11,6 @@ data class CreatePostRequest(
 
     @field:NotBlank(message = "본문은 필수입니다.")
     val content: String,
+
+    val topics: List<String> = emptyList(),
 )

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/dto/PostDetailResponse.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/dto/PostDetailResponse.kt
@@ -1,0 +1,15 @@
+package io.github.kitae9999.openlog.post.dto
+
+data class PostDetailResponse(
+    val id: Long,
+    val title: String,
+    val description: String,
+    val content: String,
+    val authorName: String,
+    val authorAvatarSrc: String?,
+    val publishedAtLabel: String,
+    val readTimeLabel: String,
+    val topics: List<String>,
+    val likes: Int = 0,
+    val comments: Int = 0,
+)

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/entity/Post.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/entity/Post.kt
@@ -1,0 +1,64 @@
+package io.github.kitae9999.openlog.post.entity
+
+import io.github.kitae9999.openlog.user.entity.User
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.Version
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "posts",
+)
+class Post(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+    blogId: Long,
+    author: User,
+    title: String,
+    description: String,
+    content: String,
+    version: Long = 0L,
+) {
+    @Column(name = "blog_id", nullable = false)
+    var blogId: Long = blogId
+        protected set
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "author_id", nullable = false)
+    var author: User = author
+        protected set
+
+    @Column(nullable = false)
+    var title: String = title
+        protected set
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    var description: String = description
+        protected set
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    var content: String = content
+        protected set
+
+    @Version
+    @Column(nullable = false)
+    var version: Long = version
+        protected set
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now()
+        protected set
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+        protected set
+}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/entity/Post.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/entity/Post.kt
@@ -1,5 +1,6 @@
 package io.github.kitae9999.openlog.post.entity
 
+import io.github.kitae9999.openlog.blog.entity.Blog
 import io.github.kitae9999.openlog.user.entity.User
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -21,15 +22,16 @@ class Post(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
-    blogId: Long,
+    blog: Blog,
     author: User,
     title: String,
     description: String,
     content: String,
     version: Long = 0L,
 ) {
-    @Column(name = "blog_id", nullable = false)
-    var blogId: Long = blogId
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "blog_id", nullable = false)
+    var blog: Blog = blog
         protected set
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/repository/PostRepository.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/repository/PostRepository.kt
@@ -1,0 +1,7 @@
+package io.github.kitae9999.openlog.post.repository
+
+import io.github.kitae9999.openlog.post.entity.Post
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PostRepository: JpaRepository<Post, Long> {
+}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/posttopic/entity/PostTopic.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/posttopic/entity/PostTopic.kt
@@ -1,0 +1,37 @@
+package io.github.kitae9999.openlog.posttopic.entity
+
+import io.github.kitae9999.openlog.post.entity.Post
+import io.github.kitae9999.openlog.topic.entity.Topic
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.MapsId
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "post_topics")
+class PostTopic(
+    post: Post,
+    topic: Topic,
+) {
+    @EmbeddedId
+    var id: PostTopicId = PostTopicId(
+        postId = requireNotNull(post.id),
+        topicId = requireNotNull(topic.id),
+    )
+        protected set
+
+    @MapsId("postId")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "post_id", nullable = false)
+    var post: Post = post
+        protected set
+
+    @MapsId("topicId")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "topic_id", nullable = false)
+    var topic: Topic = topic
+        protected set
+}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/posttopic/entity/PostTopicId.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/posttopic/entity/PostTopicId.kt
@@ -1,0 +1,13 @@
+package io.github.kitae9999.openlog.posttopic.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import java.io.Serializable
+
+@Embeddable
+data class PostTopicId(
+    @Column(name = "post_id")
+    val postId: Long = 0L,
+    @Column(name = "topic_id")
+    val topicId: Long = 0L,
+) : Serializable

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/posttopic/repository/PostTopicRepository.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/posttopic/repository/PostTopicRepository.kt
@@ -1,0 +1,9 @@
+package io.github.kitae9999.openlog.posttopic.repository
+
+import io.github.kitae9999.openlog.posttopic.entity.PostTopic
+import io.github.kitae9999.openlog.posttopic.entity.PostTopicId
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PostTopicRepository : JpaRepository<PostTopic, PostTopicId> {
+    fun findAllByPostId(postId: Long): List<PostTopic>
+}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/topic/entity/Topic.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/topic/entity/Topic.kt
@@ -1,0 +1,21 @@
+package io.github.kitae9999.openlog.topic.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "topics")
+class Topic(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+    name: String,
+) {
+    @Column(nullable = false, unique = true)
+    var name: String = name
+        protected set
+}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/topic/repository/TopicRepository.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/topic/repository/TopicRepository.kt
@@ -1,0 +1,8 @@
+package io.github.kitae9999.openlog.topic.repository
+
+import io.github.kitae9999.openlog.topic.entity.Topic
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface TopicRepository : JpaRepository<Topic, Long> {
+    fun findByNameIn(names: Collection<String>): List<Topic>
+}

--- a/frontend/app/posts/[slug]/page.tsx
+++ b/frontend/app/posts/[slug]/page.tsx
@@ -1,11 +1,15 @@
+import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { getUserOrRedirectToOnboarding } from "@/features/auth/api/requireOnboarding";
+import { getPostDetail } from "@/entities/post/api/getPostDetail";
 import { Footer, Header } from "@/widgets/chrome/ui";
 import { PostArticle } from "@/widgets/post/ui";
 import {
   getPostEntry,
   contributors,
 } from "@/entities/post/model";
+import { assets } from "@/shared/config/assets";
+import { MarkdownContent } from "@/shared/ui/markdown";
 
 export default async function PostPage({
   params,
@@ -16,10 +20,54 @@ export default async function PostPage({
   const slugParam = p?.slug;
   const slug = Array.isArray(slugParam) ? slugParam[0] : slugParam;
   if (!slug) notFound();
+  const viewer = await getUserOrRedirectToOnboarding();
+  const headerStore = await headers();
+
+  if (/^\d+$/.test(slug)) {
+    const detail = await getPostDetail(Number(slug), headerStore.get("cookie") ?? "");
+    if (!detail) notFound();
+
+    return (
+      <div className="min-h-dvh bg-white text-zinc-950">
+        <Header
+          isLoggedIn={!!viewer}
+          profileImageUrl={viewer?.profileImageUrl}
+        />
+
+        <main className="mx-auto w-full max-w-[1083px] pb-16 pt-6 sm:px-8">
+          <PostArticle
+            post={{
+              title: detail.title,
+              description: detail.description,
+              authorName: detail.authorName,
+              authorAvatarSrc: detail.authorAvatarSrc ?? assets.defaultAvatar,
+              publishedAtLabel: detail.publishedAtLabel,
+              readTimeLabel: detail.readTimeLabel,
+              tags: detail.topics,
+              coverSrc: assets.postCover,
+              likes: detail.likes,
+              comments: detail.comments,
+            }}
+            backHref="/?tab=trending"
+            articleHref={`/posts/${detail.id}`}
+            suggestsHref={`/posts/${detail.id}/suggests`}
+            suggestEditsHref="/contribute"
+            suggestCount={0}
+            showSuggestsTab={false}
+          >
+            <div className="mt-8 space-y-6 text-[16px] leading-8 text-zinc-700">
+              <MarkdownContent markdown={detail.content} />
+            </div>
+          </PostArticle>
+        </main>
+
+        <Footer />
+      </div>
+    );
+  }
 
   const entry = getPostEntry(slug);
   if (!entry) notFound();
-  const viewer = await getUserOrRedirectToOnboarding();
 
   const articleHref = `/posts/${slug}`;
   const suggestsHref = `${articleHref}/suggests`;

--- a/frontend/app/write/action-state.ts
+++ b/frontend/app/write/action-state.ts
@@ -1,0 +1,9 @@
+type WriteFieldName = "title" | "description" | "content";
+
+export type WriteActionState = {
+  errors: Partial<Record<WriteFieldName | "form", string>>;
+};
+
+export const initialWriteActionState: WriteActionState = {
+  errors: {},
+};

--- a/frontend/app/write/actions.ts
+++ b/frontend/app/write/actions.ts
@@ -1,0 +1,77 @@
+"use server";
+
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { API_CONFIG } from "@/shared/api";
+import type { WriteActionState } from "./action-state";
+
+export async function submitPost(
+  _prevState: WriteActionState,
+  formData: FormData,
+): Promise<WriteActionState> {
+  const title = String(formData.get("title") ?? "").trim();
+  const description = String(formData.get("description") ?? "").trim();
+  const content = String(formData.get("content") ?? "").trim();
+  const topics = formData
+    .getAll("topics")
+    .map((value) => String(value).trim().toLowerCase())
+    .filter(Boolean)
+    .filter((value, index, list) => list.indexOf(value) === index);
+
+  const errors: WriteActionState["errors"] = {};
+
+  if (!title) {
+    errors.title = "제목은 필수입니다.";
+  }
+
+  if (!description) {
+    errors.description = "설명은 필수입니다.";
+  }
+
+  if (!content) {
+    errors.content = "본문은 필수입니다.";
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return { errors };
+  }
+
+  const headerStore = await headers();
+  const response = await fetch(`${API_CONFIG.baseURL}/posts`, {
+    method: "POST",
+    cache: "no-store",
+    headers: {
+      "content-type": "application/json",
+      cookie: headerStore.get("cookie") ?? "",
+    },
+    body: JSON.stringify({
+      title,
+      description,
+      content,
+      topics,
+    }),
+  });
+
+  if (response.ok) {
+    const location = response.headers.get("location");
+    redirect(location || "/");
+  }
+
+  if (response.status === 401) {
+    redirect("/");
+  }
+
+  let errorBody: { message?: string } | null = null;
+
+  try {
+    errorBody = (await response.json()) as { message?: string };
+  } catch {
+    errorBody = null;
+  }
+
+  return {
+    errors: {
+      form: errorBody?.message ?? "글을 발행하는 중 문제가 발생했습니다.",
+    },
+  };
+}

--- a/frontend/src/01_widgets/post/ui/PostArticle.tsx
+++ b/frontend/src/01_widgets/post/ui/PostArticle.tsx
@@ -88,6 +88,7 @@ export function PostArticle({
   suggestsHref = "/contribute",
   suggestEditsHref = "/contribute",
   suggestCount = 0,
+  showSuggestsTab = true,
 }: {
   post: Post;
   contributors?: Contributor[];
@@ -97,6 +98,7 @@ export function PostArticle({
   suggestsHref?: string;
   suggestEditsHref?: string;
   suggestCount?: number;
+  showSuggestsTab?: boolean;
 }) {
   const list = contributors ?? [];
 
@@ -130,6 +132,7 @@ export function PostArticle({
             articleHref={articleHref}
             suggestsHref={suggestsHref}
             suggestCount={suggestCount}
+            showSuggestsTab={showSuggestsTab}
           />
 
           <header className="mt-8 space-y-5">
@@ -170,16 +173,24 @@ export function PostArticle({
               {post.title}
             </h1>
 
-            <div className="flex flex-wrap gap-2">
-              {post.tags.map((tag) => (
-                <span
-                  key={tag}
-                  className="rounded-full border border-zinc-200 bg-zinc-50 px-3 py-1 text-[11px] font-medium uppercase tracking-wide text-zinc-600"
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
+            {post.description ? (
+              <p className="max-w-[60ch] text-[18px] leading-8 text-zinc-600">
+                {post.description}
+              </p>
+            ) : null}
+
+            {post.tags.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {post.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded-full border border-zinc-200 bg-zinc-50 px-3 py-1 text-[11px] font-medium uppercase tracking-wide text-zinc-600"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            ) : null}
           </header>
 
           <div className="mt-7 overflow-hidden rounded-2xl border border-zinc-200 bg-zinc-50 shadow-sm">
@@ -205,39 +216,41 @@ export function PostArticle({
             />
           </div>
 
-          <section className="mt-12 rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2 text-sm font-semibold text-zinc-950">
-                <Image
-                  src="/Users.svg"
-                  alt=""
-                  width={16}
-                  height={16}
-                  aria-hidden="true"
-                  className="size-4"
-                />
-                Contributors
+          {list.length > 0 ? (
+            <section className="mt-12 rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2 text-sm font-semibold text-zinc-950">
+                  <Image
+                    src="/Users.svg"
+                    alt=""
+                    width={16}
+                    height={16}
+                    aria-hidden="true"
+                    className="size-4"
+                  />
+                  Contributors
+                </div>
+                <span className="rounded-full border border-zinc-200 bg-zinc-50 px-2.5 py-1 text-[11px] font-medium text-zinc-500">
+                  {list.length} people
+                </span>
               </div>
-              <span className="rounded-full border border-zinc-200 bg-zinc-50 px-2.5 py-1 text-[11px] font-medium text-zinc-500">
-                {list.length} people
-              </span>
-            </div>
 
-            <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
-              {list.slice(0, 2).map((c) => (
-                <ContributorCard key={c.name} contributor={c} />
-              ))}
-            </div>
+              <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {list.slice(0, 2).map((c) => (
+                  <ContributorCard key={c.name} contributor={c} />
+                ))}
+              </div>
 
-            <div className="mt-4 text-center">
-              <Link
-                href="/contribute/history"
-                className="text-xs font-medium text-zinc-500 transition hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
-              >
-                View contribution history
-              </Link>
-            </div>
-          </section>
+              <div className="mt-4 text-center">
+                <Link
+                  href="/contribute/history"
+                  className="text-xs font-medium text-zinc-500 transition hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
+                >
+                  View contribution history
+                </Link>
+              </div>
+            </section>
+          ) : null}
         </article>
       </div>
     </div>

--- a/frontend/src/01_widgets/post/ui/PostTabs.tsx
+++ b/frontend/src/01_widgets/post/ui/PostTabs.tsx
@@ -9,11 +9,13 @@ export function PostTabs({
   articleHref,
   suggestsHref,
   suggestCount = 0,
+  showSuggestsTab = true,
 }: {
   activeTab: PostTabKey;
   articleHref: string;
   suggestsHref: string;
   suggestCount?: number;
+  showSuggestsTab?: boolean;
 }) {
   return (
     <nav aria-label="Post sections" className="mt-6 border-b border-zinc-200">
@@ -32,24 +34,26 @@ export function PostTabs({
           <span>Article</span>
         </Link>
 
-        <Link
-          href={suggestsHref}
-          aria-current={activeTab === "suggests" ? "page" : undefined}
-          className={cn(
-            "relative -mb-px inline-flex h-[34px] items-center gap-2 border-b-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20",
-            activeTab === "suggests"
-              ? "border-zinc-950 text-zinc-950"
-              : "border-transparent text-zinc-500 hover:text-zinc-950",
-          )}
-        >
-          <GitPullRequestIcon className="size-4" />
-          <span>Suggests</span>
-          {suggestCount > 0 ? (
-            <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-zinc-100 px-1.5 text-[11px] font-bold leading-none text-zinc-950">
-              {suggestCount}
-            </span>
-          ) : null}
-        </Link>
+        {showSuggestsTab ? (
+          <Link
+            href={suggestsHref}
+            aria-current={activeTab === "suggests" ? "page" : undefined}
+            className={cn(
+              "relative -mb-px inline-flex h-[34px] items-center gap-2 border-b-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20",
+              activeTab === "suggests"
+                ? "border-zinc-950 text-zinc-950"
+                : "border-transparent text-zinc-500 hover:text-zinc-950",
+            )}
+          >
+            <GitPullRequestIcon className="size-4" />
+            <span>Suggests</span>
+            {suggestCount > 0 ? (
+              <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-zinc-100 px-1.5 text-[11px] font-bold leading-none text-zinc-950">
+                {suggestCount}
+              </span>
+            ) : null}
+          </Link>
+        ) : null}
       </div>
     </nav>
   );

--- a/frontend/src/01_widgets/write/ui/WriteView.tsx
+++ b/frontend/src/01_widgets/write/ui/WriteView.tsx
@@ -4,19 +4,24 @@ import Image from "next/image";
 import Link from "next/link";
 import {
   startTransition,
+  useActionState,
   useDeferredValue,
   useEffect,
   useEffectEvent,
   useRef,
   useState,
+  type KeyboardEvent,
   type ReactNode,
 } from "react";
-import { cn } from "@/shared/lib/cn";
-import { MarkdownContent, MarkdownToolbar } from "@/shared/ui/markdown";
+import { useFormStatus } from "react-dom";
+import { submitPost } from "@/app/write/actions";
 import {
-  formatSelection,
-  type ToolbarAction,
-} from "@/shared/lib/markdown";
+  initialWriteActionState,
+  type WriteActionState,
+} from "@/app/write/action-state";
+import { cn } from "@/shared/lib/cn";
+import { formatSelection, type ToolbarAction } from "@/shared/lib/markdown";
+import { MarkdownContent, MarkdownToolbar } from "@/shared/ui/markdown";
 import { Footer, Header } from "@/widgets/chrome/ui";
 
 type ComposerMode = "edit" | "preview";
@@ -50,15 +55,25 @@ export function WriteView({
   const [mode, setMode] = useState<ComposerMode>("edit");
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
+  const [topicInput, setTopicInput] = useState("");
+  const [topics, setTopics] = useState<string[]>([]);
   const [body, setBody] = useState("");
   const [statusMessage, setStatusMessage] = useState(
     "Drafts save locally in this browser.",
   );
   const [hasRestoredDraft, setHasRestoredDraft] = useState(false);
+  const [submitErrors, setSubmitErrors] = useState<WriteActionState["errors"]>(
+    () => ({ ...initialWriteActionState.errors }),
+  );
+  const [actionState, formAction] = useActionState(
+    submitPost,
+    initialWriteActionState,
+  );
   const editorRef = useRef<HTMLTextAreaElement>(null);
 
   const deferredTitle = useDeferredValue(title);
   const deferredDescription = useDeferredValue(description);
+  const deferredTopics = useDeferredValue(topics);
   const deferredBody = useDeferredValue(body);
   const wordCount = countWords(
     `${deferredTitle} ${deferredDescription} ${deferredBody}`,
@@ -66,12 +81,21 @@ export function WriteView({
   const readTimeMinutes =
     wordCount === 0 ? 0 : Math.max(1, Math.ceil(wordCount / 220));
 
+  useEffect(() => {
+    setSubmitErrors(actionState?.errors ?? {});
+  }, [actionState]);
+
   function persistDraft(reason: SaveReason) {
     const trimmedTitle = title.trim();
     const trimmedDescription = description.trim();
     const trimmedBody = body.trim();
 
-    if (!trimmedTitle && !trimmedDescription && !trimmedBody) {
+    if (
+      !trimmedTitle &&
+      !trimmedDescription &&
+      !trimmedBody &&
+      topics.length === 0
+    ) {
       const hasStoredDraft = Boolean(
         window.localStorage.getItem(DRAFT_STORAGE_KEY),
       );
@@ -90,6 +114,7 @@ export function WriteView({
       JSON.stringify({
         title,
         description,
+        topics,
         body,
         updatedAt,
       }),
@@ -112,12 +137,14 @@ export function WriteView({
       const draft = JSON.parse(rawDraft) as Partial<{
         title: string;
         description: string;
+        topics: string[];
         body: string;
         updatedAt: string;
       }>;
 
       setTitle(draft.title ?? "");
       setDescription(draft.description ?? "");
+      setTopics(normalizeTopics(draft.topics ?? []));
       setBody(draft.body ?? "");
       setStatusMessage(statusLabel("restored", draft.updatedAt));
     } catch {
@@ -138,7 +165,14 @@ export function WriteView({
     }, 900);
 
     return () => window.clearTimeout(timeoutId);
-  }, [body, description, hasRestoredDraft, title]);
+  }, [
+    body,
+    description,
+    hasRestoredDraft,
+    persistDraftFromEffect,
+    title,
+    topics,
+  ]);
 
   function handleModeChange(nextMode: ComposerMode) {
     startTransition(() => {
@@ -148,6 +182,64 @@ export function WriteView({
 
   function handleSaveDraft() {
     persistDraft("manual");
+  }
+
+  function clearError(name: keyof WriteActionState["errors"]) {
+    setSubmitErrors((current) => ({
+      ...current,
+      [name]: undefined,
+      form: undefined,
+    }));
+  }
+
+  function handleTitleChange(nextValue: string) {
+    setTitle(nextValue);
+    clearError("title");
+  }
+
+  function handleDescriptionChange(nextValue: string) {
+    setDescription(nextValue);
+    clearError("description");
+  }
+
+  function handleBodyChange(nextValue: string) {
+    setBody(nextValue);
+    clearError("content");
+  }
+
+  function handleTopicInputChange(nextValue: string) {
+    setTopicInput(nextValue);
+    clearError("form");
+  }
+
+  function addTopic(rawValue: string) {
+    const nextTopic = normalizeTopic(rawValue);
+    if (!nextTopic) {
+      setTopicInput("");
+      return;
+    }
+
+    setTopics((current) =>
+      current.includes(nextTopic) ? current : [...current, nextTopic],
+    );
+    setTopicInput("");
+  }
+
+  function removeTopic(targetTopic: string) {
+    setTopics((current) => current.filter((topic) => topic !== targetTopic));
+  }
+
+  function handleTopicKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.nativeEvent.isComposing) {
+      return;
+    }
+
+    if (event.key !== "Enter") {
+      return;
+    }
+
+    event.preventDefault();
+    addTopic(topicInput);
   }
 
   function insertFormatting(action: ToolbarAction) {
@@ -168,6 +260,7 @@ export function WriteView({
     );
 
     setBody(nextValue);
+    clearError("content");
     handleModeChange("edit");
 
     window.requestAnimationFrame(() => {
@@ -185,7 +278,14 @@ export function WriteView({
       />
 
       <main className="mx-auto w-full max-w-[1083px] px-4 pb-16 pt-6 sm:px-8">
-        <section className="flex flex-col gap-6">
+        <form action={formAction} className="flex flex-col gap-6">
+          {topics.map((topic) => (
+            <input key={topic} type="hidden" name="topics" value={topic} />
+          ))}
+          {mode === "preview" ? (
+            <input type="hidden" name="content" value={body} />
+          ) : null}
+
           <div className="flex flex-col gap-6 border-b border-zinc-200/80 pb-6 lg:flex-row lg:items-start lg:justify-between">
             <div className="min-w-0">
               <Link
@@ -255,7 +355,15 @@ export function WriteView({
                   <IconSave className="size-4" />
                   Save Draft
                 </button>
+
+                <PublishButton />
               </div>
+
+              {submitErrors.form ? (
+                <p className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+                  {submitErrors.form}
+                </p>
+              ) : null}
             </div>
           </div>
 
@@ -268,11 +376,24 @@ export function WriteView({
                       Title
                     </span>
                     <input
+                      name="title"
                       value={title}
-                      onChange={(event) => setTitle(event.target.value)}
+                      onChange={(event) =>
+                        handleTitleChange(event.target.value)
+                      }
                       placeholder="Summarize your idea with a clear title"
-                      className="mt-1 h-[42px] w-full rounded-[10px] border border-zinc-200 px-4 text-[16px] tracking-[-0.02em] text-zinc-950 outline-none transition placeholder:text-zinc-400 focus:border-zinc-400 focus:ring-4 focus:ring-zinc-900/5"
+                      className={cn(
+                        "mt-1 h-[42px] w-full rounded-[10px] border px-4 text-[16px] tracking-[-0.02em] text-zinc-950 outline-none transition placeholder:text-zinc-400 focus:ring-4 focus:ring-zinc-900/5",
+                        submitErrors.title
+                          ? "border-rose-300 bg-rose-50/40 focus:border-rose-400"
+                          : "border-zinc-200 focus:border-zinc-400",
+                      )}
                     />
+                    {submitErrors.title ? (
+                      <p className="mt-2 text-sm text-rose-600">
+                        {submitErrors.title}
+                      </p>
+                    ) : null}
                   </label>
 
                   <label className="block">
@@ -280,12 +401,52 @@ export function WriteView({
                       Description
                     </span>
                     <textarea
+                      name="description"
                       value={description}
-                      onChange={(event) => setDescription(event.target.value)}
+                      onChange={(event) =>
+                        handleDescriptionChange(event.target.value)
+                      }
                       placeholder="Describe why this story matters and what readers will learn..."
                       rows={4}
-                      className="mt-1 w-full rounded-[10px] border border-zinc-200 px-4 py-3 text-[16px] leading-6 tracking-[-0.02em] text-zinc-950 outline-none transition placeholder:text-zinc-400 focus:border-zinc-400 focus:ring-4 focus:ring-zinc-900/5"
+                      className={cn(
+                        "mt-1 w-full rounded-[10px] border px-4 py-3 text-[16px] leading-6 tracking-[-0.02em] text-zinc-950 outline-none transition placeholder:text-zinc-400 focus:ring-4 focus:ring-zinc-900/5",
+                        submitErrors.description
+                          ? "border-rose-300 bg-rose-50/40 focus:border-rose-400"
+                          : "border-zinc-200 focus:border-zinc-400",
+                      )}
                     />
+                    {submitErrors.description ? (
+                      <p className="mt-2 text-sm text-rose-600">
+                        {submitErrors.description}
+                      </p>
+                    ) : null}
+                  </label>
+
+                  <label className="block">
+                    <span className="text-sm font-medium text-zinc-700">
+                      Topics
+                    </span>
+                    <input
+                      value={topicInput}
+                      onChange={(event) =>
+                        handleTopicInputChange(event.target.value)
+                      }
+                      onKeyDown={handleTopicKeyDown}
+                      placeholder="Type a topic and press Enter"
+                      className="mt-1 h-[42px] w-full rounded-[10px] border border-zinc-200 px-4 text-[16px] tracking-[-0.02em] text-zinc-950 outline-none transition placeholder:text-zinc-400 focus:border-zinc-400 focus:ring-4 focus:ring-zinc-900/5"
+                    />
+
+                    {topics.length > 0 ? (
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        {topics.map((topic) => (
+                          <TopicChip
+                            key={topic}
+                            topic={topic}
+                            onRemove={() => removeTopic(topic)}
+                          />
+                        ))}
+                      </div>
+                    ) : null}
                   </label>
                 </div>
               </section>
@@ -302,8 +463,9 @@ export function WriteView({
                   {mode === "edit" ? (
                     <textarea
                       ref={editorRef}
+                      name="content"
                       value={body}
-                      onChange={(event) => setBody(event.target.value)}
+                      onChange={(event) => handleBodyChange(event.target.value)}
                       placeholder="Start typing..."
                       className="min-h-[520px] w-full resize-none px-6 py-6 text-[16px] leading-8 tracking-[-0.01em] text-zinc-900 outline-none placeholder:text-zinc-400"
                     />
@@ -311,10 +473,17 @@ export function WriteView({
                     <MarkdownPreview
                       title={deferredTitle}
                       description={deferredDescription}
+                      topics={deferredTopics}
                       body={deferredBody}
                     />
                   )}
                 </div>
+
+                {submitErrors.content ? (
+                  <div className="border-t border-rose-200 bg-rose-50 px-6 py-3 text-sm text-rose-700">
+                    {submitErrors.content}
+                  </div>
+                ) : null}
               </section>
             </div>
 
@@ -355,7 +524,7 @@ export function WriteView({
               </section>
             </aside>
           </div>
-        </section>
+        </form>
       </main>
 
       <Footer />
@@ -392,25 +561,64 @@ function ModeButton({
   );
 }
 
+function PublishButton() {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className="inline-flex h-11 items-center justify-center gap-2 rounded-xl border border-zinc-900 bg-zinc-950 px-5 text-sm font-semibold text-white shadow-[0_1px_3px_rgba(0,0,0,0.18),0_1px_2px_rgba(0,0,0,0.1)] transition hover:bg-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/25 disabled:cursor-not-allowed disabled:bg-zinc-400"
+    >
+      {pending ? "Publishing..." : "Publish"}
+    </button>
+  );
+}
+
+function TopicChip({
+  topic,
+  onRemove,
+}: {
+  topic: string;
+  onRemove: () => void;
+}) {
+  return (
+    <span className="inline-flex items-center gap-2 rounded-full border border-zinc-200 bg-zinc-50 px-3 py-1.5 text-[12px] font-medium tracking-wide text-zinc-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.85)]">
+      <span>{topic}</span>
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label={`Remove ${topic}`}
+        className="grid size-4 place-items-center rounded-full text-zinc-400 transition hover:bg-zinc-200 hover:text-zinc-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
+      >
+        <IconClose className="size-3" />
+      </button>
+    </span>
+  );
+}
+
 function MarkdownPreview({
   title,
   description,
+  topics,
   body,
 }: {
   title: string;
   description: string;
+  topics: string[];
   body: string;
 }) {
-  const hasContent = title.trim() || description.trim() || body.trim();
+  const hasContent =
+    title.trim() || description.trim() || body.trim() || topics.length > 0;
 
   if (!hasContent) {
     return (
-      <div className="flex min-h-[520px] items-center justify-center px-6 py-10">
-        <div className="max-w-[360px] text-center">
+      <div className="flex min-h-130 items-center justify-center px-6 py-10">
+        <div className="max-w-90 text-center">
           <p className="text-sm font-medium text-zinc-500">Preview is empty</p>
           <p className="mt-2 text-sm leading-6 text-zinc-400">
-            Add a title, description, or markdown content to see the article
-            preview here.
+            Add a title, description, topics, or markdown content to see the
+            article preview here.
           </p>
         </div>
       </div>
@@ -418,18 +626,30 @@ function MarkdownPreview({
   }
 
   return (
-    <article className="min-h-[520px] px-6 py-8">
+    <article className="min-h-130 px-6 py-8">
       <header className="border-b border-zinc-200 pb-8">
         <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-zinc-400">
           Live Preview
         </p>
-        <h2 className="mt-4 [font-family:Georgia,serif] text-[34px] font-bold leading-tight tracking-[-0.03em] text-zinc-950">
+        <h2 className="mt-4 font-[Georgia,serif] text-[34px] font-bold leading-tight tracking-[-0.03em] text-zinc-950">
           {title.trim() || "Untitled story"}
         </h2>
         {description.trim() ? (
           <p className="mt-4 max-w-[60ch] text-[17px] leading-8 text-zinc-600">
             {description}
           </p>
+        ) : null}
+        {topics.length > 0 ? (
+          <div className="mt-5 flex flex-wrap gap-2">
+            {topics.map((topic) => (
+              <span
+                key={topic}
+                className="rounded-full border border-zinc-200 bg-zinc-50 px-3 py-1 text-[11px] font-medium uppercase tracking-wide text-zinc-600"
+              >
+                {topic}
+              </span>
+            ))}
+          </div>
         ) : null}
       </header>
 
@@ -445,6 +665,18 @@ function MarkdownPreview({
       </div>
     </article>
   );
+}
+
+function normalizeTopic(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function normalizeTopics(values: string[]) {
+  return values
+    .map(normalizeTopic)
+    .filter(
+      (value, index, list) => Boolean(value) && list.indexOf(value) === index,
+    );
 }
 
 function countWords(value: string) {
@@ -489,7 +721,12 @@ function formatTimeLabel(isoDate?: string) {
 
 function IconArrowLeft({ className }: { className?: string }) {
   return (
-    <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
       <path
         d="M15 18l-6-6 6-6"
         stroke="currentColor"
@@ -509,7 +746,12 @@ function IconArrowLeft({ className }: { className?: string }) {
 
 function IconEdit({ className }: { className?: string }) {
   return (
-    <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
       <path
         d="M12 20h9"
         stroke="currentColor"
@@ -529,7 +771,12 @@ function IconEdit({ className }: { className?: string }) {
 
 function IconSave({ className }: { className?: string }) {
   return (
-    <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
       <path
         d="M19 21H5a2 2 0 01-2-2V5a2 2 0 012-2h11l5 5v11a2 2 0 01-2 2z"
         stroke="currentColor"
@@ -550,6 +797,30 @@ function IconSave({ className }: { className?: string }) {
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function IconClose({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M4 4l8 8"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+      />
+      <path
+        d="M12 4L4 12"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
       />
     </svg>
   );

--- a/frontend/src/03_entities/post/api/getPostDetail.ts
+++ b/frontend/src/03_entities/post/api/getPostDetail.ts
@@ -1,0 +1,34 @@
+import { API_CONFIG } from "@/shared/api";
+
+export type ApiPostDetail = {
+  id: number;
+  title: string;
+  description: string;
+  content: string;
+  authorName: string;
+  authorAvatarSrc: string | null;
+  publishedAtLabel: string;
+  readTimeLabel: string;
+  topics: string[];
+  likes: number;
+  comments: number;
+};
+
+export async function getPostDetail(id: number, cookie: string) {
+  const response = await fetch(`${API_CONFIG.baseURL}/posts/${id}`, {
+    cache: "no-store",
+    headers: {
+      cookie,
+    },
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error("Failed to load post detail.");
+  }
+
+  return (await response.json()) as ApiPostDetail;
+}

--- a/frontend/src/03_entities/post/model/postData.tsx
+++ b/frontend/src/03_entities/post/model/postData.tsx
@@ -9,6 +9,7 @@ export type Contributor = {
 
 export type Post = {
   title: string;
+  description?: string;
   authorName: string;
   authorAvatarSrc: string;
   publishedAtLabel: string;


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #

---

## 1. PR 유형
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ✨ 새로운 기능 (New Feature)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 업데이트 (Documentation)
- [ ] ⚙️ 설정/빌드 변경 (Chore)

---

## 2. 작업 배경 및 목적
- **기존 상태:** `frontend/src/01_widgets/write/ui/WriteView.tsx`의 글쓰기 화면은 제목, 설명, 본문을 브라우저 `localStorage`에만 저장하는 편집 UI였고, 이를 실제 게시물로 저장할 `POST /posts` 백엔드 API가 없었습니다. `/posts/[slug]` 페이지는 문자열 slug 기준의 목업 `postEntries`만 렌더링했고, 인증 쿠키에서 현재 사용자 ID를 추출하는 로직도 `AuthController` 내부 private 함수로만 존재했습니다.
- **문제점:** Publish 이후에도 작성 내용이 DB에 영속되지 않아 브라우저 밖에서는 접근할 수 없었고, 실존 게시물의 제목·본문·토픽·작성자 정보를 조회하는 읽기 경로도 비어 있었습니다. 또한 인증이 필요한 새 엔드포인트를 만들 때마다 쿠키/JWT 파싱을 중복 구현해야 했고, 사용자/블로그/게시물 부재 상황을 일관된 404 응답으로 표준화할 수 없었습니다.
- **해결 목표:** 인증 쿠키 기반 현재 사용자 해석을 공용 컴포넌트로 분리하고, `POST /posts`, `GET /posts/{id}`를 통해 게시물과 토픽을 영속화/조회하는 파이프라인을 추가합니다. 동시에 `/write` 폼과 `/posts/[slug]`를 이 API에 연결해 발행 후 실제 게시물 상세 페이지로 이동시키고, description/topic/markdown 본문까지 같은 데이터 모델로 렌더링합니다.

---

## 3. 상세 변경 내역 및 동작 흐름

### A. 인증 쿠키에서 현재 사용자를 해석하는 공용 Resolver와 404 응답 경로 추가
- **진입점 및 초기 조건:** `backend/src/main/kotlin/io/github/kitae9999/openlog/auth/CurrentUserResolver.kt`의 `resolveUserId(request)`가 인증 진입점이고, `AuthController.getMe()`, `AuthController.completeOnboarding()`, `PostController.createPost()`가 이 Resolver를 공용으로 호출합니다. 리소스 부재는 `backend/src/main/kotlin/io/github/kitae9999/openlog/common/exception/NotFoundException.kt`와 `GlobalExceptionHandler`가 처리합니다.

```kotlin
val accessToken = request.cookies
    ?.firstOrNull { it.name == accessTokenCookieName }
    ?.value
    ?: throw OAuthAuthenticationException()

return jwtTokenService.parseUserId(accessToken)
```

- **단계별 제어 흐름:**
  1. 컨트롤러가 `HttpServletRequest`를 `CurrentUserResolver.resolveUserId()`에 전달합니다.
  2. Resolver가 JWT 쿠키를 찾고 `JwtTokenService.parseUserId()`로 `Long` 타입 사용자 ID를 복원합니다.
  3. 서비스 계층이 해당 ID로 사용자, 블로그, 게시물을 조회하다가 리소스를 찾지 못하면 `NotFoundException`을 발생시킵니다.
  4. `GlobalExceptionHandler.handleNotFoundException()`가 이를 `404 NOT_FOUND` 응답으로 직렬화합니다.
- **데이터 상태 변이:** 쿠키 문자열이 컨트롤러 내부 임시 값이 아니라 재사용 가능한 `userId: Long`으로 승격되고, 리소스 부재 예외는 엔드포인트별 ad-hoc 응답 대신 공통 `ErrorResponse(code = "NOT_FOUND")` 포맷으로 수렴합니다.
- **최종 반환 및 종료 상태:** 인증이 필요한 `auth`/`posts` API가 동일한 사용자 식별 경로를 공유하게 되었고, 이후 추가되는 인증 엔드포인트도 같은 Resolver와 404 처리기를 그대로 재사용할 수 있습니다.

### B. 게시물, 블로그, 토픽 연관을 저장하는 `POST /posts` 영속화 파이프라인 추가
- **진입점 및 초기 조건:** `backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostController.kt`의 `POST /posts`가 진입점이며, `CreatePostRequest(title, description, content, topics)` JSON payload가 Bean Validation을 통과한 상태로 주입됩니다. 저장 대상 도메인은 `Post`, `Blog`, `Topic`, `PostTopic` 엔티티와 각 JPA Repository입니다.

```kotlin
val savedPost = postRepository.save(
    Post(
        blog = blog,
        author = user,
        title = title,
        description = description,
        content = content,
    )
)
```

- **단계별 제어 흐름:**
  1. `PostController.createPost()`가 `CurrentUserResolver`로 사용자 ID를 구한 뒤 `PostService.createPost()`를 호출합니다.
  2. `PostService`가 `UserRepository.findById()`, `BlogRepository.findByUserId()`로 작성자와 작성자 블로그를 조회합니다.
  3. 요청 본문의 `title`, `description`, `content`로 `Post` 엔티티를 먼저 저장해 PK를 확보합니다.
  4. `normalizeTopics()`가 토픽 문자열을 `trim -> lowercase -> notBlank -> distinct` 순서로 정규화합니다.
  5. `TopicRepository.findByNameIn()`으로 기존 토픽을 조회하고, 누락된 이름만 `Topic(name = it)`로 신규 저장합니다.
  6. 최종 토픽 목록을 `PostTopic(post, topic)` 조인 엔티티로 매핑해 `post_topics` 연관을 일괄 저장한 뒤 `201 Created`와 `Location: /posts/{id}`를 반환합니다.
- **데이터 상태 변이:** 요청 페이로드 `{ title, description, content, topics[] }`가 `posts` 1행, 필요 시 `topics` N행, `post_topics` N행으로 변환됩니다. 토픽은 소문자 중복 제거 규칙을 거친 canonical name으로 저장되므로 `"React"`, `" react "` 같은 입력은 하나의 `react` 레코드로 합쳐집니다.
- **최종 반환 및 종료 상태:** 인증된 사용자는 실제 게시물을 DB에 생성할 수 있게 되었고, 프론트는 응답 `Location` 헤더만으로 생성된 게시물의 상세 URL을 즉시 획득할 수 있습니다.

### C. 게시물 본문, 작성자 표시명, 읽기 시간, 토픽을 평탄화하는 `GET /posts/{id}` 조회 API 추가
- **진입점 및 초기 조건:** `backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostController.kt`의 `GET /posts/{id}`가 진입점이며, `PostService.getPostDetail(postId)`가 조회 로직을 담당합니다. 입력은 숫자형 게시물 ID 하나이고, 결과는 `PostDetailResponse` DTO입니다.

```kotlin
return PostDetailResponse(
    id = requireNotNull(post.id),
    title = post.title,
    description = post.description,
    content = post.content,
    authorName = resolveAuthorName(post),
    authorAvatarSrc = post.author.profileImageUrl,
    publishedAtLabel = post.createdAt.format(PUBLISHED_AT_FORMATTER),
    readTimeLabel = estimateReadTimeLabel(post),
    topics = topics,
)
```

- **단계별 제어 흐름:**
  1. `PostRepository.findById()`로 게시물을 조회하고 없으면 `NotFoundException("글을 찾을 수 없습니다.")`를 발생시킵니다.
  2. `PostTopicRepository.findAllByPostId()`가 조인 테이블에서 현재 게시물의 토픽 연결을 읽고, 서비스가 이름만 추출해 정렬합니다.
  3. `resolveAuthorName()`이 `nickname -> username -> email -> "OpenLog member"` 순으로 작성자 표시명을 선택합니다.
  4. `estimateReadTimeLabel()`이 제목, 설명, 본문 단어 수를 합산해 `220 WPM` 기준 읽기 시간을 계산합니다.
  5. 서비스가 위 값을 `PostDetailResponse`로 평탄화해 컨트롤러에 반환합니다.
- **데이터 상태 변이:** 지연 로딩 엔티티 그래프 `Post(author, blog)`와 `PostTopic[]`가 프론트 친화적인 평면 DTO `{ title, description, content, authorName, authorAvatarSrc, publishedAtLabel, readTimeLabel, topics }`로 직렬화됩니다.
- **최종 반환 및 종료 상태:** 프론트는 숫자 ID만 알면 하나의 API 호출로 본문 markdown, 토픽 태그, 작성자 메타데이터를 모두 렌더링할 수 있게 되었습니다.

### D. `/write` 서버 액션이 폼 데이터를 정규화해 인증 쿠키와 함께 게시물 생성 API로 전달
- **진입점 및 초기 조건:** `frontend/app/write/actions.ts`의 서버 액션 `submitPost()`가 진입점이며, `WriteView`의 `<form action={formAction}>`가 `FormData`를 전달합니다. 제목, 설명, 본문은 문자열로, 토픽은 중복 가능한 `topics` hidden input 배열로 수집됩니다.

```ts
const response = await fetch(`${API_CONFIG.baseURL}/posts`, {
  method: "POST",
  cache: "no-store",
  headers: {
    "content-type": "application/json",
    cookie: headerStore.get("cookie") ?? "",
  },
  body: JSON.stringify({ title, description, content, topics }),
});
```

- **단계별 제어 흐름:**
  1. `submitPost()`가 `formData.get()` / `formData.getAll()`로 필드를 읽고 문자열을 `trim()`합니다.
  2. 토픽 목록은 `trim -> lowercase -> filter(Boolean) -> distinct` 순서로 정규화됩니다.
  3. 제목, 설명, 본문이 비어 있으면 서버 액션이 즉시 `WriteActionState.errors`를 반환해 네트워크 호출을 중단합니다.
  4. 유효한 입력이면 `headers()`에서 현재 요청의 cookie 헤더를 읽어 백엔드 `POST /posts`로 그대로 포워딩합니다.
  5. 응답이 `201`이면 `Location` 헤더로 `redirect()`하고, `401`이면 홈으로 리다이렉트하며, 기타 실패는 JSON 에러 메시지를 폼 전역 에러로 정규화합니다.
- **데이터 상태 변이:** 브라우저 폼 데이터가 서버 액션 내부에서 API payload `{ title, description, content, topics }`로 변환되고, 실패 시에는 React 렌더링 가능한 `WriteActionState.errors` 구조로 다시 역직렬화됩니다.
- **최종 반환 및 종료 상태:** Publish 버튼이 단순 UI 요소가 아니라 실제 게시물 생성 플로우의 진입점이 되었고, 성공 시 새 게시물 상세 페이지로 즉시 이동합니다.

### E. 글쓰기 화면에 토픽 편집, 발행 상태, 로컬 드래프트 복원, 필드 에러 표시를 추가
- **진입점 및 초기 조건:** `frontend/src/01_widgets/write/ui/WriteView.tsx`가 클라이언트 진입점이며, `useActionState(submitPost, initialWriteActionState)`가 서버 액션 결과를 구독합니다. 로컬 상태는 `title`, `description`, `topicInput`, `topics`, `body`, `submitErrors`, `statusMessage`로 관리됩니다.

```ts
window.localStorage.setItem(
  DRAFT_STORAGE_KEY,
  JSON.stringify({
    title,
    description,
    topics,
    body,
    updatedAt,
  }),
);
```

- **단계별 제어 흐름:**
  1. 초기 마운트 시 `localStorage`에서 draft를 읽고 제목/설명/토픽/본문을 복원합니다.
  2. 사용자가 입력을 수정하면 `useEffectEvent`와 `setTimeout(900ms)`를 통해 자동 저장이 동작합니다.
  3. Topic 입력창에서 Enter를 누르면 `normalizeTopic()`이 공백 제거 및 소문자화 후 중복 없는 chip 목록으로 편입합니다.
  4. `useActionState` 결과가 바뀌면 `submitErrors`를 최신 서버 액션 상태로 동기화하고, 각 입력 핸들러가 해당 필드 에러를 즉시 해제합니다.
  5. Preview 모드에서는 hidden `content` input을 추가하고, 제목/설명/토픽 태그/markdown 본문을 실시간으로 렌더링합니다.
- **데이터 상태 변이:** 기존 `title/description/body` 3필드 상태가 `{ title, description, topics[], body, submitErrors }`로 확장되었고, 브라우저 드래프트도 토픽까지 포함한 JSON snapshot으로 보존됩니다.
- **최종 반환 및 종료 상태:** 작성자는 토픽을 칩 형태로 관리하고, draft 복원/자동 저장/필드별 검증/Preview를 유지한 채 게시물을 발행할 수 있습니다.

### F. 숫자 slug 게시물 상세 페이지가 실데이터와 기존 목업 데이터를 모두 수용하도록 프론트 렌더링 경로 확장
- **진입점 및 초기 조건:** `frontend/app/posts/[slug]/page.tsx`가 라우트 진입점이며, `slug`가 숫자 문자열이면 실데이터 API, 그렇지 않으면 기존 `getPostEntry(slug)` 목업 데이터를 사용합니다. 렌더링 컴포넌트는 `PostArticle`, `PostTabs`, `MarkdownContent`입니다.

```ts
if (/^\d+$/.test(slug)) {
  const detail = await getPostDetail(Number(slug), headerStore.get("cookie") ?? "");
  if (!detail) notFound();
  // ...
}
```

- **단계별 제어 흐름:**
  1. 페이지가 `getUserOrRedirectToOnboarding()`로 viewer를 조회하고, `headers()`에서 cookie 헤더를 읽습니다.
  2. `slug`가 숫자면 `getPostDetail(id, cookie)`가 백엔드 `GET /posts/{id}`를 호출하고, 404는 `null`로 바꿔 `notFound()`로 종료합니다.
  3. 응답 DTO를 `PostArticle` prop으로 매핑하면서 `topics -> tags`, `authorAvatarSrc ?? assets.defaultAvatar`, `content -> <MarkdownContent />`로 변환합니다.
  4. 숫자 게시물은 아직 제안 기능 데이터가 없으므로 `showSuggestsTab={false}`로 탭을 숨깁니다.
  5. 문자열 slug는 기존 `postEntries` fallback을 그대로 유지해 기존 데모 경로를 깨지 않습니다.
  6. `PostArticle`은 `description`과 optional contributors 렌더링을 지원하고, `PostTabs`는 `showSuggestsTab` prop으로 보조 탭 노출을 제어합니다.
- **데이터 상태 변이:** URL slug 하나가 정규식 분기를 통해 `ApiPostDetail` 또는 목업 `PostEntry`로 해석되고, `PostArticle`은 두 데이터원을 모두 받을 수 있는 공용 UI로 확장됩니다.
- **최종 반환 및 종료 상태:** 새로 발행한 게시물은 `/posts/{id}` 경로에서 실제 markdown 본문과 토픽을 렌더링하고, 기존 문자열 기반 데모 게시물도 이전과 동일하게 조회됩니다.

---

## 4. 스크린샷 (선택)
- 없음

## 5. 테스트 및 검증 방법
- **테스트 환경:** macOS 로컬 환경에서 레포 루트 Gradle Wrapper와 `frontend/` Next.js 빌드를 사용해 검증했습니다. 백엔드는 Kotlin/Spring Boot + JPA 조합, 프론트는 Next.js `16.1.6` + App Router 구성입니다.
- **입력 시나리오:**
  1. `./gradlew :backend:compileKotlin`
  2. `cd frontend && npm run build`
- **출력 검증:** `:backend:compileKotlin`이 `BUILD SUCCESSFUL`로 종료되어 `CurrentUserResolver`, `PostController`, `PostService`, 신규 엔티티/DTO 추가 이후 Kotlin 컴파일 정합성을 확인했습니다. `npm run build`도 성공했고 결과 라우트에 `/write`, `/posts/[slug]`, `/posts/[slug]/suggests`, `/posts/[slug]/suggests/[suggestId]`, `/profile`, `/onboarding`, `/`가 정상 출력되었습니다. 이는 글쓰기 서버 액션과 숫자 slug 상세 페이지 분기가 Next.js 빌드 파이프라인에 무리 없이 편입되었음을 의미합니다.

---

## 6. 리뷰어 참고 사항 (선택)
- **특이 구현 사항:** `POST /posts`는 작성자 ID로 `BlogRepository.findByUserId()`를 먼저 조회한 뒤 게시물을 저장합니다. 따라서 작성 사용자에 대응되는 `blogs` 레코드가 없으면 게시물 생성은 `404 블로그를 찾을 수 없습니다.`로 종료됩니다. 또한 숫자 slug 게시물 상세 페이지는 현재 `assets.postCover`를 공용 커버로 사용하고, `likes`/`comments`는 `PostDetailResponse` 기본값 `0`을 그대로 노출합니다.
- **파급 효과:** 이 PR은 게시물 생성/조회의 최소 경로를 열어두는 범위에 집중했기 때문에, 블로그 자동 생성 정책, 게시물 커버 이미지 업로드, 좋아요/댓글 실데이터 집계, 숫자 slug 게시물의 Suggests 탭 연결은 후속 PR에서 이어서 구현해야 합니다.

---

## 7. 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일 가이드를 준수합니다.
- [x] 변경 사항에 대한 테스트 코드를 작성하거나 통과했습니다.
- [ ] 관련된 문서(README, API 명세 등)를 업데이트했습니다.
