### PR TITLE
[Fix] suggest 페이지 ui 수정

### DIFF
--- a/frontend/src/01_widgets/post/ui/NewSuggestionView.tsx
+++ b/frontend/src/01_widgets/post/ui/NewSuggestionView.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import {
   startTransition,
-  useDeferredValue,
+  useLayoutEffect,
   useRef,
   useState,
   type ReactNode,
@@ -36,13 +36,27 @@ export function NewSuggestionView({
   articleHref: string;
 }) {
   const [composerMode, setComposerMode] = useState<ComposerMode>("edit");
+  const [descriptionMode, setDescriptionMode] = useState<ComposerMode>("edit");
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState(DEFAULT_DESCRIPTION);
   const [body, setBody] = useState(initialValues.originalContent);
+  const descriptionRef = useRef<HTMLTextAreaElement>(null);
   const editorRef = useRef<HTMLTextAreaElement>(null);
 
-  const deferredBody = useDeferredValue(body);
-  const diffRows = buildDiffRows(initialValues.originalContent, deferredBody);
+  useLayoutEffect(() => {
+    if (descriptionMode !== "edit") {
+      return;
+    }
+
+    const textarea = descriptionRef.current;
+    if (!textarea) {
+      return;
+    }
+
+    fitTextareaToContent(textarea);
+  }, [description, descriptionMode]);
+
+  const diffRows = buildDiffRows(initialValues.originalContent, body);
   const hasChanges = diffRows.some((row) => row.kind !== "context");
   const canSubmit =
     title.trim().length > 0 &&
@@ -52,6 +66,12 @@ export function NewSuggestionView({
   function handleModeChange(nextMode: ComposerMode) {
     startTransition(() => {
       setComposerMode(nextMode);
+    });
+  }
+
+  function handleDescriptionModeChange(nextMode: ComposerMode) {
+    startTransition(() => {
+      setDescriptionMode(nextMode);
     });
   }
 
@@ -81,6 +101,33 @@ export function NewSuggestionView({
     });
   }
 
+  function insertDescriptionFormatting(action: ToolbarAction) {
+    const textarea = descriptionRef.current;
+    if (!textarea) {
+      return;
+    }
+
+    const selectionStart = textarea.selectionStart;
+    const selectionEnd = textarea.selectionEnd;
+    const selectedText = description.slice(selectionStart, selectionEnd);
+    const { nextValue, nextSelectionStart, nextSelectionEnd } = formatSelection(
+      action,
+      description,
+      selectedText,
+      selectionStart,
+      selectionEnd,
+    );
+
+    setDescription(nextValue);
+    handleDescriptionModeChange("edit");
+
+    window.requestAnimationFrame(() => {
+      fitTextareaToContent(textarea);
+      textarea.focus();
+      textarea.setSelectionRange(nextSelectionStart, nextSelectionEnd);
+    });
+  }
+
   return (
     <div className="mx-auto w-full max-w-[950px] pb-12">
       <div className="flex items-start gap-15">
@@ -105,10 +152,6 @@ export function NewSuggestionView({
             <h1 className="mt-3 font-serif text-[32px] font-bold leading-[1.15] tracking-tight text-zinc-950">
               Suggest edit for &quot;{initialValues.postTitle}&quot;
             </h1>
-            <p className="mt-3 max-w-[62ch] text-sm leading-6 text-zinc-500">
-              Write the review context first, edit the article body, then check
-              the generated file diff before submitting.
-            </p>
           </header>
 
           <div className="mt-8 space-y-8">
@@ -124,7 +167,7 @@ export function NewSuggestionView({
                 name="title"
                 value={title}
                 onChange={(event) => setTitle(event.target.value)}
-                placeholder="Clarify enum persistence behavior"
+                placeholder="add title"
                 className="h-12 w-full rounded-lg border border-zinc-200 bg-white px-4 text-[16px] font-medium text-zinc-950 outline-none transition placeholder:text-zinc-400 focus:border-zinc-950 focus:ring-2 focus:ring-zinc-900/10"
               />
             </section>
@@ -137,18 +180,59 @@ export function NewSuggestionView({
                 >
                   Description
                 </label>
-                <p className="mt-1 text-sm leading-6 text-zinc-500">
-                  Use this like a pull request description. Explain what changed
-                  and why it should be accepted.
-                </p>
               </div>
-              <textarea
-                id="suggestion-description"
-                name="description"
-                value={description}
-                onChange={(event) => setDescription(event.target.value)}
-                className="min-h-[220px] w-full resize-y rounded-lg border border-zinc-200 bg-white px-4 py-4 font-mono text-[14px] leading-7 text-zinc-900 outline-none transition placeholder:text-zinc-400 focus:border-zinc-950 focus:ring-2 focus:ring-zinc-900/10"
-              />
+
+              <div className="overflow-hidden rounded-lg border border-zinc-200 bg-white shadow-sm">
+                <div className="flex flex-wrap items-center justify-between gap-3 border-b border-zinc-200 bg-zinc-50 px-4 py-2">
+                  <MarkdownToolbar
+                    disabled={descriptionMode === "preview"}
+                    onAction={insertDescriptionFormatting}
+                  />
+                  <div className="rounded-lg bg-zinc-100 p-1">
+                    <div className="flex items-center gap-1">
+                      <ModeButton
+                        active={descriptionMode === "edit"}
+                        icon={<IconEdit className="size-4" />}
+                        label="Edit"
+                        onClick={() => handleDescriptionModeChange("edit")}
+                      />
+                      <ModeButton
+                        active={descriptionMode === "preview"}
+                        icon={<IconEye className="size-4" />}
+                        label="Preview"
+                        onClick={() => handleDescriptionModeChange("preview")}
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                <div className="min-h-[220px] bg-white">
+                  {descriptionMode === "edit" ? (
+                    <textarea
+                      ref={descriptionRef}
+                      id="suggestion-description"
+                      name="description"
+                      value={description}
+                      onChange={(event) => {
+                        setDescription(event.target.value);
+                        fitTextareaToContent(event.currentTarget);
+                      }}
+                      className="min-h-[220px] w-full resize-none overflow-hidden px-4 py-4 font-mono text-[14px] leading-7 text-zinc-900 outline-none transition placeholder:text-zinc-400"
+                    />
+                  ) : (
+                    <article className="min-h-[220px] px-4 py-4">
+                      <MarkdownContent
+                        markdown={description}
+                        emptyFallback={
+                          <p className="text-zinc-400">
+                            Description preview will render here.
+                          </p>
+                        }
+                      />
+                    </article>
+                  )}
+                </div>
+              </div>
             </section>
 
             <section className="overflow-hidden rounded-lg border border-zinc-200 bg-white shadow-sm">
@@ -226,11 +310,24 @@ export function NewSuggestionView({
 
 const DEFAULT_DESCRIPTION = `## Summary
 
--
 
 ## Reason
+`;
 
--`;
+const DESCRIPTION_MIN_HEIGHT = 220;
+const DESCRIPTION_MAX_HEIGHT = 520;
+
+function fitTextareaToContent(textarea: HTMLTextAreaElement) {
+  textarea.style.height = "auto";
+  const nextHeight = Math.min(
+    Math.max(textarea.scrollHeight, DESCRIPTION_MIN_HEIGHT),
+    DESCRIPTION_MAX_HEIGHT,
+  );
+
+  textarea.style.height = `${nextHeight}px`;
+  textarea.style.overflowY =
+    textarea.scrollHeight > DESCRIPTION_MAX_HEIGHT ? "auto" : "hidden";
+}
 
 function ModeButton({
   active,
@@ -268,9 +365,6 @@ function FilesChanged({
   rows: DiffRow[];
   hasChanges: boolean;
 }) {
-  const additions = rows.filter((row) => row.kind === "add").length;
-  const deletions = rows.filter((row) => row.kind === "remove").length;
-
   return (
     <section className="overflow-hidden rounded-lg border border-zinc-200 bg-white shadow-sm">
       <div className="flex flex-wrap items-center justify-between gap-3 border-b border-zinc-200 bg-zinc-50 px-4 py-3">
@@ -279,14 +373,7 @@ function FilesChanged({
             <IconFileDiff className="size-4" />
             Files changed
           </h2>
-          <p className="mt-1 font-mono text-xs text-zinc-500">
-            post.md
-            {hasChanges ? ` · +${additions} -${deletions}` : ""}
-          </p>
         </div>
-        <span className="rounded-full border border-zinc-200 bg-white px-2.5 py-1 font-mono text-[11px] font-medium text-zinc-500">
-          Unified view
-        </span>
       </div>
 
       {hasChanges ? (
@@ -354,10 +441,7 @@ function DiffRowView({ row }: { row: DiffRow }) {
         {row.newLine ?? ""}
       </div>
       <div
-        className={cn(
-          "px-2 py-1.5 text-center font-mono text-xs",
-          markerColor,
-        )}
+        className={cn("px-2 py-1.5 text-center font-mono text-xs", markerColor)}
       >
         {marker}
       </div>
@@ -368,7 +452,10 @@ function DiffRowView({ row }: { row: DiffRow }) {
   );
 }
 
-function buildDiffRows(originalContent: string, nextContent: string): DiffRow[] {
+function buildDiffRows(
+  originalContent: string,
+  nextContent: string,
+): DiffRow[] {
   const originalLines = splitLines(originalContent);
   const nextLines = splitLines(nextContent);
 
@@ -384,10 +471,7 @@ function buildDiffRows(originalContent: string, nextContent: string): DiffRow[] 
   let originalIndex = 0;
   let nextIndex = 0;
 
-  while (
-    originalIndex < originalLines.length ||
-    nextIndex < nextLines.length
-  ) {
+  while (originalIndex < originalLines.length || nextIndex < nextLines.length) {
     if (
       originalIndex < originalLines.length &&
       nextIndex < nextLines.length &&
@@ -443,7 +527,11 @@ function buildCommonSubsequenceLengths(
     Array.from({ length: nextLines.length + 1 }, () => 0),
   );
 
-  for (let originalIndex = originalLines.length - 1; originalIndex >= 0; originalIndex -= 1) {
+  for (
+    let originalIndex = originalLines.length - 1;
+    originalIndex >= 0;
+    originalIndex -= 1
+  ) {
     for (let nextIndex = nextLines.length - 1; nextIndex >= 0; nextIndex -= 1) {
       commonLengths[originalIndex][nextIndex] =
         originalLines[originalIndex] === nextLines[nextIndex]
@@ -569,9 +657,24 @@ function IconFileDiff({ className }: { className?: string }) {
         strokeLinecap="round"
         strokeLinejoin="round"
       />
-      <path d="M9 13h6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-      <path d="M12 10v6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-      <path d="M9 18h6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      <path
+        d="M9 13h6"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <path
+        d="M12 10v6"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <path
+        d="M9 18h6"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
     </svg>
   );
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #

---

## 1. PR 유형
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ✨ 새로운 기능 (New Feature)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 업데이트 (Documentation)
- [ ] ⚙️ 설정/빌드 변경 (Chore)

---

## 2. 작업 배경 및 목적
- **기존 상태:** suggest 작성 화면의 description은 단순 textarea로만 제공되어 본문 editor와 Markdown 작성 경험이 달랐습니다. Files changed 헤더에는 `post.md`, `Unified view` 같은 보조 라벨도 함께 표시됐습니다.
- **문제점:** 사용자는 suggestion 설명을 Markdown으로 작성해도 제출 전 렌더링 결과를 같은 위치에서 확인할 수 없었고, description 입력량이 많아질 때 편집 영역의 높이 제어도 본문 editor와 일관되지 않았습니다.
- **해결 목표:** description 작성 영역을 본문 editor와 같은 Markdown toolbar + Edit/Preview 구조로 맞추고, 입력 높이는 본문 영역 높이까지만 자동 확장한 뒤 내부 스크롤로 전환되게 정리합니다.

---

## 3. 상세 변경 내역 및 동작 흐름

### A. Description Markdown 편집/미리보기 UI 추가
- **진입점 및 초기 조건:** `frontend/src/01_widgets/post/ui/NewSuggestionView.tsx`가 suggest 작성 화면을 렌더링할 때 `descriptionMode` 상태와 `descriptionRef`를 초기화합니다.
- **단계별 제어 흐름:**
  1. description 영역은 content editor와 동일한 카드형 header 안에 `MarkdownToolbar`, `Edit`, `Preview` 버튼을 렌더링합니다.
  2. 사용자가 toolbar 버튼을 누르면 `insertDescriptionFormatting()`이 현재 textarea 선택 범위를 읽고 `formatSelection()` 결과를 description 상태에 반영합니다.
  3. `Preview` 모드에서는 `MarkdownContent`가 description Markdown을 렌더링하고, `Edit` 모드에서는 textarea를 다시 표시합니다.
- **데이터 상태 변이:** description 문자열은 기존 단일 textarea 입력값에서 Markdown formatting과 preview mode를 함께 반영하는 상태로 확장됩니다. 기본 템플릿은 `## Summary`와 `## Reason`만 남기고 placeholder dash를 제거했습니다.
- **최종 반환 및 종료 상태:** 사용자는 suggestion 설명을 Markdown으로 작성하고 같은 영역에서 즉시 preview 결과를 확인할 수 있습니다.

### B. Description 높이 제어와 Files changed 헤더 정리
- **진입점 및 초기 조건:** description textarea가 edit mode로 렌더링되거나 값이 변경될 때 `fitTextareaToContent()`가 실행됩니다.
- **단계별 제어 흐름:**
  1. textarea 높이를 `auto`로 초기화한 뒤 `scrollHeight`를 읽습니다.
  2. 높이는 최소 `220px`, 최대 `520px` 범위로 고정합니다.
  3. 내용 높이가 `520px`를 넘으면 `overflowY`를 `auto`로 전환해 내부 스크롤을 사용합니다.
  4. `FilesChanged` 헤더에서는 `post.md`, 변경 건수, `Unified view` 보조 라벨을 제거합니다.
- **데이터 상태 변이:** description 입력 길이에 따라 DOM textarea height style과 overflow style이 계산됩니다. diff row 데이터 자체는 변경하지 않고 헤더 표시만 단순화합니다.
- **최종 반환 및 종료 상태:** description 입력 영역은 content editor 높이와 같은 최대 크기까지만 확장되고, Files changed 섹션은 제목 중심으로 간결하게 표시됩니다.

---

## 4. 스크린샷 (선택)
- 없음

## 5. 테스트 및 검증 방법
- **테스트 환경:** macOS 로컬 환경, `feature/suggest-ui` 브랜치, Next.js dev server `localhost:3030`
- **입력 시나리오:**
  1. `cd frontend && pnpm lint`
  2. Playwright로 suggest 작성 페이지에서 description toolbar Bold 적용, Preview/Edit 전환 검증
  3. Playwright로 긴 description 입력 시 높이 `220px -> 520px`, `overflowY: auto` 전환 검증
- **출력 검증:** `pnpm lint`는 에러 없이 종료됐고 기존 `frontend/src/01_widgets/onboarding/ui/OnboardingView.tsx`의 unused `Image` warning 1건만 보고했습니다. Playwright 검증은 `DESCRIPTION_MARKDOWN_HEADER_OK`, `DESCRIPTION_MAX_SCROLL_OK`로 통과했습니다.

---

## 6. 리뷰어 참고 사항 (선택)
- **특이 구현 사항:** description textarea 높이 제어는 React state가 아니라 DOM `scrollHeight` 기반 inline style로 처리합니다.
- **파급 효과:** suggestion 저장 API나 diff 계산 로직은 변경하지 않았으며, 작성 화면의 description UX와 Files changed 헤더 표시만 변경 범위에 포함됩니다.

---

## 7. 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일 가이드를 준수합니다.
- [x] 변경 사항에 대한 테스트 코드를 작성하거나 통과했습니다.
- [x] 관련된 문서(README, API 명세 등)를 업데이트했습니다.
