### PR TITLE
[Feat] 프로필 수정

### DIFF
--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/comment/entity/Comment.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/comment/entity/Comment.kt
@@ -48,6 +48,9 @@ class Comment (
         protected set
 
     fun updateComment(content: String) {
+        if (this.content == content){
+            return
+        }
         this.content = content
         this.updatedAt = LocalDateTime.now()
     }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserController.kt
@@ -1,11 +1,18 @@
 package io.github.kitae9999.openlog.user
 
 import io.github.kitae9999.openlog.post.dto.PostDetailResponse
+import io.github.kitae9999.openlog.post.entity.Post
+import io.github.kitae9999.openlog.post.estimateReadTimeLabel
+import io.github.kitae9999.openlog.post.formatPublishedAtLabel
 import io.github.kitae9999.openlog.user.dto.PublicUserPostSummaryResponse
 import io.github.kitae9999.openlog.user.dto.PublicUserProfileResponse
+import io.github.kitae9999.openlog.user.dto.UpdateProfileRequest
+import io.github.kitae9999.openlog.user.entity.User
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -18,7 +25,7 @@ class UserController(
     fun getPublicProfile(
         @PathVariable username: String,
     ): PublicUserProfileResponse {
-        return userService.getPublicProfile(username)
+        return userService.getPublicProfile(username).toPublicUserProfileResponse()
     }
 
     @GetMapping("{username}/posts")
@@ -26,6 +33,7 @@ class UserController(
         @PathVariable username: String,
     ): List<PublicUserPostSummaryResponse> {
         return userService.getPublicPosts(username)
+            .map { it.toPublicUserPostSummaryResponse() }
     }
 
     @GetMapping("{username}/posts/{titleSlug}")
@@ -33,13 +41,58 @@ class UserController(
         @PathVariable username: String,
         @PathVariable titleSlug: String,
     ): PostDetailResponse {
-        return userService.getPublicPostDetail(username, titleSlug)
+        return userService.getPublicPostDetail(username, titleSlug).toPostDetailResponse()
     }
 
-//    @PatchMapping("{username}")
-//    fun updateProfile(
-//        @PathVariable username: String,
-//    ){
-//
-//    }
+    @PatchMapping("{username}")
+    fun updateProfile(
+        @PathVariable username: String,
+        @Valid @RequestBody request: UpdateProfileRequest,
+    ): PublicUserProfileResponse {
+        return userService.updateProfile(
+            username = username,
+            nickname = request.nickname,
+            bio = request.bio,
+            location = request.location,
+            websiteUrl = request.websiteUrl,
+        ).toPublicUserProfileResponse()
+    }
+
+    private fun User.toPublicUserProfileResponse(): PublicUserProfileResponse {
+        return PublicUserProfileResponse(
+            username = requireNotNull(username),
+            nickname = nickname,
+            profileImageUrl = profileImageUrl,
+            bio = bio,
+            location = location,
+            websiteUrl = websiteUrl,
+            joinedAt = createdAt.toString(),
+        )
+    }
+
+    private fun Post.toPublicUserPostSummaryResponse(): PublicUserPostSummaryResponse {
+        return PublicUserPostSummaryResponse(
+            slug = slug,
+            title = title,
+            description = description,
+            publishedAtLabel = formatPublishedAtLabel(this),
+            readTimeLabel = estimateReadTimeLabel(this),
+        )
+    }
+
+    private fun PublicPostDetail.toPostDetailResponse(): PostDetailResponse {
+        return PostDetailResponse(
+            id = requireNotNull(post.id),
+            slug = post.slug,
+            title = post.title,
+            description = post.description,
+            content = post.content,
+            authorUsername = authorUsername,
+            authorName = authorName,
+            authorAvatarSrc = authorAvatarSrc,
+            publishedAtLabel = formatPublishedAtLabel(post),
+            readTimeLabel = estimateReadTimeLabel(post),
+            topics = topics,
+        )
+    }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserController.kt
@@ -4,6 +4,7 @@ import io.github.kitae9999.openlog.post.dto.PostDetailResponse
 import io.github.kitae9999.openlog.user.dto.PublicUserPostSummaryResponse
 import io.github.kitae9999.openlog.user.dto.PublicUserProfileResponse
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -34,4 +35,11 @@ class UserController(
     ): PostDetailResponse {
         return userService.getPublicPostDetail(username, titleSlug)
     }
+
+//    @PatchMapping("{username}")
+//    fun updateProfile(
+//        @PathVariable username: String,
+//    ){
+//
+//    }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserController.kt
@@ -1,13 +1,11 @@
 package io.github.kitae9999.openlog.user
 
+import io.github.kitae9999.openlog.auth.CurrentUserResolver
 import io.github.kitae9999.openlog.post.dto.PostDetailResponse
-import io.github.kitae9999.openlog.post.entity.Post
-import io.github.kitae9999.openlog.post.estimateReadTimeLabel
-import io.github.kitae9999.openlog.post.formatPublishedAtLabel
 import io.github.kitae9999.openlog.user.dto.PublicUserPostSummaryResponse
 import io.github.kitae9999.openlog.user.dto.PublicUserProfileResponse
 import io.github.kitae9999.openlog.user.dto.UpdateProfileRequest
-import io.github.kitae9999.openlog.user.entity.User
+import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -20,12 +18,13 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("users")
 class UserController(
     private val userService: UserService,
+    private val currentUserResolver: CurrentUserResolver,
 ) {
     @GetMapping("{username}")
     fun getPublicProfile(
         @PathVariable username: String,
     ): PublicUserProfileResponse {
-        return userService.getPublicProfile(username).toPublicUserProfileResponse()
+        return userService.getPublicProfile(username)
     }
 
     @GetMapping("{username}/posts")
@@ -33,7 +32,6 @@ class UserController(
         @PathVariable username: String,
     ): List<PublicUserPostSummaryResponse> {
         return userService.getPublicPosts(username)
-            .map { it.toPublicUserPostSummaryResponse() }
     }
 
     @GetMapping("{username}/posts/{titleSlug}")
@@ -41,58 +39,24 @@ class UserController(
         @PathVariable username: String,
         @PathVariable titleSlug: String,
     ): PostDetailResponse {
-        return userService.getPublicPostDetail(username, titleSlug).toPostDetailResponse()
+        return userService.getPublicPostDetail(username, titleSlug)
     }
 
     @PatchMapping("{username}")
     fun updateProfile(
         @PathVariable username: String,
         @Valid @RequestBody request: UpdateProfileRequest,
+        httpRequest: HttpServletRequest,
     ): PublicUserProfileResponse {
+        val currentUserId = currentUserResolver.resolveUserId(httpRequest)
+
         return userService.updateProfile(
+            userId = currentUserId,
             username = username,
             nickname = request.nickname,
             bio = request.bio,
             location = request.location,
             websiteUrl = request.websiteUrl,
-        ).toPublicUserProfileResponse()
-    }
-
-    private fun User.toPublicUserProfileResponse(): PublicUserProfileResponse {
-        return PublicUserProfileResponse(
-            username = requireNotNull(username),
-            nickname = nickname,
-            profileImageUrl = profileImageUrl,
-            bio = bio,
-            location = location,
-            websiteUrl = websiteUrl,
-            joinedAt = createdAt.toString(),
-        )
-    }
-
-    private fun Post.toPublicUserPostSummaryResponse(): PublicUserPostSummaryResponse {
-        return PublicUserPostSummaryResponse(
-            slug = slug,
-            title = title,
-            description = description,
-            publishedAtLabel = formatPublishedAtLabel(this),
-            readTimeLabel = estimateReadTimeLabel(this),
-        )
-    }
-
-    private fun PublicPostDetail.toPostDetailResponse(): PostDetailResponse {
-        return PostDetailResponse(
-            id = requireNotNull(post.id),
-            slug = post.slug,
-            title = post.title,
-            description = post.description,
-            content = post.content,
-            authorUsername = authorUsername,
-            authorName = authorName,
-            authorAvatarSrc = authorAvatarSrc,
-            publishedAtLabel = formatPublishedAtLabel(post),
-            readTimeLabel = estimateReadTimeLabel(post),
-            topics = topics,
         )
     }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserService.kt
@@ -1,10 +1,15 @@
 package io.github.kitae9999.openlog.user
 
+import io.github.kitae9999.openlog.common.exception.ForbiddenException
 import io.github.kitae9999.openlog.common.exception.NotFoundException
+import io.github.kitae9999.openlog.post.dto.PostDetailResponse
+import io.github.kitae9999.openlog.post.estimateReadTimeLabel
+import io.github.kitae9999.openlog.post.formatPublishedAtLabel
 import io.github.kitae9999.openlog.post.repository.PostRepository
-import io.github.kitae9999.openlog.post.entity.Post
 import io.github.kitae9999.openlog.post.resolveAuthorName
 import io.github.kitae9999.openlog.posttopic.repository.PostTopicRepository
+import io.github.kitae9999.openlog.user.dto.PublicUserPostSummaryResponse
+import io.github.kitae9999.openlog.user.dto.PublicUserProfileResponse
 import io.github.kitae9999.openlog.user.entity.User
 import io.github.kitae9999.openlog.user.repository.UserRepository
 import jakarta.transaction.Transactional
@@ -17,46 +22,67 @@ class UserService(
     private val postTopicRepository: PostTopicRepository,
 ) {
     @Transactional
-    fun getPublicProfile(username: String): User =
-        userRepository.findByUsername(username) ?: throw NotFoundException("사용자를 찾을 수 없습니다.")
-
-    @Transactional
-    fun getPublicPosts(username: String): List<Post> {
+    fun getPublicProfile(username: String): PublicUserProfileResponse {
         val user = userRepository.findByUsername(username) ?: throw NotFoundException("사용자를 찾을 수 없습니다.")
-        val authorId = requireNotNull(user.id)
 
-        return postRepository.findAllByAuthorIdOrderByCreatedAtDesc(authorId)
+        return toPublicUserProfileResponse(user)
     }
 
     @Transactional
-    fun getPublicPostDetail(username: String, slug: String): PublicPostDetail {
+    fun getPublicPosts(username: String): List<PublicUserPostSummaryResponse> {
+        val user = userRepository.findByUsername(username) ?: throw NotFoundException("사용자를 찾을 수 없습니다.")
+        val authorId = requireNotNull(user.id)
+
+        return postRepository.findAllByAuthorIdOrderByCreatedAtDesc(authorId).map { post ->
+            PublicUserPostSummaryResponse(
+                slug = post.slug,
+                title = post.title,
+                description = post.description,
+                publishedAtLabel = formatPublishedAtLabel(post),
+                readTimeLabel = estimateReadTimeLabel(post),
+            )
+        }
+    }
+
+    @Transactional
+    fun getPublicPostDetail(username: String, slug: String): PostDetailResponse {
         val user = userRepository.findByUsername(username) ?: throw NotFoundException("사용자를 찾을 수 없습니다.")
         val post = postRepository.findByAuthorIdAndSlug(requireNotNull(user.id), slug)
             ?: throw NotFoundException("글을 찾을 수 없습니다.")
-        val author = post.author
         val topics = postTopicRepository.findAllByPostId(requireNotNull(post.id))
             .map { it.topic.name }
             .sorted()
 
-        return PublicPostDetail(
-            post = post,
-            authorUsername = requireNotNull(author.username),
+        return PostDetailResponse(
+            id = requireNotNull(post.id),
+            slug = post.slug,
+            title = post.title,
+            description = post.description,
+            content = post.content,
+            authorUsername = requireNotNull(post.author.username),
             authorName = resolveAuthorName(post),
-            authorAvatarSrc = author.profileImageUrl,
+            authorAvatarSrc = post.author.profileImageUrl,
+            publishedAtLabel = formatPublishedAtLabel(post),
+            readTimeLabel = estimateReadTimeLabel(post),
             topics = topics,
         )
     }
 
     @Transactional
     fun updateProfile(
+        userId: Long,
         username: String,
         nickname: String,
         bio: String?,
         location: String?,
         websiteUrl: String?,
-    ): User {
+    ): PublicUserProfileResponse {
         val user = userRepository.findByUsername(username)
             ?: throw NotFoundException("사용자를 찾을 수 없습니다.")
+
+        if (user.id != userId) {
+            throw ForbiddenException()
+        }
 
         user.updateProfile(
             nickname = nickname.trim(),
@@ -65,14 +91,18 @@ class UserService(
             websiteUrl = websiteUrl?.trim()?.takeIf { it.isNotEmpty() },
         )
 
-        return user
+        return toPublicUserProfileResponse(user)
+    }
+
+    private fun toPublicUserProfileResponse(user: User): PublicUserProfileResponse {
+        return PublicUserProfileResponse(
+            username = requireNotNull(user.username),
+            nickname = user.nickname,
+            profileImageUrl = user.profileImageUrl,
+            bio = user.bio,
+            location = user.location,
+            websiteUrl = user.websiteUrl,
+            joinedAt = user.createdAt.toString(),
+        )
     }
 }
-
-data class PublicPostDetail(
-    val post: Post,
-    val authorUsername: String,
-    val authorName: String,
-    val authorAvatarSrc: String?,
-    val topics: List<String>,
-)

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserService.kt
@@ -1,14 +1,11 @@
 package io.github.kitae9999.openlog.user
 
 import io.github.kitae9999.openlog.common.exception.NotFoundException
-import io.github.kitae9999.openlog.post.estimateReadTimeLabel
-import io.github.kitae9999.openlog.post.formatPublishedAtLabel
 import io.github.kitae9999.openlog.post.repository.PostRepository
-import io.github.kitae9999.openlog.post.dto.PostDetailResponse
+import io.github.kitae9999.openlog.post.entity.Post
 import io.github.kitae9999.openlog.post.resolveAuthorName
 import io.github.kitae9999.openlog.posttopic.repository.PostTopicRepository
-import io.github.kitae9999.openlog.user.dto.PublicUserPostSummaryResponse
-import io.github.kitae9999.openlog.user.dto.PublicUserProfileResponse
+import io.github.kitae9999.openlog.user.entity.User
 import io.github.kitae9999.openlog.user.repository.UserRepository
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
@@ -20,55 +17,62 @@ class UserService(
     private val postTopicRepository: PostTopicRepository,
 ) {
     @Transactional
-    fun getPublicProfile(username: String): PublicUserProfileResponse {
-        val user = userRepository.findByUsername(username) ?: throw NotFoundException("사용자를 찾을 수 없습니다.")
-
-        return PublicUserProfileResponse(
-            username = requireNotNull(user.username),
-            nickname = user.nickname,
-            profileImageUrl = user.profileImageUrl,
-            bio = user.bio,
-            joinedAt = user.createdAt.toString(),
-        )
-    }
+    fun getPublicProfile(username: String): User =
+        userRepository.findByUsername(username) ?: throw NotFoundException("사용자를 찾을 수 없습니다.")
 
     @Transactional
-    fun getPublicPosts(username: String): List<PublicUserPostSummaryResponse> {
+    fun getPublicPosts(username: String): List<Post> {
         val user = userRepository.findByUsername(username) ?: throw NotFoundException("사용자를 찾을 수 없습니다.")
         val authorId = requireNotNull(user.id)
 
-        return postRepository.findAllByAuthorIdOrderByCreatedAtDesc(authorId).map { post ->
-            PublicUserPostSummaryResponse(
-                slug = post.slug,
-                title = post.title,
-                description = post.description,
-                publishedAtLabel = formatPublishedAtLabel(post),
-                readTimeLabel = estimateReadTimeLabel(post),
-            )
-        }
+        return postRepository.findAllByAuthorIdOrderByCreatedAtDesc(authorId)
     }
 
     @Transactional
-    fun getPublicPostDetail(username: String, slug: String): PostDetailResponse {
+    fun getPublicPostDetail(username: String, slug: String): PublicPostDetail {
         val user = userRepository.findByUsername(username) ?: throw NotFoundException("사용자를 찾을 수 없습니다.")
         val post = postRepository.findByAuthorIdAndSlug(requireNotNull(user.id), slug)
             ?: throw NotFoundException("글을 찾을 수 없습니다.")
+        val author = post.author
         val topics = postTopicRepository.findAllByPostId(requireNotNull(post.id))
             .map { it.topic.name }
             .sorted()
 
-        return PostDetailResponse(
-            id = requireNotNull(post.id),
-            slug = post.slug,
-            title = post.title,
-            description = post.description,
-            content = post.content,
-            authorUsername = requireNotNull(post.author.username),
+        return PublicPostDetail(
+            post = post,
+            authorUsername = requireNotNull(author.username),
             authorName = resolveAuthorName(post),
-            authorAvatarSrc = post.author.profileImageUrl,
-            publishedAtLabel = formatPublishedAtLabel(post),
-            readTimeLabel = estimateReadTimeLabel(post),
+            authorAvatarSrc = author.profileImageUrl,
             topics = topics,
         )
     }
+
+    @Transactional
+    fun updateProfile(
+        username: String,
+        nickname: String,
+        bio: String?,
+        location: String?,
+        websiteUrl: String?,
+    ): User {
+        val user = userRepository.findByUsername(username)
+            ?: throw NotFoundException("사용자를 찾을 수 없습니다.")
+
+        user.updateProfile(
+            nickname = nickname.trim(),
+            bio = bio?.trim()?.takeIf { it.isNotEmpty() },
+            location = location?.trim()?.takeIf { it.isNotEmpty() },
+            websiteUrl = websiteUrl?.trim()?.takeIf { it.isNotEmpty() },
+        )
+
+        return user
+    }
 }
+
+data class PublicPostDetail(
+    val post: Post,
+    val authorUsername: String,
+    val authorName: String,
+    val authorAvatarSrc: String?,
+    val topics: List<String>,
+)

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/dto/PublicUserProfileResponse.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/dto/PublicUserProfileResponse.kt
@@ -5,5 +5,7 @@ data class PublicUserProfileResponse(
     val nickname: String?,
     val profileImageUrl: String?,
     val bio: String?,
+    val location: String?,
+    val websiteUrl: String?,
     val joinedAt: String,
 )

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/dto/UpdateProfileRequest.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/dto/UpdateProfileRequest.kt
@@ -1,0 +1,19 @@
+package io.github.kitae9999.openlog.user.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class UpdateProfileRequest(
+    @field:NotBlank(message = "닉네임은 필수입니다.")
+    @field:Size(max = 40, message = "닉네임은 40자 이하로 입력해주세요.")
+    val nickname: String,
+
+    @field:Size(max = 160, message = "bio는 160자 이하로 입력해주세요.")
+    val bio: String? = null,
+
+    @field:Size(max = 100, message = "location은 100자 이하로 입력해주세요.")
+    val location: String? = null,
+
+    @field:Size(max = 2048, message = "website URL은 2048자 이하로 입력해주세요.")
+    val websiteUrl: String? = null,
+)

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/entity/User.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/entity/User.kt
@@ -65,6 +65,18 @@ class User(
     var updatedAt: LocalDateTime = LocalDateTime.now()
         protected set
 
+    fun updateProfile(
+        nickname: String,
+        bio: String?,
+        location: String?,
+        websiteUrl: String?,
+    ) {
+        this.nickname = nickname
+        this.bio = bio
+        this.location = location
+        this.websiteUrl = websiteUrl
+        this.updatedAt = LocalDateTime.now()
+    }
 
     fun completeOnboarding(
         nickname: String,

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/entity/User.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/entity/User.kt
@@ -24,6 +24,10 @@ class User(
     bio: String? = null,
 
     email: String? = null,
+
+    location: String? = null,
+
+    websiteUrl : String? = null,
 ){
     @Column(unique = true)
     var username: String? = username
@@ -45,6 +49,14 @@ class User(
     var email: String? = email
         protected set
 
+    @Column()
+    var location: String? = location
+        protected set
+
+    @Column(name = "website_url")
+    var websiteUrl: String? = websiteUrl
+        protected set
+
     @Column(name = "created_at", nullable = false)
     var createdAt: LocalDateTime = LocalDateTime.now()
         protected set
@@ -52,6 +64,7 @@ class User(
     @Column(name = "updated_at", nullable = false)
     var updatedAt: LocalDateTime = LocalDateTime.now()
         protected set
+
 
     fun completeOnboarding(
         nickname: String,

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/entity/User.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/entity/User.kt
@@ -71,6 +71,15 @@ class User(
         location: String?,
         websiteUrl: String?,
     ) {
+        if (
+            this.nickname == nickname &&
+            this.bio == bio &&
+            this.location == location &&
+            this.websiteUrl == websiteUrl
+        ) {
+            return
+        }
+
         this.nickname = nickname
         this.bio = bio
         this.location = location

--- a/backend/src/main/resources/db/migration/V20260411__add_profile_location_and_website.sql
+++ b/backend/src/main/resources/db/migration/V20260411__add_profile_location_and_website.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE public.users
+    ADD COLUMN IF NOT EXISTS location VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS website_url VARCHAR(2048);
+
+COMMIT;

--- a/frontend/src/01_widgets/profile/ui/EditableProfileHeader.tsx
+++ b/frontend/src/01_widgets/profile/ui/EditableProfileHeader.tsx
@@ -1,0 +1,473 @@
+"use client";
+
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useState, useTransition, type FormEvent } from "react";
+import type { PublicUserProfile } from "@/entities/user/api/getPublicUserProfile";
+import {
+  updateProfileAction,
+  type UpdateProfileActionState,
+  type UpdateProfileValues,
+} from "@/features/profile/api/profileActions";
+import { assets } from "@/shared/config/assets";
+
+type FieldName = "nickname" | "bio" | "location" | "websiteUrl";
+
+export function EditableProfileHeader({
+  profile,
+  isViewer,
+  joinedLabel,
+}: {
+  profile: PublicUserProfile;
+  isViewer: boolean;
+  joinedLabel: string;
+}) {
+  const router = useRouter();
+  const [currentProfile, setCurrentProfile] = useState(profile);
+  const [isEditing, setIsEditing] = useState(false);
+  const initialState: UpdateProfileActionState = {
+    values: toUpdateProfileValues(currentProfile),
+    errors: {},
+    profile: null,
+  };
+  const [values, setValues] = useState(initialState.values);
+  const [clientErrors, setClientErrors] = useState<
+    Partial<Record<FieldName, string>>
+  >({});
+  const [serverErrors, setServerErrors] = useState(initialState.errors);
+  const [isPending, startTransition] = useTransition();
+
+  const profileName = currentProfile.nickname ?? currentProfile.username;
+
+  function validateField(name: FieldName, value: string) {
+    const trimmed = value.trim();
+
+    if (name === "nickname") {
+      if (!trimmed) {
+        return "닉네임은 필수입니다.";
+      }
+      if (trimmed.length > 40) {
+        return "닉네임은 40자 이하로 입력해주세요.";
+      }
+      return undefined;
+    }
+
+    if (name === "bio" && trimmed.length > 160) {
+      return "bio는 160자 이하로 입력해주세요.";
+    }
+
+    if (name === "location" && trimmed.length > 100) {
+      return "location은 100자 이하로 입력해주세요.";
+    }
+
+    if (name === "websiteUrl" && trimmed.length > 2048) {
+      return "website URL은 2048자 이하로 입력해주세요.";
+    }
+
+    return undefined;
+  }
+
+  function handleFieldChange(name: FieldName, nextValue: string) {
+    setValues((current) => ({
+      ...current,
+      [name]: nextValue,
+    }));
+
+    setClientErrors((current) => ({
+      ...current,
+      [name]: undefined,
+    }));
+
+    setServerErrors((current) => ({
+      ...current,
+      [name]: undefined,
+      form: undefined,
+    }));
+  }
+
+  function handleFieldBlur(name: FieldName) {
+    const nextError = validateField(name, values[name]);
+
+    setClientErrors((current) => ({
+      ...current,
+      [name]: nextError,
+    }));
+  }
+
+  function handleCancel() {
+    if (isPending) {
+      return;
+    }
+
+    setValues(toUpdateProfileValues(currentProfile));
+    setClientErrors({});
+    setServerErrors({});
+    setIsEditing(false);
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const nextErrors: Partial<Record<FieldName, string>> = {
+      nickname: validateField("nickname", values.nickname),
+      bio: validateField("bio", values.bio),
+      location: validateField("location", values.location),
+      websiteUrl: validateField("websiteUrl", values.websiteUrl),
+    };
+
+    setClientErrors(nextErrors);
+
+    if (Object.values(nextErrors).some(Boolean)) {
+      return;
+    }
+
+    const formData = new FormData(event.currentTarget);
+
+    startTransition(async () => {
+      let result: UpdateProfileActionState;
+
+      try {
+        result = await updateProfileAction(formData);
+      } catch {
+        setServerErrors({
+          form: "프로필을 저장하는 중 문제가 발생했습니다.",
+        });
+        return;
+      }
+
+      if (result.profile) {
+        setCurrentProfile(result.profile);
+        setValues(toUpdateProfileValues(result.profile));
+        setClientErrors({});
+        setServerErrors({});
+        setIsEditing(false);
+        router.refresh();
+        return;
+      }
+
+      setValues(result.values);
+      setServerErrors(result.errors);
+    });
+  }
+
+  if (isEditing) {
+    return (
+      <section className="rounded-[28px] border border-zinc-200/80 bg-white px-6 py-7 shadow-[0_1px_2px_rgba(16,24,40,0.04)] sm:px-8 sm:py-8">
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-col gap-8 lg:flex-row lg:items-start"
+        >
+          <input type="hidden" name="username" value={currentProfile.username} />
+          <ProfileAvatar profile={currentProfile} profileName={profileName} />
+
+          <div className="min-w-0 flex-1">
+            <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm font-semibold text-zinc-500">
+                Edit profile details
+              </p>
+              {isViewer ? (
+                <EditActions onCancel={handleCancel} pending={isPending} />
+              ) : null}
+            </div>
+
+            <div className="grid min-w-0 gap-4">
+              <Field
+                name="nickname"
+                label="Nickname"
+                value={values.nickname}
+                placeholder="프로필에 표시될 이름입니다."
+                error={clientErrors.nickname ?? serverErrors.nickname}
+                maxLength={40}
+                onChange={handleFieldChange}
+                onBlur={handleFieldBlur}
+              />
+
+              <div>
+                <span className="text-sm font-semibold text-zinc-900">
+                  Username
+                </span>
+                <div className="mt-2 rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm font-medium text-zinc-500">
+                  @{currentProfile.username}
+                </div>
+              </div>
+
+              <Field
+                name="bio"
+                label="Bio"
+                value={values.bio}
+                placeholder="No bio added yet."
+                error={clientErrors.bio ?? serverErrors.bio}
+                maxLength={160}
+                multiline
+                onChange={handleFieldChange}
+                onBlur={handleFieldBlur}
+              />
+            </div>
+
+            <div className="mt-5 grid gap-4 text-sm text-zinc-500 lg:grid-cols-3">
+              <div>
+                <span className="inline-flex items-center gap-2 text-sm font-semibold text-zinc-900">
+                  <Image
+                    src="/Calendar.svg"
+                    alt=""
+                    width={16}
+                    height={16}
+                    aria-hidden="true"
+                  />
+                  Joined
+                </span>
+                <div className="mt-2 rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm font-medium text-zinc-500">
+                  {joinedLabel}
+                </div>
+              </div>
+              <Field
+                name="location"
+                label="Location"
+                value={values.location}
+                placeholder="No location added yet."
+                error={clientErrors.location ?? serverErrors.location}
+                maxLength={100}
+                iconSrc="/MapPin.svg"
+                onChange={handleFieldChange}
+                onBlur={handleFieldBlur}
+              />
+              <Field
+                name="websiteUrl"
+                label="Website"
+                value={values.websiteUrl}
+                placeholder="No website added yet."
+                error={clientErrors.websiteUrl ?? serverErrors.websiteUrl}
+                maxLength={2048}
+                iconSrc="/LinkIcon.svg"
+                onChange={handleFieldChange}
+                onBlur={handleFieldBlur}
+              />
+            </div>
+
+            {serverErrors.form ? (
+              <p className="mt-4 rounded-xl border border-rose-100 bg-rose-50 px-4 py-3 text-sm font-medium text-rose-700">
+                {serverErrors.form}
+              </p>
+            ) : null}
+          </div>
+        </form>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-[28px] border border-zinc-200/80 bg-white px-6 py-7 shadow-[0_1px_2px_rgba(16,24,40,0.04)] sm:px-8 sm:py-8">
+      <div className="flex flex-col gap-8 lg:flex-row lg:items-start">
+        <ProfileAvatar profile={currentProfile} profileName={profileName} />
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+            <div className="min-w-0">
+              <h1 className="font-[Georgia,serif] text-[40px] font-bold leading-none tracking-[-0.04em] text-zinc-950 sm:text-[48px]">
+                {profileName}
+              </h1>
+              <p className="mt-3 text-sm font-medium text-zinc-500">
+                @{currentProfile.username}
+              </p>
+              <p className="mt-4 max-w-3xl text-[18px] leading-8 text-zinc-600">
+                {currentProfile.bio ?? "No bio added yet."}
+              </p>
+            </div>
+
+            {isViewer ? (
+              <button
+                type="button"
+                onClick={() => setIsEditing(true)}
+                className="inline-flex h-11 items-center gap-2 self-start rounded-full border border-zinc-300 bg-white px-5 text-sm font-medium text-zinc-900 transition hover:border-zinc-400 hover:bg-zinc-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/10"
+              >
+                <IconPencil className="size-4" />
+                Edit Profile
+              </button>
+            ) : null}
+          </div>
+
+          <div className="mt-5 flex flex-wrap gap-x-6 gap-y-3 text-sm text-zinc-500">
+            <ProfileMeta iconSrc="/Calendar.svg" label={joinedLabel} />
+            <ProfileMeta
+              iconSrc="/MapPin.svg"
+              label={currentProfile.location ?? "No location added yet."}
+              muted={!currentProfile.location}
+            />
+            <ProfileMeta
+              iconSrc="/LinkIcon.svg"
+              label={currentProfile.websiteUrl ?? "No website added yet."}
+              muted={!currentProfile.websiteUrl}
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ProfileAvatar({
+  profile,
+  profileName,
+}: {
+  profile: PublicUserProfile;
+  profileName: string;
+}) {
+  return (
+    <div className="mx-auto lg:mx-0">
+      <div className="rounded-full border-4 border-zinc-50 bg-white p-1">
+        <Image
+          src={profile.profileImageUrl ?? assets.defaultAvatar}
+          alt={`${profileName} avatar`}
+          width={128}
+          height={128}
+          className="size-28 rounded-full object-cover sm:size-32"
+          priority
+        />
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  name,
+  label,
+  value,
+  placeholder,
+  error,
+  maxLength,
+  iconSrc,
+  multiline = false,
+  onChange,
+  onBlur,
+}: {
+  name: FieldName;
+  label: string;
+  value: string;
+  placeholder: string;
+  error?: string;
+  maxLength: number;
+  iconSrc?: string;
+  multiline?: boolean;
+  onChange: (name: FieldName, value: string) => void;
+  onBlur: (name: FieldName) => void;
+}) {
+  const inputClassName = error
+    ? "border-rose-300 bg-rose-50/40 focus:border-rose-400 focus:ring-rose-100"
+    : "border-zinc-200 bg-white focus:border-zinc-400 focus:ring-zinc-200/70";
+  const className = `mt-2 w-full rounded-xl border px-4 py-3 text-sm text-zinc-950 outline-none transition placeholder:text-zinc-400 focus:ring-4 ${inputClassName}`;
+
+  return (
+    <label className={iconSrc ? "block md:col-span-1" : "block"}>
+      <span className="inline-flex items-center gap-2 text-sm font-semibold text-zinc-900">
+        {iconSrc ? (
+          <Image src={iconSrc} alt="" width={16} height={16} aria-hidden="true" />
+        ) : null}
+        {label}
+      </span>
+      {multiline ? (
+        <textarea
+          name={name}
+          value={value}
+          placeholder={placeholder}
+          rows={4}
+          maxLength={maxLength}
+          className={`${className} min-h-[132px] resize-none leading-6`}
+          onChange={(event) => onChange(name, event.target.value)}
+          onBlur={() => onBlur(name)}
+        />
+      ) : (
+        <input
+          name={name}
+          value={value}
+          placeholder={placeholder}
+          maxLength={maxLength}
+          className={className}
+          onChange={(event) => onChange(name, event.target.value)}
+          onBlur={() => onBlur(name)}
+        />
+      )}
+      {error ? <p className="mt-2 text-sm text-rose-600">{error}</p> : null}
+    </label>
+  );
+}
+
+function EditActions({
+  onCancel,
+  pending,
+}: {
+  onCancel: () => void;
+  pending: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-2 self-start">
+      <button
+        type="button"
+        onClick={onCancel}
+        disabled={pending}
+        className="inline-flex h-11 items-center rounded-xl border border-zinc-300 bg-white px-4 text-sm font-medium text-zinc-700 transition hover:border-zinc-400 hover:bg-zinc-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/10 disabled:cursor-not-allowed disabled:text-zinc-300"
+      >
+        Cancel
+      </button>
+      <button
+        type="submit"
+        disabled={pending}
+        className="inline-flex h-11 items-center rounded-xl bg-zinc-950 px-5 text-sm font-semibold text-white transition hover:bg-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20 disabled:cursor-not-allowed disabled:bg-zinc-400"
+      >
+        {pending ? "Saving..." : "Save"}
+      </button>
+    </div>
+  );
+}
+
+function ProfileMeta({
+  iconSrc,
+  label,
+  muted = false,
+}: {
+  iconSrc: string;
+  label: string;
+  muted?: boolean;
+}) {
+  return (
+    <div className="inline-flex items-center gap-2.5">
+      <Image src={iconSrc} alt="" width={16} height={16} aria-hidden="true" />
+      <span className={muted ? "text-zinc-400" : undefined}>{label}</span>
+    </div>
+  );
+}
+
+function IconPencil({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M12 20h9"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M16.5 3.5a2.12 2.12 0 113 3L7 19l-4 1 1-4 12.5-12.5z"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function toUpdateProfileValues(profile: PublicUserProfile): UpdateProfileValues {
+  return {
+    username: profile.username,
+    nickname: profile.nickname ?? "",
+    bio: profile.bio ?? "",
+    location: profile.location ?? "",
+    websiteUrl: profile.websiteUrl ?? "",
+  };
+}

--- a/frontend/src/01_widgets/profile/ui/ProfileView.tsx
+++ b/frontend/src/01_widgets/profile/ui/ProfileView.tsx
@@ -10,6 +10,7 @@ import {
   buildViewerProfileHref,
 } from "@/shared/lib/publicRoutes";
 import { Footer, Header } from "@/widgets/chrome/ui";
+import { EditableProfileHeader } from "./EditableProfileHeader";
 
 export async function ProfileView({ username }: { username: string }) {
   const [viewer, profile, posts] = await Promise.all([
@@ -38,62 +39,11 @@ export async function ProfileView({ username }: { username: string }) {
       />
 
       <main className="mx-auto w-full max-w-[1083px] flex-1 px-4 pb-20 pt-8 sm:px-8">
-        <section className="rounded-[28px] border border-zinc-200/80 bg-white px-6 py-7 shadow-[0_1px_2px_rgba(16,24,40,0.04)] sm:px-8 sm:py-8">
-          <div className="flex flex-col gap-8 lg:flex-row lg:items-start">
-            <div className="mx-auto lg:mx-0">
-              <div className="rounded-full border-4 border-zinc-50 bg-white p-1">
-                <Image
-                  src={profile.profileImageUrl ?? assets.defaultAvatar}
-                  alt={`${profileName} avatar`}
-                  width={128}
-                  height={128}
-                  className="size-28 rounded-full object-cover sm:size-32"
-                  priority
-                />
-              </div>
-            </div>
-
-            <div className="min-w-0 flex-1">
-              <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
-                <div className="min-w-0">
-                  <h1 className="font-[Georgia,serif] text-[40px] font-bold leading-none tracking-[-0.04em] text-zinc-950 sm:text-[48px]">
-                    {profileName}
-                  </h1>
-                  <p className="mt-3 text-sm font-medium text-zinc-500">
-                    @{profile.username}
-                  </p>
-                  <p className="mt-4 max-w-3xl text-[18px] leading-8 text-zinc-600">
-                    {profile.bio ?? "No bio added yet."}
-                  </p>
-                </div>
-
-                {isViewer ? (
-                  <button
-                    type="button"
-                    className="inline-flex h-11 items-center gap-2 self-start rounded-full border border-zinc-300 bg-white px-5 text-sm font-medium text-zinc-900 transition hover:border-zinc-400 hover:bg-zinc-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/10"
-                  >
-                    <IconPencil className="size-4" />
-                    Edit Profile
-                  </button>
-                ) : null}
-              </div>
-
-              <div className="mt-5 flex flex-wrap gap-x-6 gap-y-3 text-sm text-zinc-500">
-                <ProfileMeta iconSrc="/Calendar.svg" label={joinedLabel} />
-                <ProfileMeta
-                  iconSrc="/MapPin.svg"
-                  label="No location added yet."
-                  muted
-                />
-                <ProfileMeta
-                  iconSrc="/LinkIcon.svg"
-                  label="No website added yet."
-                  muted
-                />
-              </div>
-            </div>
-          </div>
-        </section>
+        <EditableProfileHeader
+          profile={profile}
+          isViewer={isViewer}
+          joinedLabel={joinedLabel}
+        />
 
         <div className="mt-10 grid grid-cols-1 gap-10 lg:grid-cols-[minmax(0,1fr)_280px]">
           <section className="min-w-0">
@@ -192,23 +142,6 @@ function SectionHeading({
   );
 }
 
-function ProfileMeta({
-  iconSrc,
-  label,
-  muted = false,
-}: {
-  iconSrc: string;
-  label: string;
-  muted?: boolean;
-}) {
-  return (
-    <div className="inline-flex items-center gap-2.5">
-      <Image src={iconSrc} alt="" width={16} height={16} aria-hidden="true" />
-      <span className={muted ? "text-zinc-400" : undefined}>{label}</span>
-    </div>
-  );
-}
-
 function EmptyStateCard({
   title,
   description,
@@ -238,30 +171,4 @@ function formatJoinedLabel(joinedAt: string) {
     month: "long",
     year: "numeric",
   }).format(parsed)}`;
-}
-
-function IconPencil({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      className={className}
-      aria-hidden="true"
-    >
-      <path
-        d="M12 20h9"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M16.5 3.5a2.12 2.12 0 113 3L7 19l-4 1 1-4 12.5-12.5z"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
 }

--- a/frontend/src/02_features/profile/api/profileActions.ts
+++ b/frontend/src/02_features/profile/api/profileActions.ts
@@ -1,0 +1,116 @@
+"use server";
+
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import type { PublicUserProfile } from "@/entities/user/api/getPublicUserProfile";
+import { API_CONFIG } from "@/shared/api";
+
+export type UpdateProfileValues = {
+  username: string;
+  nickname: string;
+  bio: string;
+  location: string;
+  websiteUrl: string;
+};
+
+export type UpdateProfileActionState = {
+  values: UpdateProfileValues;
+  errors: Partial<
+    Record<"nickname" | "bio" | "location" | "websiteUrl" | "form", string>
+  >;
+  profile: PublicUserProfile | null;
+};
+
+export async function updateProfileAction(
+  formData: FormData,
+): Promise<UpdateProfileActionState> {
+  const values: UpdateProfileValues = {
+    username: String(formData.get("username") ?? "").trim(),
+    nickname: String(formData.get("nickname") ?? "").trim(),
+    bio: String(formData.get("bio") ?? "").trim(),
+    location: String(formData.get("location") ?? "").trim(),
+    websiteUrl: String(formData.get("websiteUrl") ?? "").trim(),
+  };
+  const errors: UpdateProfileActionState["errors"] = {};
+
+  if (!values.nickname) {
+    errors.nickname = "닉네임은 필수입니다.";
+  } else if (values.nickname.length > 40) {
+    errors.nickname = "닉네임은 40자 이하로 입력해주세요.";
+  }
+
+  if (values.bio.length > 160) {
+    errors.bio = "bio는 160자 이하로 입력해주세요.";
+  }
+
+  if (values.location.length > 100) {
+    errors.location = "location은 100자 이하로 입력해주세요.";
+  }
+
+  if (values.websiteUrl.length > 2048) {
+    errors.websiteUrl = "website URL은 2048자 이하로 입력해주세요.";
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return { values, errors, profile: null };
+  }
+
+  const headerStore = await headers();
+  const response = await fetch(
+    `${API_CONFIG.baseURL}/users/${encodeURIComponent(values.username)}`,
+    {
+      method: "PATCH",
+      cache: "no-store",
+      headers: {
+        "content-type": "application/json",
+        cookie: headerStore.get("cookie") ?? "",
+      },
+      body: JSON.stringify({
+        nickname: values.nickname,
+        bio: values.bio || null,
+        location: values.location || null,
+        websiteUrl: values.websiteUrl || null,
+      }),
+    },
+  );
+
+  if (response.ok) {
+    const profile = (await response.json()) as PublicUserProfile;
+
+    return {
+      values: toUpdateProfileValues(profile),
+      errors: {},
+      profile,
+    };
+  }
+
+  if (response.status === 401) {
+    redirect("/");
+  }
+
+  let errorBody: { message?: string } | null = null;
+
+  try {
+    errorBody = (await response.json()) as { message?: string };
+  } catch {
+    errorBody = null;
+  }
+
+  return {
+    values,
+    errors: {
+      form: errorBody?.message ?? "프로필을 저장하는 중 문제가 발생했습니다.",
+    },
+    profile: null,
+  };
+}
+
+function toUpdateProfileValues(profile: PublicUserProfile): UpdateProfileValues {
+  return {
+    username: profile.username,
+    nickname: profile.nickname ?? "",
+    bio: profile.bio ?? "",
+    location: profile.location ?? "",
+    websiteUrl: profile.websiteUrl ?? "",
+  };
+}

--- a/frontend/src/03_entities/user/api/getPublicUserProfile.ts
+++ b/frontend/src/03_entities/user/api/getPublicUserProfile.ts
@@ -7,6 +7,8 @@ export type PublicUserProfile = {
   nickname: string | null;
   profileImageUrl: string | null;
   bio: string | null;
+  location: string | null;
+  websiteUrl: string | null;
   joinedAt: string;
 };
 


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #

---

## 1. PR 유형
- [x] 🐛 버그 수정 (Bug Fix)
- [x] ✨ 새로운 기능 (New Feature)
- [ ] ♻️ 리팩토링 (Refactoring)
- [x] 📝 문서 업데이트 (Documentation)
- [x] ⚙️ 설정/빌드 변경 (Chore)

---

## 2. 작업 배경 및 목적
- **기존 상태:** 공개 프로필 페이지는 `nickname`, `username`, `bio`, 가입일, avatar만 표시했고, `location`과 `website`는 화면에 placeholder 문구만 존재했습니다. `users` 테이블과 `User` 엔티티에도 해당 값을 저장할 컬럼이 없었으며, 프로필 수정 버튼은 UI에 표시되지만 실제 편집 상태나 저장 API와 연결되어 있지 않았습니다.
- **문제점:** 사용자는 프로필 페이지에서 위치와 웹사이트 정보를 저장하거나 수정할 수 없었고, 프론트 타입과 백엔드 공개 프로필 응답도 신규 필드를 전달할 수 없는 상태였습니다. 또한 `PATCH /users/{username}`를 단순히 열면 버튼 노출 여부와 무관하게 다른 사용자의 경로로 직접 요청할 수 있으므로, 백엔드에서 현재 로그인 사용자와 수정 대상 사용자를 비교하는 권한 검증이 필요했습니다.
- **해결 목표:** `users` 테이블, `User` 엔티티, 공개 프로필 응답, 프론트 프로필 타입을 `location`/`websiteUrl`까지 확장하고, 본인 프로필에서만 인라인 편집 UI를 제공해 `nickname`, `bio`, `location`, `websiteUrl`을 저장할 수 있게 합니다. 저장 요청은 서버 액션이 인증 쿠키를 백엔드에 전달하고, 백엔드는 현재 사용자 ID와 path username의 사용자 ID를 비교해 본인 수정만 허용하도록 구성합니다.

---

## 3. 상세 변경 내역 및 동작 흐름

### A. 프로필 부가 정보 저장을 위한 DB/엔티티 확장
- **진입점 및 초기 조건:** `backend/src/main/resources/db/migration/V20260411__add_profile_location_and_website.sql` Flyway 마이그레이션이 `public.users` 테이블을 대상으로 실행됩니다. 백엔드 런타임에서는 `backend/src/main/kotlin/io/github/kitae9999/openlog/user/entity/User.kt`의 `User` 엔티티가 `users` 테이블과 매핑됩니다.

```sql
ALTER TABLE public.users
    ADD COLUMN IF NOT EXISTS location VARCHAR(100),
    ADD COLUMN IF NOT EXISTS website_url VARCHAR(2048);
```

- **단계별 제어 흐름:**
  1. Flyway가 `V20260411__add_profile_location_and_website.sql`을 실행해 기존 `users` 테이블에 nullable `location`, `website_url` 컬럼을 추가합니다.
  2. JPA는 `User.location`을 기본 컬럼명 `location`에 매핑하고, `User.websiteUrl`을 `@Column(name = "website_url")`로 snake_case 컬럼에 매핑합니다.
  3. `User.updateProfile()`은 서비스에서 정규화된 `nickname`, `bio`, `location`, `websiteUrl` 값을 받아 엔티티 필드와 `updatedAt`을 한 트랜잭션 안에서 갱신합니다.
- **데이터 상태 변이:** 기존 사용자 레코드는 신규 컬럼을 `NULL` 상태로 유지하고, 프로필 수정 요청이 성공하면 optional 입력값이 빈 문자열일 때 `NULL`, 값이 있을 때 해당 문자열로 저장됩니다. `nickname`은 필수 문자열로 저장되고, 수정 시점마다 `updatedAt`이 현재 시각으로 갱신됩니다.
- **최종 반환 및 종료 상태:** 데이터베이스는 기존 사용자 데이터 손실 없이 `location`, `website_url` 값을 저장할 수 있는 스키마가 되고, `User` 엔티티는 프로필 수정 유스케이스에서 네 개의 편집 필드를 일관되게 관리합니다.

### B. 공개 프로필 조회 응답과 프로필 수정 API 확장
- **진입점 및 초기 조건:** 공개 프로필 조회는 `GET /users/{username}`이고, 프로필 수정은 `PATCH /users/{username}`입니다. 수정 요청은 `UpdateProfileRequest`의 `nickname`, `bio`, `location`, `websiteUrl` 값을 JSON body로 받으며, 인증 쿠키가 포함된 요청이어야 합니다.

```kotlin
@PatchMapping("{username}")
fun updateProfile(
    @PathVariable username: String,
    @Valid @RequestBody request: UpdateProfileRequest,
    httpRequest: HttpServletRequest,
): PublicUserProfileResponse
```

- **단계별 제어 흐름:**
  1. `UserController.updateProfile()`은 `CurrentUserResolver.resolveUserId(httpRequest)`로 JWT 쿠키에서 현재 사용자 ID를 해석합니다.
  2. 컨트롤러는 path의 `username`, 현재 사용자 ID, request body의 프로필 필드를 `UserService.updateProfile()`에 전달합니다.
  3. `UserService.updateProfile()`은 `userRepository.findByUsername(username)`으로 수정 대상 사용자를 조회하고, 대상 사용자의 `id`와 현재 사용자 ID가 다르면 `ForbiddenException`을 발생시킵니다.
  4. 권한 검증이 통과하면 `nickname.trim()`, `bio/location/websiteUrl`의 trim 및 빈 문자열 null 변환을 수행한 뒤 `User.updateProfile()`을 호출합니다.
  5. 서비스는 수정된 `User` 엔티티를 `PublicUserProfileResponse`로 매핑해 컨트롤러에 반환합니다.
- **데이터 상태 변이:** 요청 body의 `nickname`은 `@NotBlank`, `@Size(max = 40)`로 검증되고, `bio`, `location`, `websiteUrl`은 각각 160자, 100자, 2048자 제한을 받습니다. 서비스 레이어에서 optional 필드는 `trim().takeIf { it.isNotEmpty() }`를 통해 빈 문자열이 DB의 `NULL` 상태로 변환됩니다.
- **최종 반환 및 종료 상태:** 본인 사용자의 수정 요청은 최신 `PublicUserProfileResponse(username, nickname, profileImageUrl, bio, location, websiteUrl, joinedAt)`를 반환합니다. 다른 사용자의 username 경로로 직접 PATCH 요청을 보내면 `ForbiddenException`에 의해 `403 FORBIDDEN` 응답으로 종료됩니다.

### C. 프로필 페이지 인라인 편집 UI 분리 및 상태 관리
- **진입점 및 초기 조건:** `frontend/src/01_widgets/profile/ui/ProfileView.tsx`는 서버 컴포넌트로 유지되어 `getUser()`, `getPublicUserProfile()`, `getPublicUserPosts()`를 병렬 호출합니다. 상단 프로필 블록은 새 클라이언트 컴포넌트 `EditableProfileHeader`가 담당합니다.

```tsx
<EditableProfileHeader
  profile={profile}
  isViewer={isViewer}
  joinedLabel={joinedLabel}
/>
```

- **단계별 제어 흐름:**
  1. `ProfileView`는 현재 로그인 사용자와 공개 프로필의 username을 비교해 `isViewer`를 계산하고 `EditableProfileHeader`에 전달합니다.
  2. `EditableProfileHeader`는 보기 모드에서 nickname, username, bio, 가입일, location, websiteUrl을 렌더링하고, `isViewer === true`일 때만 `Edit Profile` 버튼을 표시합니다.
  3. 사용자가 `Edit Profile`을 클릭하면 `isEditing` state가 `true`로 바뀌며 `nickname`, `bio`, `location`, `websiteUrl` 입력 필드와 읽기 전용 username 블록을 표시합니다.
  4. `Cancel`은 pending 상태가 아닐 때 입력 state를 현재 프로필 값으로 복원하고 편집 모드를 종료합니다.
  5. `Save`는 submit handler에서 클라이언트 검증을 통과한 경우 `FormData`를 만들어 서버 액션 `updateProfileAction()`을 호출합니다.
- **데이터 상태 변이:** 클라이언트 컴포넌트는 `currentProfile`과 `values`를 분리해 관리합니다. 입력 변경은 `values`만 갱신하고, 저장 성공 응답이 오면 `currentProfile`을 서버가 반환한 `PublicUserProfile`로 교체합니다. 저장 실패 시에는 서버 액션이 반환한 field/form error를 `serverErrors`에 저장해 편집 상태를 유지합니다.
- **최종 반환 및 종료 상태:** 저장 성공 시 `EditableProfileHeader`는 편집 모드를 닫고 최신 프로필 값을 즉시 반영하며 `router.refresh()`로 서버 컴포넌트 데이터를 재검증합니다. 저장 실패 시에는 기존 입력값과 편집 모드를 유지한 채 오류 메시지를 표시합니다.

### D. 프로필 수정 서버 액션과 프론트 타입 연결
- **진입점 및 초기 조건:** `frontend/src/02_features/profile/api/profileActions.ts`의 `updateProfileAction(formData)`가 클라이언트 컴포넌트의 submit handler에서 호출됩니다. action은 Next.js 서버 환경에서 실행되며 `headers()`로 현재 요청의 쿠키를 읽을 수 있습니다.

```ts
const response = await fetch(
  `${API_CONFIG.baseURL}/users/${encodeURIComponent(values.username)}`,
  {
    method: "PATCH",
    headers: {
      "content-type": "application/json",
      cookie: headerStore.get("cookie") ?? "",
    },
    body: JSON.stringify({
      nickname: values.nickname,
      bio: values.bio || null,
      location: values.location || null,
      websiteUrl: values.websiteUrl || null,
    }),
  },
);
```

- **단계별 제어 흐름:**
  1. 서버 액션은 `FormData`에서 `username`, `nickname`, `bio`, `location`, `websiteUrl`를 문자열로 꺼낸 뒤 trim합니다.
  2. nickname 필수 여부와 각 필드 길이를 프론트 액션 레벨에서 다시 검증합니다.
  3. 검증 오류가 있으면 `{ values, errors, profile: null }`을 반환해 클라이언트 컴포넌트가 필드별 오류를 표시할 수 있게 합니다.
  4. 검증을 통과하면 현재 요청의 cookie header를 백엔드 `PATCH /users/{username}` 요청에 포함합니다.
  5. 백엔드 응답이 `200 OK`이면 `PublicUserProfile` JSON을 파싱해 `profile`에 담고, `401`이면 홈으로 redirect하며, 그 외 실패는 form error로 변환합니다.
- **데이터 상태 변이:** `getPublicUserProfile.ts`의 `PublicUserProfile` 타입은 `location`, `websiteUrl`을 포함하도록 확장됩니다. 서버 액션 성공 응답은 동일 타입으로 파싱되어 클라이언트의 `currentProfile` state를 교체하는 기준 데이터가 됩니다.
- **최종 반환 및 종료 상태:** 프론트는 백엔드가 반환한 최신 공개 프로필 응답을 기준으로 화면 state를 갱신합니다. optional 입력값이 빈 문자열이면 `null`로 전송되므로 사용자는 기존 location/website 값을 삭제할 수 있습니다.

### E. 동일 내용 저장 시 updatedAt 변경 방지
- **진입점 및 초기 조건:** 댓글 수정 API가 기존 댓글 내용과 동일한 `content`로 `Comment.updateComment(content)`를 호출할 수 있고, 프로필 수정 API도 기존 프로필 필드와 동일한 `nickname`, `bio`, `location`, `websiteUrl`로 `User.updateProfile()`을 호출할 수 있습니다.

```kotlin
fun updateComment(content: String) {
    if (this.content == content){
        return
    }
    this.content = content
    this.updatedAt = LocalDateTime.now()
}
```

```kotlin
fun updateProfile(
    nickname: String,
    bio: String?,
    location: String?,
    websiteUrl: String?,
) {
    if (
        this.nickname == nickname &&
        this.bio == bio &&
        this.location == location &&
        this.websiteUrl == websiteUrl
    ) {
        return
    }
    this.nickname = nickname
    this.bio = bio
    this.location = location
    this.websiteUrl = websiteUrl
    this.updatedAt = LocalDateTime.now()
}
```

- **단계별 제어 흐름:**
  1. `Comment.updateComment()`은 입력 content와 현재 `this.content`를 먼저 비교합니다.
  2. 두 값이 동일하면 필드 대입과 `updatedAt` 갱신 없이 즉시 반환합니다.
  3. `User.updateProfile()`은 입력 `nickname`, `bio`, `location`, `websiteUrl`과 현재 엔티티 필드 네 개를 모두 비교합니다.
  4. 네 프로필 필드가 모두 동일하면 필드 대입과 `updatedAt` 갱신 없이 즉시 반환합니다.
  5. 댓글 또는 프로필 값이 하나라도 다를 때만 대상 필드를 새 값으로 교체하고 `updatedAt`을 현재 시각으로 갱신합니다.
- **데이터 상태 변이:** 동일 내용 저장 요청은 댓글 엔티티의 `content`, `updatedAt` 값을 변경하지 않고, 동일 프로필 저장 요청도 사용자 엔티티의 `nickname`, `bio`, `location`, `websiteUrl`, `updatedAt` 값을 변경하지 않습니다. 실제 내용이 바뀐 요청만 각 엔티티 본문 필드와 수정 시각을 변경합니다.
- **최종 반환 및 종료 상태:** 사용자가 댓글 edit 모드에서 내용을 바꾸지 않고 저장하거나, 프로필 edit 모드에서 필드 값을 바꾸지 않고 저장해도 불필요한 수정 시각 변경이 발생하지 않습니다.

---

## 4. 스크린샷 (선택)
- 없음

## 5. 테스트 및 검증 방법
- **테스트 환경:** macOS 로컬 환경에서 `feature/edit-profile` 브랜치 기준으로 백엔드 Spring Boot Kotlin 모듈과 프론트 Next.js 앱을 검증했습니다.
- **입력 시나리오:**
  1. `./gradlew :backend:test`
  2. `cd frontend && npm run lint`
  3. `cd frontend && npm exec tsc -- --noEmit`
  4. `git diff --check develop..HEAD`
- **출력 검증:** `./gradlew :backend:test`는 `BUILD SUCCESSFUL`로 종료되어 사용자 프로필 수정 API, 권한 검증, 엔티티/DTO 확장 코드가 Kotlin 컴파일 및 기존 테스트를 통과했습니다. `npm run lint`는 exit code 0으로 종료됐고, 기존 파일인 `frontend/src/01_widgets/onboarding/ui/OnboardingView.tsx`의 미사용 `Image` warning과 `frontend/src/01_widgets/write/ui/WriteView.tsx`의 `useEffectEvent` dependency warning만 보고했습니다. `npm exec tsc -- --noEmit`은 TypeScript 타입 오류 없이 종료됐고, `git diff --check develop..HEAD`는 공백 오류 없이 종료됐습니다.

---

## 6. 리뷰어 참고 사항 (선택)
- **특이 구현 사항:** 프로필 수정 저장 성공 후 프론트는 백엔드 응답으로 클라이언트 state를 즉시 갱신하고, 이어서 `router.refresh()`를 호출해 서버 컴포넌트의 공개 프로필 조회 결과도 재검증합니다. 이는 클라이언트 상호작용의 즉시성 유지와 서버 데이터 정합성 확인을 분리하기 위한 구현입니다.
- **파급 효과:** `websiteUrl`은 이번 PR에서 길이 제한만 검증합니다. 실제 링크 렌더링 시 `http`/`https` scheme만 허용하는 정규화 또는 저장 시점 URL 형식 검증은 후속 작업에서 결정할 수 있습니다.

---

## 7. 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일 가이드를 준수합니다.
- [x] 변경 사항에 대한 테스트 코드를 작성하거나 통과했습니다.
- [x] 관련된 문서(README, API 명세 등)를 업데이트했습니다.
