### PR TITLE
[Feat] 포스트 상세 페이지 기능 추가

### DIFF
--- a/frontend/app/[username]/posts/[postSlug]/page.tsx
+++ b/frontend/app/[username]/posts/[postSlug]/page.tsx
@@ -71,6 +71,7 @@ export default async function PublicPostPage({
               comments: detail.comments,
             }}
             authorHref={authorHref}
+            currentUserAvatarSrc={viewer?.profileImageUrl}
             backHref="/?tab=trending"
             articleHref={articleHref}
             suggestsHref={suggestsHref}
@@ -111,6 +112,7 @@ export default async function PublicPostPage({
           post={entry.post}
           contributors={contributors}
           authorHref={authorHref}
+          currentUserAvatarSrc={viewer?.profileImageUrl}
           backHref="/?tab=trending"
           articleHref={articleHref}
           suggestsHref={suggestsHref}

--- a/frontend/app/[username]/posts/[postSlug]/page.tsx
+++ b/frontend/app/[username]/posts/[postSlug]/page.tsx
@@ -6,6 +6,7 @@ import { getPostEntry, contributors } from "@/entities/post/model";
 import { getUser } from "@/features/auth/api/getUser";
 import { assets } from "@/shared/config/assets";
 import {
+  buildPublicProfilePath,
   buildPublicPostPath,
   buildPublicSuggestsPath,
   buildViewerProfileHref,
@@ -40,6 +41,7 @@ export default async function PublicPostPage({
   const profileHref = viewer ? buildViewerProfileHref(viewer.username) : undefined;
 
   if (detail) {
+    const authorHref = buildPublicProfilePath(detail.authorUsername);
     const articleHref = buildPublicPostPath(detail.authorUsername, detail.slug);
     const suggestsHref = buildPublicSuggestsPath(
       detail.authorUsername,
@@ -68,6 +70,7 @@ export default async function PublicPostPage({
               likes: detail.likes,
               comments: detail.comments,
             }}
+            authorHref={authorHref}
             backHref="/?tab=trending"
             articleHref={articleHref}
             suggestsHref={suggestsHref}
@@ -92,6 +95,7 @@ export default async function PublicPostPage({
   }
 
   const articleHref = buildPublicPostPath(authorUsername, canonicalPostSlug);
+  const authorHref = buildPublicProfilePath(authorUsername);
   const suggestsHref = buildPublicSuggestsPath(authorUsername, canonicalPostSlug);
 
   return (
@@ -106,6 +110,7 @@ export default async function PublicPostPage({
         <PostArticle
           post={entry.post}
           contributors={contributors}
+          authorHref={authorHref}
           backHref="/?tab=trending"
           articleHref={articleHref}
           suggestsHref={suggestsHref}

--- a/frontend/app/[username]/posts/[postSlug]/page.tsx
+++ b/frontend/app/[username]/posts/[postSlug]/page.tsx
@@ -38,7 +38,9 @@ export default async function PublicPostPage({
     getUser(),
     getPostDetail(authorUsername, canonicalPostSlug),
   ]);
-  const profileHref = viewer ? buildViewerProfileHref(viewer.username) : undefined;
+  const profileHref = viewer
+    ? buildViewerProfileHref(viewer.username)
+    : undefined;
 
   if (detail) {
     const authorHref = buildPublicProfilePath(detail.authorUsername);
@@ -77,7 +79,6 @@ export default async function PublicPostPage({
             suggestsHref={suggestsHref}
             suggestEditsHref="/contribute"
             suggestCount={0}
-            showSuggestsTab={false}
           >
             <div className="mt-8 space-y-6 text-[16px] leading-8 text-zinc-700">
               <MarkdownContent markdown={detail.content} />
@@ -97,7 +98,10 @@ export default async function PublicPostPage({
 
   const articleHref = buildPublicPostPath(authorUsername, canonicalPostSlug);
   const authorHref = buildPublicProfilePath(authorUsername);
-  const suggestsHref = buildPublicSuggestsPath(authorUsername, canonicalPostSlug);
+  const suggestsHref = buildPublicSuggestsPath(
+    authorUsername,
+    canonicalPostSlug,
+  );
 
   return (
     <div className="min-h-dvh bg-white text-zinc-950">

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -31,12 +31,12 @@ body {
 
 .markdown-code .hljs {
   background: transparent;
-  color: #f8fafc;
+  color: #18181b;
 }
 
 .markdown-code .hljs-comment,
 .markdown-code .hljs-quote {
-  color: #94a3b8;
+  color: #71717a;
   font-style: italic;
 }
 
@@ -45,7 +45,7 @@ body {
 .markdown-code .hljs-section,
 .markdown-code .hljs-type,
 .markdown-code .hljs-literal {
-  color: #f472b6;
+  color: #c0266d;
 }
 
 .markdown-code .hljs-title,
@@ -55,7 +55,7 @@ body {
 .markdown-code .hljs-attr,
 .markdown-code .hljs-attribute,
 .markdown-code .hljs-property {
-  color: #7dd3fc;
+  color: #0369a1;
 }
 
 .markdown-code .hljs-string,
@@ -63,7 +63,7 @@ body {
 .markdown-code .hljs-meta .hljs-string,
 .markdown-code .hljs-template-tag,
 .markdown-code .hljs-template-variable {
-  color: #86efac;
+  color: #15803d;
 }
 
 .markdown-code .hljs-number,
@@ -72,7 +72,7 @@ body {
 .markdown-code .hljs-variable,
 .markdown-code .hljs-params,
 .markdown-code .hljs-built_in {
-  color: #fdba74;
+  color: #c2410c;
 }
 
 .markdown-code .hljs-meta,
@@ -81,11 +81,11 @@ body {
 .markdown-code .hljs-selector-id,
 .markdown-code .hljs-selector-attr,
 .markdown-code .hljs-selector-pseudo {
-  color: #c4b5fd;
+  color: #6d28d9;
 }
 
 .markdown-code .hljs-link {
-  color: #93c5fd;
+  color: #2563eb;
   text-decoration: underline;
 }
 

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -28,3 +28,71 @@ body {
     "Segoe UI", Roboto, Helvetica, Arial, "Apple Color Emoji",
     "Segoe UI Emoji";
 }
+
+.markdown-code .hljs {
+  background: transparent;
+  color: #f8fafc;
+}
+
+.markdown-code .hljs-comment,
+.markdown-code .hljs-quote {
+  color: #94a3b8;
+  font-style: italic;
+}
+
+.markdown-code .hljs-keyword,
+.markdown-code .hljs-selector-tag,
+.markdown-code .hljs-section,
+.markdown-code .hljs-type,
+.markdown-code .hljs-literal {
+  color: #f472b6;
+}
+
+.markdown-code .hljs-title,
+.markdown-code .hljs-title.class_,
+.markdown-code .hljs-title.function_,
+.markdown-code .hljs-function .hljs-title,
+.markdown-code .hljs-attr,
+.markdown-code .hljs-attribute,
+.markdown-code .hljs-property {
+  color: #7dd3fc;
+}
+
+.markdown-code .hljs-string,
+.markdown-code .hljs-regexp,
+.markdown-code .hljs-meta .hljs-string,
+.markdown-code .hljs-template-tag,
+.markdown-code .hljs-template-variable {
+  color: #86efac;
+}
+
+.markdown-code .hljs-number,
+.markdown-code .hljs-symbol,
+.markdown-code .hljs-bullet,
+.markdown-code .hljs-variable,
+.markdown-code .hljs-params,
+.markdown-code .hljs-built_in {
+  color: #fdba74;
+}
+
+.markdown-code .hljs-meta,
+.markdown-code .hljs-doctag,
+.markdown-code .hljs-selector-class,
+.markdown-code .hljs-selector-id,
+.markdown-code .hljs-selector-attr,
+.markdown-code .hljs-selector-pseudo {
+  color: #c4b5fd;
+}
+
+.markdown-code .hljs-link {
+  color: #93c5fd;
+  text-decoration: underline;
+}
+
+.markdown-code .hljs-emphasis {
+  font-style: italic;
+}
+
+.markdown-code .hljs-strong {
+  font-weight: 700;
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@tanstack/react-query": "^5.96.1",
     "@tanstack/react-query-devtools": "^5.96.1",
     "axios": "^1.14.0",
+    "highlight.js": "^11.11.1",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       axios:
         specifier: ^1.14.0
         version: 1.14.0
+      highlight.js:
+        specifier: ^11.11.1
+        version: 11.11.1
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1246,6 +1249,10 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -3310,6 +3317,8 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  highlight.js@11.11.1: {}
 
   ignore@5.3.2: {}
 

--- a/frontend/src/01_widgets/post/ui/PostArticle.tsx
+++ b/frontend/src/01_widgets/post/ui/PostArticle.tsx
@@ -4,86 +4,12 @@ import type { ReactNode } from "react";
 import type { Contributor, Post } from "@/entities/post/model";
 import { PostTabs } from "./PostTabs";
 
-const defaultBody = (
-  <div className="mt-8 space-y-6 text-[14px] leading-[1.65] text-zinc-700">
-    <h2 className="text-[22px] font-semibold tracking-tight text-zinc-950">
-      Understanding React Server Components
-    </h2>
-
-    <p>
-      React Server Components (RSC) represent a paradigm shift in how we think
-      about building React applications. Traditionally, React components have
-      run primarily on the client-side, with optional server-side rendering
-      (SSR) for initial load performance.
-    </p>
-
-    <h3 className="text-[18px] font-semibold tracking-tight text-zinc-950">
-      The Problem with Client-Only Rendering
-    </h3>
-
-    <p>
-      In a typical client-side rendered (CSR) app, the user downloads a large
-      JavaScript bundle. The browser parses and executes this bundle, which then
-      fetches data from an API. Only after the data arrives can the user see the
-      content.
-    </p>
-
-    <h3 className="text-[18px] font-semibold tracking-tight text-zinc-950">
-      Enter Server Components
-    </h3>
-
-    <p>
-      Server Components allow us to render components exclusively on the server.
-      This means:
-    </p>
-
-    <ul className="list-disc space-y-2 pl-6">
-      <li>
-        <span className="font-semibold text-zinc-950">Zero Bundle Size</span>
-        {": "}The component&apos;s code is never sent to the client.
-      </li>
-      <li>
-        <span className="font-semibold text-zinc-950">
-          Direct Backend Access
-        </span>
-        {": "}Server Components can query the database directly.
-      </li>
-    </ul>
-
-    <p className="text-zinc-500">
-      [[React Architecture]] [[Performance Optimization]]
-    </p>
-
-    <p className="font-medium text-zinc-950">Code Example:</p>
-
-    <pre className="overflow-x-auto rounded-xl border border-zinc-200 bg-zinc-50 p-4 text-[12px] leading-5 text-zinc-900">
-      <code>{`// Note: This component runs on the server!
-import db from './db';
-
-async function NoteList({ userId }) {
-  const notes = await db.notes.getAll(userId);
-  return (
-    <ul>
-      {notes.map(note => (
-        <li key={note.id}>{note.title}</li>
-      ))}
-    </ul>
-  );
-}`}</code>
-    </pre>
-
-    <p className="text-[12px] text-zinc-500">
-      This creates a seamless blend of server capabilities with React&apos;s
-      component model.
-    </p>
-  </div>
-);
-
 export function PostArticle({
   post,
   contributors,
   backHref = "/",
   children,
+  authorHref,
   articleHref = "#",
   suggestsHref = "/contribute",
   suggestEditsHref = "/contribute",
@@ -94,6 +20,7 @@ export function PostArticle({
   contributors?: Contributor[];
   backHref?: string;
   children?: ReactNode;
+  authorHref?: string;
   articleHref?: string;
   suggestsHref?: string;
   suggestEditsHref?: string;
@@ -138,20 +65,45 @@ export function PostArticle({
           <header className="mt-8 space-y-5">
             <div className="flex items-start justify-between gap-4">
               <div className="flex items-center gap-4">
-                <div className="relative">
-                  <Image
-                    src={post.authorAvatarSrc}
-                    alt={`${post.authorName} avatar`}
-                    width={48}
-                    height={48}
-                    className="size-12 rounded-full border border-zinc-100 object-cover shadow-[0_1px_3px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.1)]"
-                  />
-                </div>
+                {authorHref ? (
+                  <Link
+                    href={authorHref}
+                    aria-label={`Open ${post.authorName} profile`}
+                    className="relative rounded-full transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
+                  >
+                    <Image
+                      src={post.authorAvatarSrc}
+                      alt={`${post.authorName} avatar`}
+                      width={48}
+                      height={48}
+                      className="size-12 rounded-full border border-zinc-100 object-cover shadow-[0_1px_3px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.1)]"
+                    />
+                  </Link>
+                ) : (
+                  <div className="relative">
+                    <Image
+                      src={post.authorAvatarSrc}
+                      alt={`${post.authorName} avatar`}
+                      width={48}
+                      height={48}
+                      className="size-12 rounded-full border border-zinc-100 object-cover shadow-[0_1px_3px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.1)]"
+                    />
+                  </div>
+                )}
 
                 <div className="min-w-0">
-                  <p className="truncate text-[16px] font-semibold tracking-tight text-zinc-950">
-                    {post.authorName}
-                  </p>
+                  {authorHref ? (
+                    <Link
+                      href={authorHref}
+                      className="truncate text-[16px] font-semibold tracking-tight text-zinc-950 transition hover:text-zinc-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
+                    >
+                      {post.authorName}
+                    </Link>
+                  ) : (
+                    <p className="truncate text-[16px] font-semibold tracking-tight text-zinc-950">
+                      {post.authorName}
+                    </p>
+                  )}
                   <p className="mt-0.5 flex items-center gap-2 text-sm text-zinc-500">
                     <span>{post.publishedAtLabel}</span>
                     <span className="text-zinc-300">·</span>
@@ -206,7 +158,7 @@ export function PostArticle({
             </div>
           </div>
 
-          {children ?? defaultBody}
+          {children}
 
           <div className="mt-10 flex justify-center lg:hidden">
             <MobileActionBar

--- a/frontend/src/01_widgets/post/ui/PostArticle.tsx
+++ b/frontend/src/01_widgets/post/ui/PostArticle.tsx
@@ -230,7 +230,7 @@ function PostActionRail({
   suggestEditsHref: string;
 }) {
   return (
-    <nav className="flex flex-col items-center gap-3 rounded-2xl border border-zinc-200 bg-white/80 px-2 py-3 shadow-sm backdrop-blur">
+    <nav className="-translate-y-[150px] flex flex-col items-center gap-3 rounded-2xl border border-zinc-200 bg-white/80 px-2 py-3 shadow-sm backdrop-blur">
       <button
         type="button"
         aria-label={`Like (${likes})`}
@@ -323,7 +323,7 @@ function PostCommentsSection({
     >
       <div className="flex flex-wrap items-center justify-between gap-3 border-b border-zinc-200 pb-5">
         <div>
-          <div className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.24em] text-zinc-400">
+          <div className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.10em] text-zinc-400">
             <IconMessageSquare className="size-3.5" />
             Comments
           </div>

--- a/frontend/src/01_widgets/post/ui/PostArticle.tsx
+++ b/frontend/src/01_widgets/post/ui/PostArticle.tsx
@@ -2,7 +2,11 @@ import Image from "next/image";
 import Link from "next/link";
 import type { ReactNode } from "react";
 import type { Contributor, Post } from "@/entities/post/model";
+import { DiscussionComposer } from "@/features/discussion-composer/ui";
+import { assets } from "@/shared/config/assets";
 import { PostTabs } from "./PostTabs";
+
+const COMMENTS_SECTION_ID = "post-comments";
 
 export function PostArticle({
   post,
@@ -10,6 +14,7 @@ export function PostArticle({
   backHref = "/",
   children,
   authorHref,
+  currentUserAvatarSrc,
   articleHref = "#",
   suggestsHref = "/contribute",
   suggestEditsHref = "/contribute",
@@ -21,6 +26,7 @@ export function PostArticle({
   backHref?: string;
   children?: ReactNode;
   authorHref?: string;
+  currentUserAvatarSrc?: string | null;
   articleHref?: string;
   suggestsHref?: string;
   suggestEditsHref?: string;
@@ -203,6 +209,11 @@ export function PostArticle({
               </div>
             </section>
           ) : null}
+
+          <PostCommentsSection
+            comments={post.comments}
+            currentUserAvatarSrc={currentUserAvatarSrc}
+          />
         </article>
       </div>
     </div>
@@ -231,14 +242,14 @@ function PostActionRail({
 
       <div className="h-px w-7 bg-zinc-200" aria-hidden="true" />
 
-      <button
-        type="button"
-        aria-label={`Comments (${comments})`}
+      <a
+        href={`#${COMMENTS_SECTION_ID}`}
+        aria-label={`Jump to comments (${comments})`}
         className="group flex w-full flex-col items-center gap-1 rounded-xl px-1 py-2 text-zinc-500 transition hover:bg-zinc-50 hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
       >
         <IconMessageSquare className="size-5 transition-transform group-hover:scale-[1.03]" />
         <span className="text-[12px] font-medium leading-none">{comments}</span>
-      </button>
+      </a>
 
       <div className="h-px w-7 bg-zinc-200" aria-hidden="true" />
 
@@ -274,13 +285,13 @@ function MobileActionBar({
           <span>{likes}</span>
         </button>
 
-        <button
-          type="button"
+        <a
+          href={`#${COMMENTS_SECTION_ID}`}
           className="inline-flex items-center gap-2 text-[16px] font-medium text-zinc-500 transition hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
         >
           <IconMessageSquare className="size-6" />
           <span>{comments}</span>
-        </button>
+        </a>
       </div>
 
       <span className="h-6 w-px bg-zinc-300" aria-hidden="true" />
@@ -293,6 +304,66 @@ function MobileActionBar({
         Suggests
       </Link>
     </div>
+  );
+}
+
+function PostCommentsSection({
+  comments,
+  currentUserAvatarSrc,
+}: {
+  comments: number;
+  currentUserAvatarSrc?: string | null;
+}) {
+  const resolvedAvatarSrc = currentUserAvatarSrc ?? assets.defaultAvatar;
+
+  return (
+    <section
+      id={COMMENTS_SECTION_ID}
+      className="mt-14 scroll-mt-24 rounded-[28px] border border-zinc-200 bg-[linear-gradient(180deg,#ffffff_0%,#fbfbfa_100%)] p-6 shadow-[0_22px_50px_rgba(24,24,27,0.06)] sm:p-7"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-zinc-200 pb-5">
+        <div>
+          <div className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.24em] text-zinc-400">
+            <IconMessageSquare className="size-3.5" />
+            Comments
+          </div>
+          <h2 className="mt-3 font-serif text-[28px] font-semibold tracking-tight text-zinc-950">
+            Join the thread
+          </h2>
+          <p className="mt-2 max-w-[58ch] text-sm leading-6 text-zinc-600">
+            Leave feedback, ask for clarification, or keep a focused discussion
+            attached to this article.
+          </p>
+        </div>
+        <span className="rounded-full border border-zinc-200 bg-white px-3 py-1 text-xs font-medium text-zinc-500 shadow-sm">
+          {comments} comments
+        </span>
+      </div>
+
+      {comments > 0 ? (
+        <div className="mt-5 rounded-2xl border border-dashed border-zinc-200 bg-zinc-50/80 px-4 py-4 text-sm leading-6 text-zinc-500">
+          Existing comment entries are not wired into this detail view yet. The
+          section is ready for comment-thread data and new replies.
+        </div>
+      ) : (
+        <div className="mt-5 rounded-2xl border border-dashed border-zinc-200 bg-zinc-50/80 px-4 py-4 text-sm leading-6 text-zinc-500">
+          No comments yet. Start the first thread for this article.
+        </div>
+      )}
+
+      <div className="mt-6 flex items-start gap-4">
+        <Image
+          src={resolvedAvatarSrc}
+          alt="Current user avatar"
+          width={40}
+          height={40}
+          className="mt-1 size-10 rounded-full border border-zinc-200 object-cover"
+        />
+        <div className="min-w-0 flex-1">
+          <DiscussionComposer />
+        </div>
+      </div>
+    </section>
   );
 }
 

--- a/frontend/src/04_shared/lib/markdown/highlightCode.ts
+++ b/frontend/src/04_shared/lib/markdown/highlightCode.ts
@@ -1,12 +1,22 @@
 import hljs from "highlight.js/lib/core";
 import bash from "highlight.js/lib/languages/bash";
+import c from "highlight.js/lib/languages/c";
+import cpp from "highlight.js/lib/languages/cpp";
+import csharp from "highlight.js/lib/languages/csharp";
 import css from "highlight.js/lib/languages/css";
+import go from "highlight.js/lib/languages/go";
 import javascript from "highlight.js/lib/languages/javascript";
+import java from "highlight.js/lib/languages/java";
 import json from "highlight.js/lib/languages/json";
+import kotlin from "highlight.js/lib/languages/kotlin";
 import markdown from "highlight.js/lib/languages/markdown";
+import php from "highlight.js/lib/languages/php";
 import plaintext from "highlight.js/lib/languages/plaintext";
 import python from "highlight.js/lib/languages/python";
+import ruby from "highlight.js/lib/languages/ruby";
+import rust from "highlight.js/lib/languages/rust";
 import sql from "highlight.js/lib/languages/sql";
+import swift from "highlight.js/lib/languages/swift";
 import typescript from "highlight.js/lib/languages/typescript";
 import xml from "highlight.js/lib/languages/xml";
 import yaml from "highlight.js/lib/languages/yaml";
@@ -18,13 +28,23 @@ type HighlightResult = {
 
 const SUPPORTED_LANGUAGES = [
   "bash",
+  "c",
+  "cpp",
+  "csharp",
   "css",
+  "go",
   "javascript",
+  "java",
   "json",
+  "kotlin",
   "markdown",
+  "php",
   "plaintext",
   "python",
+  "ruby",
+  "rust",
   "sql",
+  "swift",
   "typescript",
   "xml",
   "yaml",
@@ -32,23 +52,46 @@ const SUPPORTED_LANGUAGES = [
 
 const LANGUAGE_ALIASES: Record<string, (typeof SUPPORTED_LANGUAGES)[number]> = {
   bash: "bash",
+  c: "c",
+  "c#": "csharp",
+  "c++": "cpp",
+  cc: "cpp",
   cjs: "javascript",
+  cpp: "cpp",
+  cs: "csharp",
+  cxx: "cpp",
   css: "css",
+  go: "go",
+  golang: "go",
+  h: "c",
   html: "xml",
+  hpp: "cpp",
+  hxx: "cpp",
   javascript: "javascript",
+  java: "java",
   js: "javascript",
   json: "json",
   jsx: "javascript",
+  kt: "kotlin",
+  kts: "kotlin",
+  kotlin: "kotlin",
   markdown: "markdown",
   md: "markdown",
   plain: "plaintext",
   plaintext: "plaintext",
+  php: "php",
   py: "python",
   python: "python",
+  rb: "ruby",
+  rs: "rust",
+  ruby: "ruby",
+  rust: "rust",
+  rustm: "rust",
   sh: "bash",
   shell: "bash",
   sql: "sql",
   svg: "xml",
+  swift: "swift",
   ts: "typescript",
   tsx: "typescript",
   txt: "plaintext",
@@ -93,17 +136,38 @@ function ensureHighlightLanguages() {
   if (!hljs.getLanguage("bash")) {
     hljs.registerLanguage("bash", bash);
   }
+  if (!hljs.getLanguage("c")) {
+    hljs.registerLanguage("c", c);
+  }
+  if (!hljs.getLanguage("cpp")) {
+    hljs.registerLanguage("cpp", cpp);
+  }
+  if (!hljs.getLanguage("csharp")) {
+    hljs.registerLanguage("csharp", csharp);
+  }
   if (!hljs.getLanguage("css")) {
     hljs.registerLanguage("css", css);
+  }
+  if (!hljs.getLanguage("go")) {
+    hljs.registerLanguage("go", go);
   }
   if (!hljs.getLanguage("javascript")) {
     hljs.registerLanguage("javascript", javascript);
   }
+  if (!hljs.getLanguage("java")) {
+    hljs.registerLanguage("java", java);
+  }
   if (!hljs.getLanguage("json")) {
     hljs.registerLanguage("json", json);
   }
+  if (!hljs.getLanguage("kotlin")) {
+    hljs.registerLanguage("kotlin", kotlin);
+  }
   if (!hljs.getLanguage("markdown")) {
     hljs.registerLanguage("markdown", markdown);
+  }
+  if (!hljs.getLanguage("php")) {
+    hljs.registerLanguage("php", php);
   }
   if (!hljs.getLanguage("plaintext")) {
     hljs.registerLanguage("plaintext", plaintext);
@@ -111,8 +175,17 @@ function ensureHighlightLanguages() {
   if (!hljs.getLanguage("python")) {
     hljs.registerLanguage("python", python);
   }
+  if (!hljs.getLanguage("ruby")) {
+    hljs.registerLanguage("ruby", ruby);
+  }
+  if (!hljs.getLanguage("rust")) {
+    hljs.registerLanguage("rust", rust);
+  }
   if (!hljs.getLanguage("sql")) {
     hljs.registerLanguage("sql", sql);
+  }
+  if (!hljs.getLanguage("swift")) {
+    hljs.registerLanguage("swift", swift);
   }
   if (!hljs.getLanguage("typescript")) {
     hljs.registerLanguage("typescript", typescript);

--- a/frontend/src/04_shared/lib/markdown/highlightCode.ts
+++ b/frontend/src/04_shared/lib/markdown/highlightCode.ts
@@ -1,0 +1,146 @@
+import hljs from "highlight.js/lib/core";
+import bash from "highlight.js/lib/languages/bash";
+import css from "highlight.js/lib/languages/css";
+import javascript from "highlight.js/lib/languages/javascript";
+import json from "highlight.js/lib/languages/json";
+import markdown from "highlight.js/lib/languages/markdown";
+import plaintext from "highlight.js/lib/languages/plaintext";
+import python from "highlight.js/lib/languages/python";
+import sql from "highlight.js/lib/languages/sql";
+import typescript from "highlight.js/lib/languages/typescript";
+import xml from "highlight.js/lib/languages/xml";
+import yaml from "highlight.js/lib/languages/yaml";
+
+type HighlightResult = {
+  html: string;
+  languageLabel: string;
+};
+
+const SUPPORTED_LANGUAGES = [
+  "bash",
+  "css",
+  "javascript",
+  "json",
+  "markdown",
+  "plaintext",
+  "python",
+  "sql",
+  "typescript",
+  "xml",
+  "yaml",
+] as const;
+
+const LANGUAGE_ALIASES: Record<string, (typeof SUPPORTED_LANGUAGES)[number]> = {
+  bash: "bash",
+  cjs: "javascript",
+  css: "css",
+  html: "xml",
+  javascript: "javascript",
+  js: "javascript",
+  json: "json",
+  jsx: "javascript",
+  markdown: "markdown",
+  md: "markdown",
+  plain: "plaintext",
+  plaintext: "plaintext",
+  py: "python",
+  python: "python",
+  sh: "bash",
+  shell: "bash",
+  sql: "sql",
+  svg: "xml",
+  ts: "typescript",
+  tsx: "typescript",
+  txt: "plaintext",
+  typescript: "typescript",
+  xml: "xml",
+  yaml: "yaml",
+  yml: "yaml",
+  zsh: "bash",
+};
+
+let isConfigured = false;
+
+export function highlightCodeBlock(
+  code: string,
+  language: string,
+): HighlightResult {
+  ensureHighlightLanguages();
+
+  const preferredLanguage = normalizeLanguage(language);
+  if (preferredLanguage) {
+    return {
+      html: hljs.highlight(code, {
+        ignoreIllegals: true,
+        language: preferredLanguage,
+      }).value,
+      languageLabel: language.trim() || preferredLanguage,
+    };
+  }
+
+  const autoDetected = hljs.highlightAuto(code, [...SUPPORTED_LANGUAGES]);
+  return {
+    html: autoDetected.value || escapeHtml(code),
+    languageLabel: autoDetected.language ?? "code",
+  };
+}
+
+function ensureHighlightLanguages() {
+  if (isConfigured) {
+    return;
+  }
+
+  if (!hljs.getLanguage("bash")) {
+    hljs.registerLanguage("bash", bash);
+  }
+  if (!hljs.getLanguage("css")) {
+    hljs.registerLanguage("css", css);
+  }
+  if (!hljs.getLanguage("javascript")) {
+    hljs.registerLanguage("javascript", javascript);
+  }
+  if (!hljs.getLanguage("json")) {
+    hljs.registerLanguage("json", json);
+  }
+  if (!hljs.getLanguage("markdown")) {
+    hljs.registerLanguage("markdown", markdown);
+  }
+  if (!hljs.getLanguage("plaintext")) {
+    hljs.registerLanguage("plaintext", plaintext);
+  }
+  if (!hljs.getLanguage("python")) {
+    hljs.registerLanguage("python", python);
+  }
+  if (!hljs.getLanguage("sql")) {
+    hljs.registerLanguage("sql", sql);
+  }
+  if (!hljs.getLanguage("typescript")) {
+    hljs.registerLanguage("typescript", typescript);
+  }
+  if (!hljs.getLanguage("xml")) {
+    hljs.registerLanguage("xml", xml);
+  }
+  if (!hljs.getLanguage("yaml")) {
+    hljs.registerLanguage("yaml", yaml);
+  }
+
+  isConfigured = true;
+}
+
+function normalizeLanguage(language: string) {
+  const normalized = language.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+
+  return LANGUAGE_ALIASES[normalized] ?? null;
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}

--- a/frontend/src/04_shared/ui/markdown/MarkdownCodeBlock.tsx
+++ b/frontend/src/04_shared/ui/markdown/MarkdownCodeBlock.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { cn } from "@/shared/lib/cn";
+
+type CopyState = "idle" | "copied" | "error";
+
+export function MarkdownCodeBlock({
+  code,
+  highlightedHtml,
+  languageLabel,
+  variant,
+}: {
+  code: string;
+  highlightedHtml: string;
+  languageLabel: string;
+  variant: "default" | "compact";
+}) {
+  const [copyState, setCopyState] = useState<CopyState>("idle");
+
+  useEffect(() => {
+    if (copyState === "idle") {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setCopyState("idle");
+    }, 1800);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [copyState]);
+
+  async function handleCopy() {
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(code);
+      } else {
+        copyWithSelectionFallback(code);
+      }
+
+      setCopyState("copied");
+    } catch {
+      setCopyState("error");
+    }
+  }
+
+  const isCopied = copyState === "copied";
+
+  return (
+    <div className="markdown-code overflow-hidden rounded-xl border border-zinc-200 bg-zinc-950 text-zinc-100 shadow-[0_20px_50px_rgba(9,9,11,0.18)]">
+      <div className="flex items-center justify-between gap-2 border-b border-white/10 px-4 py-1.5">
+        <span className="truncate text-[10px] uppercase tracking-[0.18em] text-zinc-400">
+          {languageLabel}
+        </span>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className={cn(
+            "inline-flex size-7 shrink-0 items-center justify-center rounded-md border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60",
+            isCopied
+              ? "border-emerald-400/40 bg-emerald-400/12 text-emerald-200"
+              : copyState === "error"
+                ? "border-rose-400/40 bg-rose-400/12 text-rose-200 hover:border-rose-300/60 hover:bg-rose-400/16"
+                : "border-white/12 bg-white/5 text-zinc-300 hover:border-sky-300/30 hover:bg-sky-400/10 hover:text-sky-100",
+          )}
+          aria-label={getCopyAriaLabel(copyState, languageLabel)}
+          title={getCopyTooltip(copyState)}
+        >
+          <CopyIcon copied={isCopied} />
+        </button>
+      </div>
+      <pre
+        className={cn(
+          "overflow-x-auto p-4 font-mono",
+          variant === "default" ? "text-[13px] leading-6" : "text-xs leading-5",
+        )}
+      >
+        <code
+          className="hljs block bg-transparent p-0"
+          dangerouslySetInnerHTML={{ __html: highlightedHtml }}
+        />
+      </pre>
+    </div>
+  );
+}
+
+function getCopyLabel(copyState: CopyState) {
+  switch (copyState) {
+    case "copied":
+      return "Copied";
+    case "error":
+      return "Retry";
+    default:
+      return "Copy";
+  }
+}
+
+function getCopyAriaLabel(copyState: CopyState, languageLabel: string) {
+  return `${languageLabel} code ${getCopyLabel(copyState).toLowerCase()}`;
+}
+
+function getCopyTooltip(copyState: CopyState) {
+  return getCopyLabel(copyState);
+}
+
+function copyWithSelectionFallback(code: string) {
+  const textarea = document.createElement("textarea");
+  textarea.value = code;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "absolute";
+  textarea.style.opacity = "0";
+  textarea.style.pointerEvents = "none";
+  document.body.appendChild(textarea);
+  textarea.select();
+  textarea.setSelectionRange(0, textarea.value.length);
+
+  const didCopy = document.execCommand("copy");
+  document.body.removeChild(textarea);
+
+  if (!didCopy) {
+    throw new Error("copy failed");
+  }
+}
+
+function CopyIcon({ copied }: { copied: boolean }) {
+  if (copied) {
+    return (
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 16 16"
+        className="size-3"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.7"
+      >
+        <path
+          d="M3.75 8.25 6.5 11l5.75-6.25"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    );
+  }
+
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      className="size-3"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+    >
+      <rect x="5.25" y="2.75" width="7" height="9" rx="1.5" />
+      <path
+        d="M3.75 5.25V12a1.5 1.5 0 0 0 1.5 1.5H10.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/frontend/src/04_shared/ui/markdown/MarkdownCodeBlock.tsx
+++ b/frontend/src/04_shared/ui/markdown/MarkdownCodeBlock.tsx
@@ -49,21 +49,21 @@ export function MarkdownCodeBlock({
   const isCopied = copyState === "copied";
 
   return (
-    <div className="markdown-code overflow-hidden rounded-xl border border-zinc-200 bg-zinc-950 text-zinc-100 shadow-[0_20px_50px_rgba(9,9,11,0.18)]">
-      <div className="flex items-center justify-between gap-2 border-b border-white/10 px-4 py-1.5">
-        <span className="truncate text-[10px] uppercase tracking-[0.18em] text-zinc-400">
+    <div className="markdown-code overflow-hidden rounded-xl border border-zinc-200 bg-[linear-gradient(180deg,#fdfdfc_0%,#fafaf8_100%)] text-zinc-900 shadow-[0_20px_50px_rgba(113,113,122,0.14)]">
+      <div className="flex items-center justify-between gap-2 border-b border-zinc-200/90 bg-[rgba(244,244,245,0.75)] px-4 py-1.5 backdrop-blur-sm">
+        <span className="truncate text-[10px] uppercase tracking-[0.18em] text-zinc-500">
           {languageLabel}
         </span>
         <button
           type="button"
           onClick={handleCopy}
           className={cn(
-            "inline-flex size-7 shrink-0 items-center justify-center rounded-md border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60",
+            "inline-flex size-7 shrink-0 items-center justify-center rounded-md border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/40",
             isCopied
-              ? "border-emerald-400/40 bg-emerald-400/12 text-emerald-200"
+              ? "border-emerald-300 bg-emerald-50 text-emerald-700"
               : copyState === "error"
-                ? "border-rose-400/40 bg-rose-400/12 text-rose-200 hover:border-rose-300/60 hover:bg-rose-400/16"
-                : "border-white/12 bg-white/5 text-zinc-300 hover:border-sky-300/30 hover:bg-sky-400/10 hover:text-sky-100",
+                ? "border-rose-300 bg-rose-50 text-rose-700 hover:border-rose-400 hover:bg-rose-100"
+                : "border-zinc-200 bg-white/90 text-zinc-500 hover:border-sky-300 hover:bg-sky-50 hover:text-sky-700",
           )}
           aria-label={getCopyAriaLabel(copyState, languageLabel)}
           title={getCopyTooltip(copyState)}

--- a/frontend/src/04_shared/ui/markdown/MarkdownContent.tsx
+++ b/frontend/src/04_shared/ui/markdown/MarkdownContent.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { cn } from "@/shared/lib/cn";
+import { highlightCodeBlock } from "@/shared/lib/markdown/highlightCode";
 
 type MarkdownBlock =
   | { type: "heading"; level: 1 | 2 | 3; text: string }
@@ -103,14 +104,15 @@ export function MarkdownContent({
                 ))}
               </ol>
             );
-          case "code":
+          case "code": {
+            const highlighted = highlightCodeBlock(block.code, block.language);
             return (
               <div
                 key={key}
-                className="overflow-hidden rounded-2xl border border-zinc-200 bg-zinc-950 text-zinc-100"
+                className="markdown-code overflow-hidden rounded-2xl border border-zinc-200 bg-zinc-950 text-zinc-100 shadow-[0_20px_50px_rgba(9,9,11,0.18)]"
               >
                 <div className="border-b border-white/10 px-4 py-2 text-[11px] uppercase tracking-[0.22em] text-zinc-400">
-                  {block.language || "code"}
+                  {highlighted.languageLabel}
                 </div>
                 <pre
                   className={cn(
@@ -118,10 +120,14 @@ export function MarkdownContent({
                     variant === "default" ? "text-[13px] leading-6" : "text-xs leading-5",
                   )}
                 >
-                  <code>{block.code}</code>
+                  <code
+                    className="hljs block bg-transparent p-0"
+                    dangerouslySetInnerHTML={{ __html: highlighted.html }}
+                  />
                 </pre>
               </div>
             );
+          }
         }
       })}
     </div>

--- a/frontend/src/04_shared/ui/markdown/MarkdownContent.tsx
+++ b/frontend/src/04_shared/ui/markdown/MarkdownContent.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { cn } from "@/shared/lib/cn";
 import { highlightCodeBlock } from "@/shared/lib/markdown/highlightCode";
+import { MarkdownCodeBlock } from "./MarkdownCodeBlock";
 
 type MarkdownBlock =
   | { type: "heading"; level: 1 | 2 | 3; text: string }
@@ -107,25 +108,13 @@ export function MarkdownContent({
           case "code": {
             const highlighted = highlightCodeBlock(block.code, block.language);
             return (
-              <div
+              <MarkdownCodeBlock
                 key={key}
-                className="markdown-code overflow-hidden rounded-2xl border border-zinc-200 bg-zinc-950 text-zinc-100 shadow-[0_20px_50px_rgba(9,9,11,0.18)]"
-              >
-                <div className="border-b border-white/10 px-4 py-2 text-[11px] uppercase tracking-[0.22em] text-zinc-400">
-                  {highlighted.languageLabel}
-                </div>
-                <pre
-                  className={cn(
-                    "overflow-x-auto p-4 font-mono",
-                    variant === "default" ? "text-[13px] leading-6" : "text-xs leading-5",
-                  )}
-                >
-                  <code
-                    className="hljs block bg-transparent p-0"
-                    dangerouslySetInnerHTML={{ __html: highlighted.html }}
-                  />
-                </pre>
-              </div>
+                code={block.code}
+                highlightedHtml={highlighted.html}
+                languageLabel={highlighted.languageLabel}
+                variant={variant}
+              />
             );
           }
         }


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #

---

## 1. PR 유형
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ✨ 새로운 기능 (New Feature)
- [ ] ♻️ 리팩토링 (Refactoring)
- [x] 📝 문서 업데이트 (Documentation)
- [ ] ⚙️ 설정/빌드 변경 (Chore)

---

## 2. 작업 배경 및 목적
- **기존 상태:** `frontend/src/04_shared/ui/markdown/MarkdownContent.tsx`는 fenced code block을 단순 `<pre><code>`로만 렌더링해 언어별 하이라이팅과 복사 UI가 없었고, 글 상세 위젯 `frontend/src/01_widgets/post/ui/PostArticle.tsx`는 작성자 아바타/이름을 프로필 링크와 연결하지 않았습니다. 또한 상세페이지 액션 레일의 댓글 버튼은 실제 댓글 섹션으로 이동하지 않았고, API 상세 경로 `frontend/app/[username]/posts/[postSlug]/page.tsx`는 `showSuggestsTab={false}`를 고정해 `Suggests` 탭을 숨기고 있었습니다.
- **문제점:** 코드가 포함된 게시글은 토큰 구분 없이 평문 블록으로 출력되어 가독성과 복사 효율이 떨어졌고, 상세페이지에서 작성자 프로필 이동과 댓글 진입 경로가 분리되어 상호작용이 단절되었습니다. 동시에 `Suggests` 목록 라우트가 존재해도 API 상세 경로에서 탭이 노출되지 않아 사용자가 수정 제안 영역의 존재 자체를 발견하기 어려웠습니다.
- **해결 목표:** 마크다운 코드 블록을 언어 인식 기반의 라이트 테마 하이라이트 UI로 승격하고, 상세페이지에서는 작성자 프로필 이동, 댓글 섹션 진입, 제안 탭 노출을 한 흐름으로 연결해 게시글 읽기 화면에서 후속 행동으로 자연스럽게 이동할 수 있게 만듭니다.

---

## 3. 상세 변경 내역 및 동작 흐름

### A. 마크다운 fenced code block을 Highlight.js 기반 코드 렌더링 파이프라인으로 치환
- **진입점 및 초기 조건:** `frontend/src/04_shared/ui/markdown/MarkdownContent.tsx`의 `MarkdownContent({ markdown })`가 진입점이며, `parseMarkdown()`이 ``` fence를 만나면 `{ type: "code", language, code }` 블록을 생성합니다. 기존 구현은 이 블록을 그대로 `<pre><code>{block.code}</code></pre>`에 넣어 다크 배경의 평문으로 출력했습니다.

```tsx
case "code": {
  const highlighted = highlightCodeBlock(block.code, block.language);
  return (
    <MarkdownCodeBlock
      key={key}
      code={block.code}
      highlightedHtml={highlighted.html}
      languageLabel={highlighted.languageLabel}
      variant={variant}
    />
  );
}
```

- **단계별 제어 흐름:**
  1. `parseMarkdown()`이 fenced code block의 언어 라벨과 본문 문자열을 분리해 `MarkdownBlock` 배열에 적재합니다.
  2. `MarkdownContent`의 `case "code"` 분기가 `highlightCodeBlock(block.code, block.language)`를 호출합니다.
  3. `frontend/src/04_shared/lib/markdown/highlightCode.ts`가 `highlight.js/lib/core`에 지원 언어를 한 번만 등록하고, alias(`ts`, `tsx`, `zsh`, `c++` 등)를 canonical language로 정규화합니다.
  4. 언어 라벨이 유효하면 `hljs.highlight()`를, 없으면 `hljs.highlightAuto()`를 실행해 HTML 토큰 문자열과 표시용 언어 라벨을 반환합니다.
  5. `frontend/src/04_shared/ui/markdown/MarkdownCodeBlock.tsx`가 반환된 HTML을 `<code dangerouslySetInnerHTML>`로 렌더링하고, 복사 버튼 클릭 시 Clipboard API 또는 selection fallback으로 원문 코드를 복사합니다.
  6. `frontend/app/globals.css`의 `.markdown-code .hljs-*` 규칙이 토큰별 색상을 적용해 라이트 테마 코드 블록을 완성합니다.
- **데이터 상태 변이:** 원본 markdown 문자열은 `MarkdownBlock[]`로 구조화되고, 코드 블록 본문은 `highlightCodeBlock()`을 거치며 `highlightedHtml + languageLabel` 조합으로 변환됩니다. 클라이언트에서는 `MarkdownCodeBlock`의 `copyState`가 `idle -> copied/error -> idle`로 전이되며 복사 버튼 상태와 tooltip 문구를 제어합니다.
- **최종 반환 및 종료 상태:** 상세 본문에 포함된 fenced code block은 지원 언어 기준으로 하이라이트된 HTML 코드 블록으로 렌더링되고, 사용자는 라이트 테마 토큰 색상과 복사 버튼이 포함된 UI를 통해 코드를 바로 읽고 복사할 수 있습니다.

### B. 상세페이지 라우트가 작성자 프로필, 댓글 섹션, Suggests 탭을 하나의 상호작용 흐름으로 연결
- **진입점 및 초기 조건:** `frontend/app/[username]/posts/[postSlug]/page.tsx`의 `PublicPostPage()`가 `getUser()`와 `getPostDetail()` 결과를 조합해 상세페이지 props를 구성합니다. 변경 전에는 `PostArticle`에 `authorHref`와 `currentUserAvatarSrc`를 전달하지 않았고, `showSuggestsTab={false}`를 명시해 API 상세 경로에서는 `Suggests` 탭을 숨겼습니다. 또한 `PostArticle` 내부에는 하드코딩된 fallback body가 존재해 상세 라우트 외 문맥에서도 샘플 본문이 섞일 수 있었습니다.

```tsx
<PostArticle
  post={...}
  authorHref={authorHref}
  currentUserAvatarSrc={viewer?.profileImageUrl}
  articleHref={articleHref}
  suggestsHref={suggestsHref}
  suggestEditsHref="/contribute"
  suggestCount={0}
>
  <div className="mt-8 space-y-6 text-[16px] leading-8 text-zinc-700">
    <MarkdownContent markdown={detail.content} />
  </div>
</PostArticle>
```

- **단계별 제어 흐름:**
  1. `PublicPostPage()`가 `buildPublicProfilePath(detail.authorUsername)`와 `buildPublicSuggestsPath(...)`를 계산한 뒤 `authorHref`, `currentUserAvatarSrc`, `suggestsHref`를 `PostArticle`에 전달합니다.
  2. `PostArticle`는 `authorHref` 존재 여부를 검사해 작성자 아바타와 이름을 `next/link`로 감싸고, `children`만 본문으로 사용하도록 바꿔 샘플 fallback body를 제거합니다.
  3. 데스크톱 `PostActionRail`과 모바일 `MobileActionBar`의 댓글 버튼은 `button`에서 `href="#post-comments"` anchor로 바뀌어 클릭 시 상세페이지 하단 댓글 섹션으로 스크롤 이동합니다.
  4. 새 `PostCommentsSection`이 `comments` 수와 `currentUserAvatarSrc`를 받아 댓글 개수 badge, 현재 연결 상태 placeholder, `DiscussionComposer` 입력 UI를 렌더링합니다.
  5. 액션 레일 컨테이너는 `-translate-y-[150px]`를 적용해 sticky 위치를 상향 조정하고, 동일 화면 안에서 댓글 진입 버튼이 더 이른 시점에 노출되도록 정렬합니다.
  6. 상세 라우트에서 `showSuggestsTab={false}`를 제거해 `PostTabs` 기본값(`true`)이 적용되도록 만들어 `Suggests` 탭을 다시 노출합니다.
- **데이터 상태 변이:** 라우트 단계에서 계산한 `authorHref`, `currentUserAvatarSrc`, `suggestsHref`는 `PostArticle` props로 주입되고, 위젯 내부에서는 이 값들이 각각 프로필 링크 target, 댓글 작성자 아바타, 탭 링크 href로 재배치됩니다. `comments` 정수는 댓글 섹션 badge와 placeholder 메시지 분기(`comments > 0`)에 사용되고, `showSuggestsTab`의 강제 `false` 값이 제거되면서 탭 가시 상태가 `hidden -> visible`로 전환됩니다.
- **최종 반환 및 종료 상태:** 게시글 상세페이지에서 작성자 이름/아바타 클릭 시 공개 프로필로 이동할 수 있고, 댓글 액션은 하단 `#post-comments` 섹션과 연결되며, API 상세 경로에서도 `Suggests` 탭이 노출됩니다. 댓글 목록 데이터는 아직 연결되지 않았지만 댓글 작성 UI와 진입 경로는 상세페이지 안에 준비된 상태로 남습니다.

---

## 4. 스크린샷 (선택)
- 없음

## 5. 테스트 및 검증 방법
- **테스트 환경:** macOS 로컬 환경에서 `frontend/`의 Next.js 16.1.6 + React 19 앱을 기준으로 `npm` 스크립트를 실행했습니다. 검증 범위는 정적 분석과 production build 성공 여부입니다.
- **입력 시나리오:**
  1. `cd frontend && npm run lint`
  2. `cd frontend && npm run build`
- **출력 검증:** `npm run lint`는 exit code 0으로 종료됐고, `frontend/src/01_widgets/onboarding/ui/OnboardingView.tsx`의 미사용 import warning 1건과 `frontend/src/01_widgets/write/ui/WriteView.tsx`의 `useEffectEvent` dependency warning 1건만 보고되었습니다. 두 warning 모두 이번 PR에서 변경한 파일과 무관합니다. `npm run build`는 성공했고 결과 라우트에 `/[username]/posts/[postSlug]`, `/[username]/posts/[postSlug]/suggests`, `/[username]/posts/[postSlug]/suggests/[suggestId]`가 정상 생성되어, 코드블럭 렌더링 변경과 상세페이지 상호작용 변경이 Next.js 빌드 파이프라인에 정상 편입됐음을 확인했습니다.

---

## 6. 리뷰어 참고 사항 (선택)
- **특이 구현 사항:** 코드 하이라이트는 `MarkdownCodeBlock`에서 `dangerouslySetInnerHTML`로 출력하지만, HTML 소스는 사용자 입력 원문이 아니라 `highlightCodeBlock()`이 `highlight.js`로 생성한 문자열만 사용합니다. 또한 상세 댓글 섹션은 `DiscussionComposer`와 진입 anchor만 먼저 연결했고, 기존 댓글 스레드 데이터 바인딩은 placeholder 메시지로 남겨 두었습니다.
- **파급 효과:** `Suggests` 탭은 이제 API 상세 경로에서도 보이지만 `suggestCount`는 아직 `0` 고정이며 실제 suggestion 목록 데이터는 별도 API 연동이 필요합니다. 댓글 섹션도 작성 UI와 개수 badge는 동작하지만, 저장/목록 조회가 붙지 않은 상태이므로 후속 PR에서 discussion 데이터 소스를 연결해야 합니다.

---

## 7. 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일 가이드를 준수합니다.
- [ ] 변경 사항에 대한 테스트 코드를 작성하거나 통과했습니다.
- [ ] 관련된 문서(README, API 명세 등)를 업데이트했습니다.
