### PR TITLE
[Feat] Discussion 기능 구현

### DIFF
--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthController.kt
@@ -40,7 +40,7 @@ class AuthController(
     fun getMe(
         request: HttpServletRequest
     ): MeResponse {
-        val meUser = authService.getCurrentUser(currentUserResolver.resolveUserIdFromJwt(request))
+        val meUser = currentUserResolver.resolveCurrentUser(request)
 
         return meUser.toMeResponse() // 코틀린 확장 함수 (메서드 아님)
     }
@@ -50,12 +50,13 @@ class AuthController(
         request: HttpServletRequest,
         @Valid @RequestBody onboardingRequest: CompleteOnboardingRequest,
     ): MeResponse {
-        val currentUser = authService.completeOnboarding(
-            userId = currentUserResolver.resolveUserIdFromJwt(request),
+        val currentUser = currentUserResolver.resolveCurrentUser(request)
+        val onboardedUser = authService.completeOnboarding(
+            userId = requireNotNull(currentUser.id),
             request = onboardingRequest,
         )
 
-        return currentUser.toMeResponse()
+        return onboardedUser.toMeResponse()
     }
 
     @GetMapping("google")

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/CurrentUserResolver.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/CurrentUserResolver.kt
@@ -1,13 +1,17 @@
 package io.github.kitae9999.openlog.auth
 
 import io.github.kitae9999.openlog.auth.exception.OAuthAuthenticationException
+import io.github.kitae9999.openlog.user.entity.User
+import io.github.kitae9999.openlog.user.repository.UserRepository
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
+import kotlin.jvm.optionals.getOrNull
 
 @Component
 class CurrentUserResolver(
     private val jwtTokenService: JwtTokenService,
+    private val userRepository: UserRepository,
     @Value("\${auth.jwt.cookie-name:openlog_access_token}")
     private val accessTokenCookieName: String,
 ) {
@@ -20,5 +24,9 @@ class CurrentUserResolver(
         return jwtTokenService.parseUserId(accessToken)
     }
 
-
+    fun resolveCurrentUser(request: HttpServletRequest): User {
+        val userId = resolveUserIdFromJwt(request)
+        return userRepository.findById(userId).getOrNull()
+            ?: throw OAuthAuthenticationException()
+    }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/comment/CommentController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/comment/CommentController.kt
@@ -31,9 +31,9 @@ class CommentController(
         @Valid @RequestBody createCommentRequest: CreateCommentRequest,
         request: HttpServletRequest,
     ): ResponseEntity<CommentResponse> {
-        val currentUserId = currentUserResolver.resolveUserIdFromJwt(request)
+        val currentUser = currentUserResolver.resolveCurrentUser(request)
         val content = createCommentRequest.content
-        val createdComment = commentService.createComment(currentUserId, postId, content)
+        val createdComment = commentService.createComment(currentUser, postId, content)
 
         return ResponseEntity.status(201).body(createdComment)
     }
@@ -60,8 +60,8 @@ class CommentController(
         @PathVariable postId: Long,
         request: HttpServletRequest,
     ): ResponseEntity<Void> {
-        val userId = currentUserResolver.resolveUserIdFromJwt(request)
-        commentService.deleteComment(userId, postId, commentId)
+        val currentUser = currentUserResolver.resolveCurrentUser(request)
+        commentService.deleteComment(requireNotNull(currentUser.id), postId, commentId)
         return ResponseEntity.noContent().build()
     }
 
@@ -72,9 +72,9 @@ class CommentController(
         @Valid @RequestBody updateCommentRequest: UpdateCommentRequest,
         request: HttpServletRequest,
     ): ResponseEntity<CommentResponse> {
-        val userId = currentUserResolver.resolveUserIdFromJwt(request)
+        val currentUser = currentUserResolver.resolveCurrentUser(request)
         val updatedComment = commentService.updateComment(
-            userId,
+            requireNotNull(currentUser.id),
             postId,
             commentId,
             updateCommentRequest.content,

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/comment/CommentService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/comment/CommentService.kt
@@ -8,7 +8,6 @@ import io.github.kitae9999.openlog.common.exception.ForbiddenException
 import io.github.kitae9999.openlog.common.exception.NotFoundException
 import io.github.kitae9999.openlog.post.repository.PostRepository
 import io.github.kitae9999.openlog.user.entity.User
-import io.github.kitae9999.openlog.user.repository.UserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import kotlin.jvm.optionals.getOrNull
@@ -17,11 +16,9 @@ import kotlin.jvm.optionals.getOrNull
 class CommentService(
     private val commentRepository: CommentRepository,
     private val postRepository: PostRepository,
-    private val userRepository: UserRepository
 ) {
     @Transactional
-    fun createComment(userId: Long, postId: Long, content: String): CommentResponse {
-        val author = userRepository.findById(userId).getOrNull() ?: throw NotFoundException("사용자를 찾을 수 없습니다.")
+    fun createComment(author: User, postId: Long, content: String): CommentResponse {
         val post = postRepository.findById(postId).getOrNull() ?: throw NotFoundException("포스트를 찾을 수 없습니다.")
 
         val savedComment = commentRepository.save(
@@ -32,7 +29,7 @@ class CommentService(
             )
         )
 
-        return toCommentResponse(savedComment, userId = userId)
+        return toCommentResponse(savedComment, userId = requireNotNull(author.id))
     }
 
     /**

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/DiscussionController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/DiscussionController.kt
@@ -1,0 +1,35 @@
+package io.github.kitae9999.openlog.discussion
+
+import io.github.kitae9999.openlog.auth.CurrentUserResolver
+import io.github.kitae9999.openlog.discussion.dto.WriteDiscussionRequest
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/posts/{postId}/suggestions/{suggestionId}/discussions")
+class DiscussionController(
+    private val discussionService: DiscussionService,
+    private val currentUserResolver: CurrentUserResolver
+) {
+
+    @PostMapping()
+    fun createDiscussion(
+        request: HttpServletRequest,
+        @RequestBody createDiscussionRequest: WriteDiscussionRequest,
+        @PathVariable postId: Long,
+        @PathVariable suggestionId: Long,
+    ){
+        val currentUser = currentUserResolver.resolveCurrentUser(request)
+
+        discussionService.createDiscussion(
+            currentUser = currentUser,
+            postId = postId,
+            suggestionId = suggestionId,
+            content = createDiscussionRequest.content
+        )
+    }
+}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/DiscussionController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/DiscussionController.kt
@@ -5,6 +5,8 @@ import io.github.kitae9999.openlog.discussion.dto.DiscussionResponse
 import io.github.kitae9999.openlog.discussion.dto.WriteDiscussionRequest
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -35,5 +37,33 @@ class DiscussionController(
         )
 
         return ResponseEntity.status(201).body(discussion)
+    }
+
+    @DeleteMapping("{discussionId}")
+    fun deleteDiscussion(
+        request: HttpServletRequest,
+        @PathVariable postId: Long,
+        @PathVariable suggestionId: Long,
+        @PathVariable discussionId: Long,
+    ){
+        val currentUser = currentUserResolver.resolveCurrentUser(request)
+
+        discussionService.deleteDiscussion(
+            currentUser = currentUser,
+            postId = postId,
+            suggestionId = suggestionId,
+            discussionId = discussionId
+        )
+
+    }
+
+    @PatchMapping("{discussionId}")
+    fun updateDiscussion(
+        request: HttpServletRequest,
+        @PathVariable postId: Long,
+        @PathVariable suggestionId: Long,
+        @PathVariable discussionId: Long,
+    ){
+
     }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/DiscussionController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/DiscussionController.kt
@@ -4,6 +4,7 @@ import io.github.kitae9999.openlog.auth.CurrentUserResolver
 import io.github.kitae9999.openlog.discussion.dto.DiscussionResponse
 import io.github.kitae9999.openlog.discussion.dto.WriteDiscussionRequest
 import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -23,7 +24,7 @@ class DiscussionController(
     @PostMapping()
     fun createDiscussion(
         request: HttpServletRequest,
-        @RequestBody createDiscussionRequest: WriteDiscussionRequest,
+        @Valid @RequestBody createDiscussionRequest: WriteDiscussionRequest,
         @PathVariable postId: Long,
         @PathVariable suggestionId: Long,
     ): ResponseEntity<DiscussionResponse> {
@@ -45,25 +46,36 @@ class DiscussionController(
         @PathVariable postId: Long,
         @PathVariable suggestionId: Long,
         @PathVariable discussionId: Long,
-    ){
+    ): ResponseEntity<Void> {
         val currentUser = currentUserResolver.resolveCurrentUser(request)
 
         discussionService.deleteDiscussion(
-            currentUser = currentUser,
+            userId = requireNotNull(currentUser.id),
             postId = postId,
             suggestionId = suggestionId,
             discussionId = discussionId
         )
 
+        return ResponseEntity.noContent().build()
     }
 
     @PatchMapping("{discussionId}")
     fun updateDiscussion(
         request: HttpServletRequest,
+        @Valid @RequestBody updateDiscussionRequest: WriteDiscussionRequest,
         @PathVariable postId: Long,
         @PathVariable suggestionId: Long,
         @PathVariable discussionId: Long,
-    ){
+    ): ResponseEntity<DiscussionResponse> {
+        val currentUser = currentUserResolver.resolveCurrentUser(request)
+        val updatedDiscussion = discussionService.updateDiscussion(
+            userId = requireNotNull(currentUser.id),
+            postId = postId,
+            suggestionId = suggestionId,
+            discussionId = discussionId,
+            content = updateDiscussionRequest.content,
+        )
 
+        return ResponseEntity.ok(updatedDiscussion)
     }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/DiscussionController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/DiscussionController.kt
@@ -1,8 +1,10 @@
 package io.github.kitae9999.openlog.discussion
 
 import io.github.kitae9999.openlog.auth.CurrentUserResolver
+import io.github.kitae9999.openlog.discussion.dto.DiscussionResponse
 import io.github.kitae9999.openlog.discussion.dto.WriteDiscussionRequest
 import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -22,14 +24,16 @@ class DiscussionController(
         @RequestBody createDiscussionRequest: WriteDiscussionRequest,
         @PathVariable postId: Long,
         @PathVariable suggestionId: Long,
-    ){
+    ): ResponseEntity<DiscussionResponse> {
         val currentUser = currentUserResolver.resolveCurrentUser(request)
 
-        discussionService.createDiscussion(
+        val discussion = discussionService.createDiscussion(
             currentUser = currentUser,
             postId = postId,
             suggestionId = suggestionId,
             content = createDiscussionRequest.content
         )
+
+        return ResponseEntity.status(201).body(discussion)
     }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/DiscussionService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/DiscussionService.kt
@@ -1,6 +1,7 @@
 package io.github.kitae9999.openlog.discussion
 
 import io.github.kitae9999.openlog.common.exception.NotFoundException
+import io.github.kitae9999.openlog.discussion.dto.DiscussionResponse
 import io.github.kitae9999.openlog.discussion.entity.Discussion
 import io.github.kitae9999.openlog.discussion.repository.DiscussionRepository
 import io.github.kitae9999.openlog.suggest.repository.SuggestionRepository
@@ -19,16 +20,41 @@ class DiscussionService (
         postId: Long,
         suggestionId: Long,
         content: String
-    ): Discussion{
+    ): DiscussionResponse {
         val suggestion = suggestionRepository.findByIdAndPostId(suggestionId, postId)
             ?: throw NotFoundException("포스트에 존재하지 않는 Suggestion입니다.")
 
-        return discussionRepository.save(
+        val discussion = discussionRepository.save(
             Discussion(
                 suggestion = suggestion,
                 user = currentUser,
                 content = content,
             )
         )
+
+        return toDiscussionResponse(discussion, requireNotNull(currentUser.id))
+    }
+
+    fun toDiscussionResponse(discussion: Discussion, currentUserId: Long?): DiscussionResponse {
+        val author = discussion.user
+        val authorId = requireNotNull(author.id)
+
+        return DiscussionResponse(
+            id = requireNotNull(discussion.id),
+            authorName = resolveAuthorName(author),
+            authorProfileImageUrl = author.profileImageUrl,
+            content = discussion.content,
+            createdAt = discussion.createdAt.toString(),
+            canManage = currentUserId == authorId,
+        )
+    }
+
+    private fun resolveAuthorName(user: User): String {
+        return when {
+            !user.nickname.isNullOrBlank() -> user.nickname.orEmpty()
+            !user.username.isNullOrBlank() -> user.username.orEmpty()
+            !user.email.isNullOrBlank() -> user.email.orEmpty()
+            else -> "OpenLog member"
+        }
     }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/DiscussionService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/DiscussionService.kt
@@ -1,5 +1,6 @@
 package io.github.kitae9999.openlog.discussion
 
+import io.github.kitae9999.openlog.common.exception.ForbiddenException
 import io.github.kitae9999.openlog.common.exception.NotFoundException
 import io.github.kitae9999.openlog.discussion.dto.DiscussionResponse
 import io.github.kitae9999.openlog.discussion.entity.Discussion
@@ -33,6 +34,29 @@ class DiscussionService (
         )
 
         return toDiscussionResponse(discussion, requireNotNull(currentUser.id))
+    }
+    @Transactional
+    fun deleteDiscussion(
+        currentUser: User, // User는 검증 완료
+        postId: Long,
+        suggestionId: Long,
+        discussionId: Long,
+    ){
+        val discussion = discussionRepository.findWithUserByIdAndSuggestionIdAndPostId(
+            discussionId = discussionId,
+            suggestionId = suggestionId,
+            postId = postId,
+        ) ?: throw NotFoundException("Discussion을 찾을 수 없습니다.")
+
+        if (discussion.user.id != currentUser.id) {
+            throw ForbiddenException("권한이 없습니다.")
+        }
+
+        discussionRepository.delete(discussion)
+    }
+
+    fun updateDiscussion(){
+
     }
 
     fun toDiscussionResponse(discussion: Discussion, currentUserId: Long?): DiscussionResponse {

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/DiscussionService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/DiscussionService.kt
@@ -37,26 +37,27 @@ class DiscussionService (
     }
     @Transactional
     fun deleteDiscussion(
-        currentUser: User, // User는 검증 완료
+        userId: Long,
         postId: Long,
         suggestionId: Long,
         discussionId: Long,
     ){
-        val discussion = discussionRepository.findWithUserByIdAndSuggestionIdAndPostId(
-            discussionId = discussionId,
-            suggestionId = suggestionId,
-            postId = postId,
-        ) ?: throw NotFoundException("Discussion을 찾을 수 없습니다.")
-
-        if (discussion.user.id != currentUser.id) {
-            throw ForbiddenException("권한이 없습니다.")
-        }
-
+        val discussion = getManageableDiscussion(userId, postId, suggestionId, discussionId)
         discussionRepository.delete(discussion)
     }
 
-    fun updateDiscussion(){
+    @Transactional
+    fun updateDiscussion(
+        userId: Long,
+        postId: Long,
+        suggestionId: Long,
+        discussionId: Long,
+        content: String,
+    ): DiscussionResponse {
+        val discussion = getManageableDiscussion(userId, postId, suggestionId, discussionId)
+        discussion.updateContent(content)
 
+        return toDiscussionResponse(discussion, userId)
     }
 
     fun toDiscussionResponse(discussion: Discussion, currentUserId: Long?): DiscussionResponse {
@@ -80,5 +81,24 @@ class DiscussionService (
             !user.email.isNullOrBlank() -> user.email.orEmpty()
             else -> "OpenLog member"
         }
+    }
+
+    private fun getManageableDiscussion(
+        userId: Long,
+        postId: Long,
+        suggestionId: Long,
+        discussionId: Long,
+    ): Discussion {
+        val discussion = discussionRepository.findWithUserByIdAndSuggestionIdAndPostId(
+            discussionId = discussionId,
+            suggestionId = suggestionId,
+            postId = postId,
+        ) ?: throw NotFoundException("Discussion을 찾을 수 없습니다.")
+
+        if (discussion.user.id != userId) {
+            throw ForbiddenException("권한이 없습니다.")
+        }
+
+        return discussion
     }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/DiscussionService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/DiscussionService.kt
@@ -1,0 +1,34 @@
+package io.github.kitae9999.openlog.discussion
+
+import io.github.kitae9999.openlog.common.exception.NotFoundException
+import io.github.kitae9999.openlog.discussion.entity.Discussion
+import io.github.kitae9999.openlog.discussion.repository.DiscussionRepository
+import io.github.kitae9999.openlog.suggest.repository.SuggestionRepository
+import io.github.kitae9999.openlog.user.entity.User
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class DiscussionService (
+    private val discussionRepository: DiscussionRepository,
+    private val suggestionRepository: SuggestionRepository,
+){
+    @Transactional
+    fun createDiscussion(
+        currentUser: User,
+        postId: Long,
+        suggestionId: Long,
+        content: String
+    ): Discussion{
+        val suggestion = suggestionRepository.findByIdAndPostId(suggestionId, postId)
+            ?: throw NotFoundException("포스트에 존재하지 않는 Suggestion입니다.")
+
+        return discussionRepository.save(
+            Discussion(
+                suggestion = suggestion,
+                user = currentUser,
+                content = content,
+            )
+        )
+    }
+}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/dto/DiscussionResponse.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/dto/DiscussionResponse.kt
@@ -1,0 +1,10 @@
+package io.github.kitae9999.openlog.discussion.dto
+
+data class DiscussionResponse(
+    val id: Long,
+    val authorName: String,
+    val authorProfileImageUrl: String?,
+    val content: String,
+    val createdAt: String,
+    val canManage: Boolean,
+)

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/dto/WriteDiscussionRequest.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/dto/WriteDiscussionRequest.kt
@@ -1,5 +1,8 @@
 package io.github.kitae9999.openlog.discussion.dto
 
+import jakarta.validation.constraints.NotBlank
+
 data class WriteDiscussionRequest(
+    @field:NotBlank(message = "댓글 내용은 필수입니다.")
     val content: String
 )

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/dto/WriteDiscussionRequest.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/dto/WriteDiscussionRequest.kt
@@ -1,0 +1,5 @@
+package io.github.kitae9999.openlog.discussion.dto
+
+data class WriteDiscussionRequest(
+    val content: String
+)

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/entity/Discussion.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/entity/Discussion.kt
@@ -1,0 +1,56 @@
+package io.github.kitae9999.openlog.discussion.entity
+
+import io.github.kitae9999.openlog.suggest.entity.Suggestion
+import io.github.kitae9999.openlog.user.entity.User
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "discussions")
+class Discussion(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+    suggestion: Suggestion,
+    user: User,
+    content: String,
+) {
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "suggestion_id", nullable = false)
+    var suggestion: Suggestion = suggestion
+        protected set
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    var user: User = user
+        protected set
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    var content: String = content
+        protected set
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now()
+        protected set
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+        protected set
+
+    fun updateContent(content: String) {
+        if (this.content == content) {
+            return
+        }
+
+        this.content = content
+        this.updatedAt = LocalDateTime.now()
+    }
+}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/repository/DiscussionRepository.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/repository/DiscussionRepository.kt
@@ -2,5 +2,20 @@ package io.github.kitae9999.openlog.discussion.repository
 
 import io.github.kitae9999.openlog.discussion.entity.Discussion
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
-interface DiscussionRepository : JpaRepository<Discussion, Long>
+interface DiscussionRepository : JpaRepository<Discussion, Long> {
+    @Query(
+        """
+        select d
+        from Discussion d
+        join fetch d.user
+        where d.suggestion.id = :suggestionId
+        order by d.createdAt asc
+        """
+    )
+    fun findAllWithUserBySuggestionId(@Param("suggestionId") suggestionId: Long): List<Discussion>
+
+    fun countBySuggestionId(suggestionId: Long): Long
+}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/repository/DiscussionRepository.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/repository/DiscussionRepository.kt
@@ -1,0 +1,6 @@
+package io.github.kitae9999.openlog.discussion.repository
+
+import io.github.kitae9999.openlog.discussion.entity.Discussion
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface DiscussionRepository : JpaRepository<Discussion, Long>

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/repository/DiscussionRepository.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/discussion/repository/DiscussionRepository.kt
@@ -17,5 +17,21 @@ interface DiscussionRepository : JpaRepository<Discussion, Long> {
     )
     fun findAllWithUserBySuggestionId(@Param("suggestionId") suggestionId: Long): List<Discussion>
 
+    @Query(
+        """
+        select d
+        from Discussion d
+        join fetch d.user
+        where d.id = :discussionId
+          and d.suggestion.id = :suggestionId
+          and d.suggestion.post.id = :postId
+        """
+    )
+    fun findWithUserByIdAndSuggestionIdAndPostId(
+        @Param("discussionId") discussionId: Long,
+        @Param("suggestionId") suggestionId: Long,
+        @Param("postId") postId: Long,
+    ): Discussion?
+
     fun countBySuggestionId(suggestionId: Long): Long
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostController.kt
@@ -26,9 +26,9 @@ class PostController(
         request: HttpServletRequest,
         @Valid @RequestBody postWriteRequest: PostWriteRequest
     ): ResponseEntity<PostWriteResponse> {
-        val userId = currentUserResolver.resolveUserIdFromJwt(request)
+        val currentUser = currentUserResolver.resolveCurrentUser(request)
         val (title, description, content, topics) = postWriteRequest
-        val createdPost = postService.createPost(userId, PostWriteCommand(
+        val createdPost = postService.createPost(currentUser, PostWriteCommand(
             title = title,
             description = description,
             content = content,
@@ -43,9 +43,9 @@ class PostController(
         @PathVariable postId: Long,
         request: HttpServletRequest,
     ): ResponseEntity<Void>{
-        val userId = currentUserResolver.resolveUserIdFromJwt(request)
+        val currentUser = currentUserResolver.resolveCurrentUser(request)
 
-        postService.deletePost(userId, postId)
+        postService.deletePost(requireNotNull(currentUser.id), postId)
 
         return ResponseEntity.noContent().build()
     }
@@ -57,10 +57,10 @@ class PostController(
         request: HttpServletRequest,
         @Valid @RequestBody postWriteRequest: PostWriteRequest,
     ): ResponseEntity<PostWriteResponse> {
-        val userId = currentUserResolver.resolveUserIdFromJwt(request)
+        val currentUser = currentUserResolver.resolveCurrentUser(request)
         val (title, description, content, topics) = postWriteRequest
         val updatedPost = postService.updatePost(
-            userId,
+            requireNotNull(currentUser.id),
             postId,
             PostWriteCommand(
                 title = title,

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostService.kt
@@ -11,7 +11,7 @@ import io.github.kitae9999.openlog.posttopic.repository.PostTopicRepository
 import io.github.kitae9999.openlog.suggest.repository.SuggestionRepository
 import io.github.kitae9999.openlog.topic.entity.Topic
 import io.github.kitae9999.openlog.topic.repository.TopicRepository
-import io.github.kitae9999.openlog.user.repository.UserRepository
+import io.github.kitae9999.openlog.user.entity.User
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import kotlin.jvm.optionals.getOrNull
@@ -22,11 +22,10 @@ class PostService(
     private val postTopicRepository: PostTopicRepository,
     private val suggestionRepository: SuggestionRepository,
     private val topicRepository: TopicRepository,
-    private val userRepository: UserRepository,
 ) {
     @Transactional
-    fun createPost(userId: Long, postWriteCommand: PostWriteCommand): PostWriteResponse {
-        val user = userRepository.findById(userId).getOrNull() ?: throw NotFoundException("사용자를 찾을 수 없습니다.")
+    fun createPost(user: User, postWriteCommand: PostWriteCommand): PostWriteResponse {
+        val userId = requireNotNull(user.id)
         val authorUsername = user.username?.trim().orEmpty()
         if (authorUsername.isBlank()) {
             throw NotFoundException("username이 설정된 사용자를 찾을 수 없습니다.")

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/postlike/PostLikeController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/postlike/PostLikeController.kt
@@ -19,7 +19,7 @@ class PostLikeController(
         @PathVariable postId: Long,
         request: HttpServletRequest
     ): Boolean {
-        val userId = currentUserResolver.resolveUserIdFromJwt(request)
-        return postLikeService.toggleLike(userId, postId)
+        val currentUser = currentUserResolver.resolveCurrentUser(request)
+        return postLikeService.toggleLike(currentUser, postId)
     }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/postlike/PostLikeService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/postlike/PostLikeService.kt
@@ -3,7 +3,7 @@ package io.github.kitae9999.openlog.postlike
 import io.github.kitae9999.openlog.common.exception.NotFoundException
 import io.github.kitae9999.openlog.post.repository.PostRepository
 import io.github.kitae9999.openlog.postlike.entity.PostLike
-import io.github.kitae9999.openlog.user.repository.UserRepository
+import io.github.kitae9999.openlog.user.entity.User
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 
@@ -11,11 +11,11 @@ import org.springframework.stereotype.Service
 class PostLikeService(
     private val postLikeRepository: PostLikeRepository,
     private val postRepository: PostRepository,
-    private val userRepository: UserRepository
 ) {
 
     @Transactional
-    fun toggleLike(userId: Long, postId: Long): Boolean {
+    fun toggleLike(user: User, postId: Long): Boolean {
+        val userId = requireNotNull(user.id)
         val postLike = postLikeRepository.findByPostIdAndUserId(postId, userId)
 
         if (postLike != null) {
@@ -27,7 +27,6 @@ class PostLikeService(
             }
 
             val post = postRepository.getReferenceById(postId)
-            val user = userRepository.getReferenceById(userId)
 
             postLikeRepository.save(
                 PostLike(

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/suggest/SuggestController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/suggest/SuggestController.kt
@@ -34,9 +34,9 @@ class SuggestController(
         @RequestBody createSuggestionRequest: WriteSuggestionRequest,
         request: HttpServletRequest
     ){
-        val userId = currentUserResolver.resolveUserIdFromJwt(request)
+        val currentUser = currentUserResolver.resolveCurrentUser(request)
         val (title, description, content) = createSuggestionRequest
-        suggestService.createPostSuggestion(userId, postId, title, description, content)
+        suggestService.createPostSuggestion(currentUser, postId, title, description, content)
     }
 
     @GetMapping("/posts/{postId}/suggestions/{suggestionId}")
@@ -54,11 +54,11 @@ class SuggestController(
         request: HttpServletRequest,
         @RequestBody manageSuggestionRequest: ManageSuggestionRequest,
     ): ResponseEntity<Void> {
-        val userId = currentUserResolver.resolveUserIdFromJwt(request)
+        val currentUser = currentUserResolver.resolveCurrentUser(request)
         val action = manageSuggestionRequest.action
 
         suggestService.manageSuggestion(
-            userId = userId,
+            userId = requireNotNull(currentUser.id),
             postId = postId,
             suggestionId = suggestionId,
             action = action
@@ -74,9 +74,9 @@ class SuggestController(
         request: HttpServletRequest,
         @RequestBody updateSuggestionRequest: WriteSuggestionRequest
     ): ResponseEntity<Void>{
-        val userId = currentUserResolver.resolveUserIdFromJwt(request)
+        val currentUser = currentUserResolver.resolveCurrentUser(request)
         suggestService.updateSuggestion(
-            userId = userId,
+            userId = requireNotNull(currentUser.id),
             postId = postId,
             suggestionId = suggestionId,
             title = updateSuggestionRequest.title,

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/suggest/SuggestController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/suggest/SuggestController.kt
@@ -1,6 +1,7 @@
 package io.github.kitae9999.openlog.suggest
 
 import io.github.kitae9999.openlog.auth.CurrentUserResolver
+import io.github.kitae9999.openlog.auth.exception.OAuthAuthenticationException
 import io.github.kitae9999.openlog.suggest.dto.WriteSuggestionRequest
 import io.github.kitae9999.openlog.suggest.dto.ManageSuggestionRequest
 import io.github.kitae9999.openlog.suggest.dto.SuggestionDetailResponse
@@ -43,8 +44,13 @@ class SuggestController(
     fun getSuggestionDetail(
         @PathVariable postId: Long,
         @PathVariable suggestionId: Long,
+        request: HttpServletRequest,
     ): SuggestionDetailResponse {
-        return suggestService.getSuggestionDetail(postId, suggestionId)
+        return suggestService.getSuggestionDetail(
+            postId = postId,
+            suggestionId = suggestionId,
+            currentUserId = resolveCurrentUserIdOrNull(request),
+        )
     }
 
     @PostMapping("/posts/{postId}/suggestions/{suggestionId}/resolutions")
@@ -85,5 +91,13 @@ class SuggestController(
         )
 
         return ResponseEntity.noContent().build()
+    }
+
+    private fun resolveCurrentUserIdOrNull(request: HttpServletRequest): Long? {
+        return try {
+            currentUserResolver.resolveCurrentUser(request).id
+        } catch (e: OAuthAuthenticationException) {
+            null
+        }
     }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/suggest/SuggestService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/suggest/SuggestService.kt
@@ -3,6 +3,8 @@ package io.github.kitae9999.openlog.suggest
 import io.github.kitae9999.openlog.common.exception.BadRequestException
 import io.github.kitae9999.openlog.common.exception.ForbiddenException
 import io.github.kitae9999.openlog.common.exception.NotFoundException
+import io.github.kitae9999.openlog.discussion.DiscussionService
+import io.github.kitae9999.openlog.discussion.repository.DiscussionRepository
 import io.github.kitae9999.openlog.post.repository.PostRepository
 import io.github.kitae9999.openlog.suggest.dto.SuggestionDetailResponse
 import io.github.kitae9999.openlog.suggest.dto.SuggestionSummaryResponse
@@ -18,7 +20,9 @@ import kotlin.jvm.optionals.getOrNull
 @Service
 class SuggestService(
     val postRepository: PostRepository,
-    val suggestionRepository: SuggestionRepository
+    val suggestionRepository: SuggestionRepository,
+    private val discussionRepository: DiscussionRepository,
+    private val discussionService: DiscussionService,
 ) {
     @Transactional
     fun getPostSuggestions(postId: Long): List<SuggestionSummaryResponse> {
@@ -35,7 +39,7 @@ class SuggestService(
                 authorProfileImageUrl = suggestion.user.profileImageUrl,
                 createdAt = suggestion.createdAt,
                 updatedAt = suggestion.updatedAt,
-                commentCount = 0,
+                commentCount = discussionRepository.countBySuggestionId(requireNotNull(suggestion.id)).toInt(),
             )
         }
     }
@@ -65,10 +69,12 @@ class SuggestService(
     @Transactional
     fun getSuggestionDetail(
         postId: Long,
-        suggestionId: Long
+        suggestionId: Long,
+        currentUserId: Long?,
     ): SuggestionDetailResponse {
         val suggestion = suggestionRepository.findDetailWithUserByIdAndPostId(suggestionId, postId)
             ?: throw NotFoundException("포스트에 존재하지 않는 Suggestion입니다.")
+        val discussions = discussionRepository.findAllWithUserBySuggestionId(suggestionId)
 
         return SuggestionDetailResponse(
             id = requireNotNull(suggestion.id),
@@ -84,6 +90,9 @@ class SuggestService(
             authorProfileImageUrl = suggestion.user.profileImageUrl,
             createdAt = suggestion.createdAt,
             postBaseVersion = suggestion.postBaseVersion,
+            discussions = discussions.map { discussion ->
+                discussionService.toDiscussionResponse(discussion, currentUserId)
+            },
         )
     }
 

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/suggest/SuggestService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/suggest/SuggestService.kt
@@ -10,14 +10,13 @@ import io.github.kitae9999.openlog.suggest.entity.Suggestion
 import io.github.kitae9999.openlog.suggest.entity.SuggestionAction
 import io.github.kitae9999.openlog.suggest.entity.SuggestionStatus
 import io.github.kitae9999.openlog.suggest.repository.SuggestionRepository
-import io.github.kitae9999.openlog.user.repository.UserRepository
+import io.github.kitae9999.openlog.user.entity.User
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import kotlin.jvm.optionals.getOrNull
 
 @Service
 class SuggestService(
-    val userRepository: UserRepository,
     val postRepository: PostRepository,
     val suggestionRepository: SuggestionRepository
 ) {
@@ -43,19 +42,17 @@ class SuggestService(
 
     @Transactional
     fun createPostSuggestion(
-        userId: Long,
+        user: User,
         postId: Long ,
         title: String,
         description: String,
         content: String
     ){
         val postToSuggest = postRepository.findById(postId).getOrNull() ?: throw NotFoundException("포스트가 존재하지 않습니다.")
-        val author = userRepository.findById(userId).getOrNull()
-            ?: throw NotFoundException("사용자를 찾을 수 없습니다.")
         suggestionRepository.save(
             Suggestion(
                 post = postToSuggest,
-                user = author,
+                user = user,
                 title = title,
                 content = content,
                 baseContent = postToSuggest.content,

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/suggest/dto/SuggestionDetailResponse.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/suggest/dto/SuggestionDetailResponse.kt
@@ -1,5 +1,6 @@
 package io.github.kitae9999.openlog.suggest.dto
 
+import io.github.kitae9999.openlog.discussion.dto.DiscussionResponse
 import io.github.kitae9999.openlog.suggest.entity.SuggestionStatus
 import java.time.LocalDateTime
 
@@ -15,4 +16,5 @@ data class SuggestionDetailResponse(
     val authorProfileImageUrl: String?,
     val createdAt: LocalDateTime,
     val postBaseVersion: Long,
+    val discussions: List<DiscussionResponse>,
 )

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/suggest/entity/Discussion.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/suggest/entity/Discussion.kt
@@ -1,4 +1,0 @@
-package io.github.kitae9999.openlog.suggest.entity
-
-class Discussion {
-}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/suggest/repository/DiscussionRepository.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/suggest/repository/DiscussionRepository.kt
@@ -1,4 +1,0 @@
-package io.github.kitae9999.openlog.suggest.repository
-
-interface DiscussionRepository {
-}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserController.kt
@@ -50,10 +50,10 @@ class UserController(
         @Valid @RequestBody request: UpdateProfileRequest,
         httpRequest: HttpServletRequest,
     ): PublicUserProfileResponse {
-        val currentUserId = currentUserResolver.resolveUserIdFromJwt(httpRequest)
+        val currentUser = currentUserResolver.resolveCurrentUser(httpRequest)
 
         return userService.updateProfile(
-            userId = currentUserId,
+            userId = requireNotNull(currentUser.id),
             username = username,
             nickname = request.nickname,
             bio = request.bio,

--- a/backend/src/test/kotlin/io/github/kitae9999/openlog/post/PostServiceTest.kt
+++ b/backend/src/test/kotlin/io/github/kitae9999/openlog/post/PostServiceTest.kt
@@ -11,7 +11,6 @@ import io.github.kitae9999.openlog.suggest.repository.SuggestionRepository
 import io.github.kitae9999.openlog.topic.entity.Topic
 import io.github.kitae9999.openlog.topic.repository.TopicRepository
 import io.github.kitae9999.openlog.user.entity.User
-import io.github.kitae9999.openlog.user.repository.UserRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
@@ -42,9 +41,6 @@ class PostServiceTest {
     @Mock
     private lateinit var topicRepository: TopicRepository
 
-    @Mock
-    private lateinit var userRepository: UserRepository
-
     private lateinit var postService: PostService
 
     @BeforeEach
@@ -54,18 +50,16 @@ class PostServiceTest {
             postTopicRepository = postTopicRepository,
             suggestionRepository = suggestionRepository,
             topicRepository = topicRepository,
-            userRepository = userRepository,
         )
     }
 
     @Test
     fun `createPost saves post without blog dependency`() {
         val user = User(id = 1L, username = "alice")
-        given(userRepository.findById(1L)).willReturn(Optional.of(user))
         given(postRepository.existsByAuthorIdAndSlug(1L, "hello-openlog")).willReturn(false)
         given(postRepository.save(any(Post::class.java))).willAnswer { invocation -> invocation.getArgument(0) }
 
-        val response = postService.createPost(1L, createRequest())
+        val response = postService.createPost(user, createRequest())
 
         val postCaptor = ArgumentCaptor.forClass(Post::class.java)
         verify(postRepository).save(postCaptor.capture())
@@ -81,12 +75,11 @@ class PostServiceTest {
     @Test
     fun `createPost appends numeric suffix when author slug already exists`() {
         val user = User(id = 1L, username = "alice")
-        given(userRepository.findById(1L)).willReturn(Optional.of(user))
         given(postRepository.existsByAuthorIdAndSlug(1L, "hello-openlog")).willReturn(true)
         given(postRepository.existsByAuthorIdAndSlug(1L, "hello-openlog-2")).willReturn(false)
         given(postRepository.save(any(Post::class.java))).willAnswer { invocation -> invocation.getArgument(0) }
 
-        val response = postService.createPost(1L, createRequest())
+        val response = postService.createPost(user, createRequest())
 
         assertThat(response.slug).isEqualTo("hello-openlog-2")
     }
@@ -94,10 +87,9 @@ class PostServiceTest {
     @Test
     fun `createPost rejects users without username`() {
         val user = User(id = 1L, username = " ")
-        given(userRepository.findById(1L)).willReturn(Optional.of(user))
 
         val exception = assertThrows(NotFoundException::class.java) {
-            postService.createPost(1L, createRequest())
+            postService.createPost(user, createRequest())
         }
 
         verify(postRepository, never()).save(any(Post::class.java))

--- a/backend/src/test/kotlin/io/github/kitae9999/openlog/suggest/SuggestServiceTest.kt
+++ b/backend/src/test/kotlin/io/github/kitae9999/openlog/suggest/SuggestServiceTest.kt
@@ -2,6 +2,8 @@ package io.github.kitae9999.openlog.suggest
 
 import io.github.kitae9999.openlog.common.exception.BadRequestException
 import io.github.kitae9999.openlog.common.exception.ForbiddenException
+import io.github.kitae9999.openlog.discussion.DiscussionService
+import io.github.kitae9999.openlog.discussion.repository.DiscussionRepository
 import io.github.kitae9999.openlog.post.entity.Post
 import io.github.kitae9999.openlog.post.repository.PostRepository
 import io.github.kitae9999.openlog.suggest.entity.Suggestion
@@ -28,6 +30,12 @@ class SuggestServiceTest {
     @Mock
     private lateinit var suggestionRepository: SuggestionRepository
 
+    @Mock
+    private lateinit var discussionRepository: DiscussionRepository
+
+    @Mock
+    private lateinit var discussionService: DiscussionService
+
     private lateinit var suggestService: SuggestService
 
     @BeforeEach
@@ -35,6 +43,8 @@ class SuggestServiceTest {
         suggestService = SuggestService(
             postRepository = postRepository,
             suggestionRepository = suggestionRepository,
+            discussionRepository = discussionRepository,
+            discussionService = discussionService,
         )
     }
 

--- a/backend/src/test/kotlin/io/github/kitae9999/openlog/suggest/SuggestServiceTest.kt
+++ b/backend/src/test/kotlin/io/github/kitae9999/openlog/suggest/SuggestServiceTest.kt
@@ -9,7 +9,6 @@ import io.github.kitae9999.openlog.suggest.entity.SuggestionAction
 import io.github.kitae9999.openlog.suggest.entity.SuggestionStatus
 import io.github.kitae9999.openlog.suggest.repository.SuggestionRepository
 import io.github.kitae9999.openlog.user.entity.User
-import io.github.kitae9999.openlog.user.repository.UserRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
@@ -24,9 +23,6 @@ import org.mockito.junit.jupiter.MockitoExtension
 @ExtendWith(MockitoExtension::class)
 class SuggestServiceTest {
     @Mock
-    private lateinit var userRepository: UserRepository
-
-    @Mock
     private lateinit var postRepository: PostRepository
 
     @Mock
@@ -37,7 +33,6 @@ class SuggestServiceTest {
     @BeforeEach
     fun setUp() {
         suggestService = SuggestService(
-            userRepository = userRepository,
             postRepository = postRepository,
             suggestionRepository = suggestionRepository,
         )

--- a/frontend/app/[username]/posts/[postSlug]/suggestions/[suggestionNumber]/page.tsx
+++ b/frontend/app/[username]/posts/[postSlug]/suggestions/[suggestionNumber]/page.tsx
@@ -194,7 +194,14 @@ function toSuggestion(
       message: detail.description,
     },
     diffRows: buildDiffRows(detail.baseContent, detail.content),
-    discussionComments: [],
+    discussionComments: detail.discussions.map((discussion) => ({
+      id: String(discussion.id),
+      authorName: discussion.authorName,
+      authorAvatarSrc: discussion.authorProfileImageUrl ?? assets.defaultAvatar,
+      commentedAtLabel: formatDateLabel(discussion.createdAt),
+      message: discussion.content,
+      canManage: discussion.canManage,
+    })),
   };
 }
 

--- a/frontend/app/[username]/posts/[postSlug]/suggestions/[suggestionNumber]/page.tsx
+++ b/frontend/app/[username]/posts/[postSlug]/suggestions/[suggestionNumber]/page.tsx
@@ -238,5 +238,7 @@ function formatDateLabel(value: string) {
     year: "numeric",
     month: "numeric",
     day: "numeric",
-  }).format(date);
+  })
+    .format(date)
+    .replace(/\.$/, "");
 }

--- a/frontend/app/[username]/posts/[postSlug]/suggestions/[suggestionNumber]/page.tsx
+++ b/frontend/app/[username]/posts/[postSlug]/suggestions/[suggestionNumber]/page.tsx
@@ -133,8 +133,11 @@ export default async function PublicPostSuggestionDetailPage({
         <SuggestionDetail
           post={post}
           suggestion={suggestion}
+          postId={detail.id}
+          suggestionId={suggestionDetail.id}
           articleHref={articleHref}
           suggestsHref={suggestsHref}
+          currentUserAvatarSrc={viewer?.profileImageUrl}
           editHref={isOpen && isSuggestionAuthor ? suggestionEditHref : undefined}
           closeAction={closeAction}
           mergeAction={mergeAction}

--- a/frontend/src/01_widgets/post/ui/PostCommentsSection.tsx
+++ b/frontend/src/01_widgets/post/ui/PostCommentsSection.tsx
@@ -247,9 +247,7 @@ function CommentCard({
             <span className="font-semibold text-zinc-950">
               {comment.authorName}
             </span>
-            <span>
-              commented on {formatCommentedAtLabel(comment.createdAt)}.
-            </span>
+            <span>commented on {formatCommentedAtLabel(comment.createdAt)}</span>
           </div>
           {canManage ? (
             <div className="flex items-center gap-2">

--- a/frontend/src/01_widgets/post/ui/SuggestionDetail.tsx
+++ b/frontend/src/01_widgets/post/ui/SuggestionDetail.tsx
@@ -193,9 +193,8 @@ function SuggestionLeadComment({
           {editHref ? (
             <Link
               href={editHref}
-              className="inline-flex h-7 items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-3 text-xs font-semibold text-zinc-700 shadow-sm transition hover:border-zinc-300 hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
+              className="text-xs font-semibold text-zinc-500 transition hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
             >
-              <IconEdit className="size-3.5" />
               Edit
             </Link>
           ) : null}
@@ -485,31 +484,6 @@ function IconComment({ className }: { className?: string }) {
         d="M13 10a2.5 2.5 0 01-2.5 2.5H5.25L2 14.5v-9A2.5 2.5 0 014.5 3h6A2.5 2.5 0 0113 5.5V10z"
         stroke="currentColor"
         strokeWidth="1.3"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function IconEdit({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      className={className}
-      aria-hidden="true"
-    >
-      <path
-        d="M12 20h9"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-      />
-      <path
-        d="M16.5 3.5a2.12 2.12 0 113 3L7 19l-4 1 1-4L16.5 3.5z"
-        stroke="currentColor"
-        strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
       />

--- a/frontend/src/01_widgets/post/ui/SuggestionDetail.tsx
+++ b/frontend/src/01_widgets/post/ui/SuggestionDetail.tsx
@@ -2,19 +2,21 @@ import Image from "next/image";
 import Link from "next/link";
 import type { ReactNode } from "react";
 import type { Post, Suggestion } from "@/entities/post/model";
-import { assets } from "@/shared/config/assets";
 import { cn } from "@/shared/lib/cn";
 import { GitPullRequestIcon } from "@/shared/ui/icons";
 import { MarkdownContent } from "@/shared/ui/markdown";
-import { DiscussionComposer } from "@/features/discussion-composer/ui";
+import { SuggestionDiscussionSection } from "./SuggestionDiscussionSection";
 
 type SuggestionManageAction = (formData: FormData) => void | Promise<void>;
 
 export function SuggestionDetail({
   post,
   suggestion,
+  postId,
+  suggestionId,
   articleHref,
   suggestsHref,
+  currentUserAvatarSrc,
   editHref,
   closeAction,
   mergeAction,
@@ -22,8 +24,11 @@ export function SuggestionDetail({
 }: {
   post: Post;
   suggestion: Suggestion;
+  postId: number;
+  suggestionId: number;
   articleHref: string;
   suggestsHref: string;
+  currentUserAvatarSrc?: string | null;
   editHref?: string;
   closeAction?: SuggestionManageAction;
   mergeAction?: SuggestionManageAction;
@@ -147,7 +152,12 @@ export function SuggestionDetail({
             </div>
           ) : null}
 
-          <DiscussionSection suggestion={suggestion} />
+          <SuggestionDiscussionSection
+            postId={postId}
+            suggestionId={suggestionId}
+            initialComments={suggestion.discussionComments}
+            currentUserAvatarSrc={currentUserAvatarSrc}
+          />
         </div>
 
         <aside className="space-y-6">
@@ -261,65 +271,6 @@ function MergedNotice({
       <div>
         <h2 className="text-sm font-bold text-violet-900">{title}</h2>
         <p className="mt-1 text-xs text-violet-700">{description}</p>
-      </div>
-    </section>
-  );
-}
-
-function DiscussionSection({
-  suggestion,
-}: {
-  suggestion: Suggestion;
-}) {
-  return (
-    <section>
-      <div className="flex items-center gap-4">
-        <div className="h-px flex-1 bg-zinc-200" />
-        <div className="inline-flex items-center gap-2 text-sm text-zinc-500">
-          <IconComment className="size-4" />
-          Discussion
-        </div>
-        <div className="h-px flex-1 bg-zinc-200" />
-      </div>
-
-      {suggestion.discussionComments.length > 0 ? (
-        <div className="mt-6 space-y-4">
-          {suggestion.discussionComments.map((comment) => (
-            <div key={comment.id} className="flex items-start gap-4">
-              <Image
-                src={comment.authorAvatarSrc}
-                alt={`${comment.authorName} avatar`}
-                width={40}
-                height={40}
-                className="mt-1 size-10 rounded-full border border-zinc-200 object-cover"
-              />
-              <section className="min-w-0 flex-1 overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-sm">
-                <div className="flex items-center gap-2 border-b border-zinc-200 bg-zinc-50/80 px-4 py-3 text-sm text-zinc-500">
-                  <span className="font-semibold text-zinc-950">
-                    {comment.authorName}
-                  </span>
-                  <span>commented on {comment.commentedAtLabel}.</span>
-                </div>
-                <div className="px-4 py-5 text-sm leading-6 text-zinc-800">
-                  {comment.message}
-                </div>
-              </section>
-            </div>
-          ))}
-        </div>
-      ) : null}
-
-      <div className="mt-6 flex items-start gap-4">
-        <Image
-          src={assets.defaultAvatar}
-          alt="Current user avatar"
-          width={40}
-          height={40}
-          className="mt-1 size-10 rounded-full border border-zinc-200 object-cover"
-        />
-        <div className="min-w-0 flex-1">
-          <DiscussionComposer />
-        </div>
       </div>
     </section>
   );
@@ -469,24 +420,5 @@ function IconFileDiff({ className }: { className?: string }) {
         mask: "url('/filediff.svg') center / contain no-repeat",
       }}
     />
-  );
-}
-
-function IconComment({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 16 16"
-      fill="none"
-      className={className}
-      aria-hidden="true"
-    >
-      <path
-        d="M13 10a2.5 2.5 0 01-2.5 2.5H5.25L2 14.5v-9A2.5 2.5 0 014.5 3h6A2.5 2.5 0 0113 5.5V10z"
-        stroke="currentColor"
-        strokeWidth="1.3"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
   );
 }

--- a/frontend/src/01_widgets/post/ui/SuggestionDiscussionSection.tsx
+++ b/frontend/src/01_widgets/post/ui/SuggestionDiscussionSection.tsx
@@ -75,7 +75,7 @@ export function SuggestionDiscussionSection({
                   <span className="font-semibold text-zinc-950">
                     {comment.authorName}
                   </span>
-                  <span>commented on {comment.commentedAtLabel}.</span>
+                  <span>commented on {comment.commentedAtLabel}</span>
                 </div>
                 <div className="px-4 py-5">
                   <MarkdownContent markdown={comment.message} variant="compact" />
@@ -119,7 +119,7 @@ function formatDiscussionDateLabel(value: string) {
     return value;
   }
 
-  return DISCUSSION_DATE_FORMATTER.format(date);
+  return DISCUSSION_DATE_FORMATTER.format(date).replace(/\.$/, "");
 }
 
 function IconComment({ className }: { className?: string }) {

--- a/frontend/src/01_widgets/post/ui/SuggestionDiscussionSection.tsx
+++ b/frontend/src/01_widgets/post/ui/SuggestionDiscussionSection.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import type { ApiDiscussion } from "@/entities/post/api/getPostSuggestionDetail";
+import type { DiscussionComment } from "@/entities/post/model";
+import { submitSuggestionDiscussion } from "@/features/discussion/api/discussionActions";
+import { DiscussionComposer } from "@/features/discussion-composer/ui";
+import { assets } from "@/shared/config/assets";
+import { MarkdownContent } from "@/shared/ui/markdown";
+
+const DISCUSSION_DATE_FORMATTER = new Intl.DateTimeFormat("ko-KR", {
+  year: "numeric",
+  month: "numeric",
+  day: "numeric",
+});
+
+export function SuggestionDiscussionSection({
+  postId,
+  suggestionId,
+  initialComments,
+  currentUserAvatarSrc,
+}: {
+  postId: number;
+  suggestionId: number;
+  initialComments: DiscussionComment[];
+  currentUserAvatarSrc?: string | null;
+}) {
+  const router = useRouter();
+  const [discussionItems, setDiscussionItems] = useState(initialComments);
+  const resolvedAvatarSrc = currentUserAvatarSrc ?? assets.defaultAvatar;
+
+  async function submitDiscussion(content: string) {
+    const result = await submitSuggestionDiscussion(postId, suggestionId, content);
+    if (!result.ok) {
+      return result;
+    }
+
+    const discussion = toDiscussionComment(result.discussion);
+    setDiscussionItems((current) =>
+      current.some((item) => item.id === discussion.id)
+        ? current
+        : [...current, discussion],
+    );
+    router.refresh();
+
+    return { ok: true as const };
+  }
+
+  return (
+    <section>
+      <div className="flex items-center gap-4">
+        <div className="h-px flex-1 bg-zinc-200" />
+        <div className="inline-flex items-center gap-2 text-sm text-zinc-500">
+          <IconComment className="size-4" />
+          Discussion
+        </div>
+        <div className="h-px flex-1 bg-zinc-200" />
+      </div>
+
+      {discussionItems.length > 0 ? (
+        <div className="mt-6 space-y-4">
+          {discussionItems.map((comment) => (
+            <div key={comment.id} className="flex items-start gap-4">
+              <Image
+                src={comment.authorAvatarSrc}
+                alt={`${comment.authorName} avatar`}
+                width={40}
+                height={40}
+                className="mt-1 size-10 rounded-full border border-zinc-200 object-cover"
+              />
+              <section className="min-w-0 flex-1 overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-sm">
+                <div className="flex items-center gap-2 border-b border-zinc-200 bg-zinc-50/80 px-4 py-3 text-sm text-zinc-500">
+                  <span className="font-semibold text-zinc-950">
+                    {comment.authorName}
+                  </span>
+                  <span>commented on {comment.commentedAtLabel}.</span>
+                </div>
+                <div className="px-4 py-5">
+                  <MarkdownContent markdown={comment.message} variant="compact" />
+                </div>
+              </section>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="mt-6 flex items-start gap-4">
+        <Image
+          src={resolvedAvatarSrc}
+          alt="Current user avatar"
+          width={40}
+          height={40}
+          className="mt-1 size-10 rounded-full border border-zinc-200 object-cover"
+        />
+        <div className="min-w-0 flex-1">
+          <DiscussionComposer onSubmit={submitDiscussion} />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function toDiscussionComment(discussion: ApiDiscussion): DiscussionComment {
+  return {
+    id: String(discussion.id),
+    authorName: discussion.authorName,
+    authorAvatarSrc: discussion.authorProfileImageUrl ?? assets.defaultAvatar,
+    commentedAtLabel: formatDiscussionDateLabel(discussion.createdAt),
+    message: discussion.content,
+    canManage: discussion.canManage,
+  };
+}
+
+function formatDiscussionDateLabel(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return DISCUSSION_DATE_FORMATTER.format(date);
+}
+
+function IconComment({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M13 10a2.5 2.5 0 01-2.5 2.5H5.25L2 14.5v-9A2.5 2.5 0 014.5 3h6A2.5 2.5 0 0113 5.5V10z"
+        stroke="currentColor"
+        strokeWidth="1.3"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/frontend/src/01_widgets/post/ui/SuggestionDiscussionSection.tsx
+++ b/frontend/src/01_widgets/post/ui/SuggestionDiscussionSection.tsx
@@ -2,10 +2,14 @@
 
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useState, useTransition } from "react";
 import type { ApiDiscussion } from "@/entities/post/api/getPostSuggestionDetail";
 import type { DiscussionComment } from "@/entities/post/model";
-import { submitSuggestionDiscussion } from "@/features/discussion/api/discussionActions";
+import {
+  deleteSuggestionDiscussion,
+  submitSuggestionDiscussion,
+  updateSuggestionDiscussion,
+} from "@/features/discussion/api/discussionActions";
 import { DiscussionComposer } from "@/features/discussion-composer/ui";
 import { assets } from "@/shared/config/assets";
 import { MarkdownContent } from "@/shared/ui/markdown";
@@ -29,6 +33,14 @@ export function SuggestionDiscussionSection({
 }) {
   const router = useRouter();
   const [discussionItems, setDiscussionItems] = useState(initialComments);
+  const [editingDiscussionId, setEditingDiscussionId] = useState<string | null>(
+    null,
+  );
+  const [deletingDiscussionId, setDeletingDiscussionId] = useState<string | null>(
+    null,
+  );
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [, startDeleteTransition] = useTransition();
   const resolvedAvatarSrc = currentUserAvatarSrc ?? assets.defaultAvatar;
 
   async function submitDiscussion(content: string) {
@@ -48,6 +60,75 @@ export function SuggestionDiscussionSection({
     return { ok: true as const };
   }
 
+  async function updateDiscussion(discussionId: string, content: string) {
+    const parsedDiscussionId = Number(discussionId);
+    if (!Number.isInteger(parsedDiscussionId)) {
+      return {
+        ok: false as const,
+        message: "댓글 수정 기능을 사용할 수 없습니다.",
+      };
+    }
+
+    const result = await updateSuggestionDiscussion(
+      postId,
+      suggestionId,
+      parsedDiscussionId,
+      content,
+    );
+    if (!result.ok) {
+      return result;
+    }
+
+    const discussion = toDiscussionComment(result.discussion);
+    setDiscussionItems((current) =>
+      current.map((item) => (item.id === discussion.id ? discussion : item)),
+    );
+    setEditingDiscussionId(null);
+    router.refresh();
+
+    return { ok: true as const };
+  }
+
+  function deleteDiscussion(discussionId: string) {
+    const parsedDiscussionId = Number(discussionId);
+    if (!Number.isInteger(parsedDiscussionId) || deletingDiscussionId !== null) {
+      return;
+    }
+
+    if (!window.confirm("댓글을 삭제할까요?")) {
+      return;
+    }
+
+    setActionError(null);
+    setDeletingDiscussionId(discussionId);
+
+    startDeleteTransition(async () => {
+      try {
+        const result = await deleteSuggestionDiscussion(
+          postId,
+          suggestionId,
+          parsedDiscussionId,
+        );
+        if (!result.ok) {
+          setActionError(result.message);
+          return;
+        }
+
+        setDiscussionItems((current) =>
+          current.filter((item) => item.id !== discussionId),
+        );
+        setEditingDiscussionId((current) =>
+          current === discussionId ? null : current,
+        );
+        router.refresh();
+      } catch {
+        setActionError("댓글을 삭제하는 중 문제가 발생했습니다.");
+      } finally {
+        setDeletingDiscussionId(null);
+      }
+    });
+  }
+
   return (
     <section>
       <div className="flex items-center gap-4">
@@ -62,28 +143,28 @@ export function SuggestionDiscussionSection({
       {discussionItems.length > 0 ? (
         <div className="mt-6 space-y-4">
           {discussionItems.map((comment) => (
-            <div key={comment.id} className="flex items-start gap-4">
-              <Image
-                src={comment.authorAvatarSrc}
-                alt={`${comment.authorName} avatar`}
-                width={40}
-                height={40}
-                className="mt-1 size-10 rounded-full border border-zinc-200 object-cover"
-              />
-              <section className="min-w-0 flex-1 overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-sm">
-                <div className="flex items-center gap-2 border-b border-zinc-200 bg-zinc-50/80 px-4 py-3 text-sm text-zinc-500">
-                  <span className="font-semibold text-zinc-950">
-                    {comment.authorName}
-                  </span>
-                  <span>commented on {comment.commentedAtLabel}</span>
-                </div>
-                <div className="px-4 py-5">
-                  <MarkdownContent markdown={comment.message} variant="compact" />
-                </div>
-              </section>
-            </div>
+            <DiscussionCard
+              key={comment.id}
+              comment={comment}
+              canManage={comment.canManage}
+              isEditing={editingDiscussionId === comment.id}
+              isDeleting={deletingDiscussionId === comment.id}
+              onEdit={() => {
+                setActionError(null);
+                setEditingDiscussionId(comment.id);
+              }}
+              onCancelEdit={() => setEditingDiscussionId(null)}
+              onSubmitEdit={(content) => updateDiscussion(comment.id, content)}
+              onDelete={() => deleteDiscussion(comment.id)}
+            />
           ))}
         </div>
+      ) : null}
+
+      {actionError ? (
+        <p className="mt-4 rounded-2xl border border-rose-100 bg-rose-50 px-4 py-3 text-sm font-medium text-rose-700">
+          {actionError}
+        </p>
       ) : null}
 
       <div className="mt-6 flex items-start gap-4">
@@ -99,6 +180,95 @@ export function SuggestionDiscussionSection({
         </div>
       </div>
     </section>
+  );
+}
+
+function DiscussionCard({
+  comment,
+  canManage,
+  isEditing,
+  isDeleting,
+  onEdit,
+  onCancelEdit,
+  onSubmitEdit,
+  onDelete,
+}: {
+  comment: DiscussionComment;
+  canManage: boolean;
+  isEditing: boolean;
+  isDeleting: boolean;
+  onEdit: () => void;
+  onCancelEdit: () => void;
+  onSubmitEdit: (content: string) => Promise<
+    | {
+        ok: true;
+      }
+    | {
+        ok: false;
+        message: string;
+      }
+  >;
+  onDelete: () => void;
+}) {
+  return (
+    <div className="flex items-start gap-4">
+      <Image
+        src={comment.authorAvatarSrc}
+        alt={`${comment.authorName} avatar`}
+        width={40}
+        height={40}
+        className="mt-1 size-10 rounded-full border border-zinc-200 object-cover"
+      />
+      <section className="min-w-0 flex-1 overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-sm">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-b border-zinc-200 bg-zinc-50/80 px-4 py-3 text-sm text-zinc-500">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-semibold text-zinc-950">
+              {comment.authorName}
+            </span>
+            <span>commented on {comment.commentedAtLabel}</span>
+          </div>
+          {canManage ? (
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={onEdit}
+                disabled={isEditing || isDeleting}
+                aria-label="Edit your discussion"
+                className="text-xs font-semibold text-zinc-500 transition hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20 disabled:cursor-not-allowed disabled:text-zinc-300"
+              >
+                Edit
+              </button>
+              <button
+                type="button"
+                onClick={onDelete}
+                disabled={isDeleting}
+                aria-label="Delete your discussion"
+                className="text-xs font-semibold text-zinc-500 transition hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-600/20 disabled:cursor-not-allowed disabled:text-rose-300"
+              >
+                {isDeleting ? "Deleting..." : "Delete"}
+              </button>
+            </div>
+          ) : null}
+        </div>
+        {isEditing ? (
+          <div className="p-4">
+            <DiscussionComposer
+              key={comment.id}
+              initialValue={comment.message}
+              submitLabel="Save"
+              pendingLabel="Saving..."
+              errorFallback="댓글을 수정하는 중 문제가 발생했습니다."
+              onCancel={onCancelEdit}
+              onSubmit={onSubmitEdit}
+            />
+          </div>
+        ) : (
+          <div className="px-4 py-5">
+            <MarkdownContent markdown={comment.message} variant="compact" />
+          </div>
+        )}
+      </section>
+    </div>
   );
 }
 

--- a/frontend/src/02_features/discussion/api/discussionActions.ts
+++ b/frontend/src/02_features/discussion/api/discussionActions.ts
@@ -2,7 +2,10 @@
 
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
-import type { DiscussionMutationResult } from "@/entities/post/api/getPostSuggestionDetail";
+import type {
+  DeleteDiscussionResult,
+  DiscussionMutationResult,
+} from "@/entities/post/api/getPostSuggestionDetail";
 import { API_CONFIG } from "@/shared/api";
 
 export async function submitSuggestionDiscussion(
@@ -10,29 +13,91 @@ export async function submitSuggestionDiscussion(
   suggestionId: number,
   content: string,
 ): Promise<DiscussionMutationResult> {
+  return sendDiscussionMutation(
+    `${API_CONFIG.baseURL}/posts/${postId}/suggestions/${suggestionId}/discussions`,
+    "POST",
+    content,
+    "댓글 내용을 입력해주세요.",
+    "댓글을 작성하는 중 문제가 발생했습니다.",
+  );
+}
+
+export async function updateSuggestionDiscussion(
+  postId: number,
+  suggestionId: number,
+  discussionId: number,
+  content: string,
+): Promise<DiscussionMutationResult> {
+  return sendDiscussionMutation(
+    `${API_CONFIG.baseURL}/posts/${postId}/suggestions/${suggestionId}/discussions/${discussionId}`,
+    "PATCH",
+    content,
+    "수정할 내용을 입력해주세요.",
+    "댓글을 수정하는 중 문제가 발생했습니다.",
+  );
+}
+
+export async function deleteSuggestionDiscussion(
+  postId: number,
+  suggestionId: number,
+  discussionId: number,
+): Promise<DeleteDiscussionResult> {
+  const headerStore = await headers();
+  const response = await fetch(
+    `${API_CONFIG.baseURL}/posts/${postId}/suggestions/${suggestionId}/discussions/${discussionId}`,
+    {
+      method: "DELETE",
+      cache: "no-store",
+      headers: {
+        cookie: headerStore.get("cookie") ?? "",
+      },
+    },
+  );
+
+  if (response.ok) {
+    return { ok: true };
+  }
+
+  if (response.status === 401) {
+    redirect("/");
+  }
+
+  return {
+    ok: false,
+    message: await getErrorMessage(
+      response,
+      "댓글을 삭제하는 중 문제가 발생했습니다.",
+    ),
+  };
+}
+
+async function sendDiscussionMutation(
+  url: string,
+  method: "POST" | "PATCH",
+  content: string,
+  emptyMessage: string,
+  fallbackMessage: string,
+): Promise<DiscussionMutationResult> {
   const nextContent = content.trim();
   if (!nextContent) {
     return {
       ok: false,
-      message: "댓글 내용을 입력해주세요.",
+      message: emptyMessage,
     };
   }
 
   const headerStore = await headers();
-  const response = await fetch(
-    `${API_CONFIG.baseURL}/posts/${postId}/suggestions/${suggestionId}/discussions`,
-    {
-      method: "POST",
-      cache: "no-store",
-      headers: {
-        "content-type": "application/json",
-        cookie: headerStore.get("cookie") ?? "",
-      },
-      body: JSON.stringify({
-        content: nextContent,
-      }),
+  const response = await fetch(url, {
+    method,
+    cache: "no-store",
+    headers: {
+      "content-type": "application/json",
+      cookie: headerStore.get("cookie") ?? "",
     },
-  );
+    body: JSON.stringify({
+      content: nextContent,
+    }),
+  });
 
   if (response.ok) {
     return {
@@ -47,10 +112,7 @@ export async function submitSuggestionDiscussion(
 
   return {
     ok: false,
-    message: await getErrorMessage(
-      response,
-      "댓글을 작성하는 중 문제가 발생했습니다.",
-    ),
+    message: await getErrorMessage(response, fallbackMessage),
   };
 }
 

--- a/frontend/src/02_features/discussion/api/discussionActions.ts
+++ b/frontend/src/02_features/discussion/api/discussionActions.ts
@@ -1,0 +1,67 @@
+"use server";
+
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import type { DiscussionMutationResult } from "@/entities/post/api/getPostSuggestionDetail";
+import { API_CONFIG } from "@/shared/api";
+
+export async function submitSuggestionDiscussion(
+  postId: number,
+  suggestionId: number,
+  content: string,
+): Promise<DiscussionMutationResult> {
+  const nextContent = content.trim();
+  if (!nextContent) {
+    return {
+      ok: false,
+      message: "댓글 내용을 입력해주세요.",
+    };
+  }
+
+  const headerStore = await headers();
+  const response = await fetch(
+    `${API_CONFIG.baseURL}/posts/${postId}/suggestions/${suggestionId}/discussions`,
+    {
+      method: "POST",
+      cache: "no-store",
+      headers: {
+        "content-type": "application/json",
+        cookie: headerStore.get("cookie") ?? "",
+      },
+      body: JSON.stringify({
+        content: nextContent,
+      }),
+    },
+  );
+
+  if (response.ok) {
+    return {
+      ok: true,
+      discussion: await response.json(),
+    };
+  }
+
+  if (response.status === 401) {
+    redirect("/");
+  }
+
+  return {
+    ok: false,
+    message: await getErrorMessage(
+      response,
+      "댓글을 작성하는 중 문제가 발생했습니다.",
+    ),
+  };
+}
+
+async function getErrorMessage(response: Response, fallbackMessage: string) {
+  let errorBody: { message?: string } | null = null;
+
+  try {
+    errorBody = (await response.json()) as { message?: string };
+  } catch {
+    errorBody = null;
+  }
+
+  return errorBody?.message ?? fallbackMessage;
+}

--- a/frontend/src/03_entities/post/api/getPostSuggestionDetail.ts
+++ b/frontend/src/03_entities/post/api/getPostSuggestionDetail.ts
@@ -16,6 +16,16 @@ export type ApiSuggestionDetail = {
   authorProfileImageUrl: string | null;
   createdAt: string;
   postBaseVersion: number;
+  discussions: ApiDiscussion[];
+};
+
+export type ApiDiscussion = {
+  id: number;
+  authorName: string;
+  authorProfileImageUrl: string | null;
+  content: string;
+  createdAt: string;
+  canManage: boolean;
 };
 
 export async function getPostSuggestionDetail(

--- a/frontend/src/03_entities/post/api/getPostSuggestionDetail.ts
+++ b/frontend/src/03_entities/post/api/getPostSuggestionDetail.ts
@@ -38,6 +38,15 @@ export type DiscussionMutationResult =
       message: string;
     };
 
+export type DeleteDiscussionResult =
+  | {
+      ok: true;
+    }
+  | {
+      ok: false;
+      message: string;
+    };
+
 export async function getPostSuggestionDetail(
   postId: number,
   suggestionId: number,

--- a/frontend/src/03_entities/post/api/getPostSuggestionDetail.ts
+++ b/frontend/src/03_entities/post/api/getPostSuggestionDetail.ts
@@ -28,6 +28,16 @@ export type ApiDiscussion = {
   canManage: boolean;
 };
 
+export type DiscussionMutationResult =
+  | {
+      ok: true;
+      discussion: ApiDiscussion;
+    }
+  | {
+      ok: false;
+      message: string;
+    };
+
 export async function getPostSuggestionDetail(
   postId: number,
   suggestionId: number,

--- a/frontend/src/03_entities/post/model/postData.tsx
+++ b/frontend/src/03_entities/post/model/postData.tsx
@@ -35,6 +35,7 @@ export type DiscussionComment = {
   authorAvatarSrc: string;
   commentedAtLabel: string;
   message: string;
+  canManage: boolean;
 };
 
 export type DiffRow = {


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #

---

## 1. PR 유형
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ✨ 새로운 기능 (New Feature)
- [x] ♻️ 리팩토링 (Refactoring)
- [x] 📝 문서 업데이트 (Documentation)
- [ ] ⚙️ 설정/빌드 변경 (Chore)

---

## 2. 작업 배경 및 목적
- **기존 상태:** Suggestion 상세 화면은 제안 본문과 diff를 표시했지만, suggestion 하위 discussion은 응답 스키마와 프론트 상태에 연결되어 있지 않았습니다. 백엔드에는 suggestion 도메인 내부에 discussion 초안 구조가 일부 있었고, 인증된 사용자를 실제 `User` 엔티티로 해석하는 흐름도 각 서비스에서 중복 처리되고 있었습니다.
- **문제점:** discussion 작성 컴포저는 `onSubmit` 없이 렌더링되어 버튼이 비활성화됐고, suggestion 상세 응답은 discussion 목록과 `canManage` 권한 값을 제공하지 않았습니다. 또한 생성, 수정, 삭제 API가 없거나 프론트 서버 액션과 연결되지 않아 사용자가 suggestion 상세 화면에서 discussion thread를 실제로 관리할 수 없었습니다.
- **해결 목표:** Discussion을 독립 도메인 패키지로 분리하고, 생성/수정/삭제 API와 suggestion 상세 조회 응답을 연결합니다. 프론트에서는 comment UI와 동일한 작성, 수정, 삭제 인터랙션을 제공하고, `canManage`가 true인 본인 discussion에만 `Edit`/`Delete` 버튼을 노출합니다.

---

## 3. 상세 변경 내역 및 동작 흐름

### A. CurrentUserResolver의 실제 User 엔티티 해석 흐름 도입
- **진입점 및 초기 조건:** 인증이 필요한 컨트롤러는 `HttpServletRequest`에서 JWT cookie를 읽어 현재 사용자를 해석합니다.
- **단계별 제어 흐름:**
  1. `CurrentUserResolver.resolveUserIdFromJwt()`는 기존과 동일하게 access token에서 user id를 파싱합니다.
  2. `CurrentUserResolver.resolveCurrentUser()`는 파싱한 user id로 `UserRepository.findById()`를 호출합니다.
  3. 사용자가 존재하지 않으면 `OAuthAuthenticationException`을 발생시켜 인증 실패 응답 경로로 이동합니다.
  4. `AuthController`, `PostController`, `CommentController`, `PostLikeController`, `SuggestController`, `UserController`는 생성/수정 계열 요청에서 실제 `User` 또는 `requireNotNull(currentUser.id)`를 서비스에 전달합니다.
- **데이터 상태 변이:** 서비스 계층의 일부 메서드는 user id로 다시 사용자를 조회하지 않고 컨트롤러에서 검증된 `User` 객체를 입력값으로 받습니다.
- **최종 반환 및 종료 상태:** Discussion 생성과 기존 post/comment/suggestion 생성 흐름이 모두 "JWT 해석 -> User 엔티티 검증 -> 서비스 실행" 순서로 통일됩니다.

```kotlin
fun resolveCurrentUser(request: HttpServletRequest): User {
    val userId = resolveUserIdFromJwt(request)
    return userRepository.findById(userId).getOrNull()
        ?: throw OAuthAuthenticationException()
}
```

### B. Discussion 백엔드 도메인과 CRUD API 추가
- **진입점 및 초기 조건:** `DiscussionController`는 `/posts/{postId}/suggestions/{suggestionId}/discussions` 하위 요청을 처리합니다.
- **단계별 제어 흐름:**
  1. `POST` 요청은 `WriteDiscussionRequest.content`를 검증하고, 현재 사용자와 `postId`, `suggestionId`를 `DiscussionService.createDiscussion()`에 전달합니다.
  2. 서비스는 `SuggestionRepository.findByIdAndPostId(suggestionId, postId)`로 suggestion과 post의 연관성을 검증합니다.
  3. 검증된 suggestion과 current user로 `Discussion` 엔티티를 생성해 저장합니다.
  4. `PATCH`와 `DELETE` 요청은 `findWithUserByIdAndSuggestionIdAndPostId()`로 `discussionId`, `suggestionId`, `postId`가 같은 경로에 속하는지 한 번에 확인합니다.
  5. 조회된 discussion의 `user.id`와 현재 user id가 다르면 `ForbiddenException`을 반환합니다.
- **데이터 상태 변이:** 생성 시 `discussions` 테이블에 새 row가 추가됩니다. 수정 시 `Discussion.updateContent()`가 content와 `updatedAt`을 변경합니다. 삭제 시 해당 discussion row가 제거됩니다.
- **최종 반환 및 종료 상태:** 생성은 `201 Created + DiscussionResponse`, 수정은 `200 OK + DiscussionResponse`, 삭제는 `204 No Content`를 반환합니다.

```kotlin
private fun getManageableDiscussion(
    userId: Long,
    postId: Long,
    suggestionId: Long,
    discussionId: Long,
): Discussion
```

### C. Suggestion 상세 응답에 discussion 목록과 권한 플래그 포함
- **진입점 및 초기 조건:** 프론트 상세 페이지는 `getPostSuggestionDetail(postId, suggestionId)`로 suggestion 상세 데이터를 조회합니다.
- **단계별 제어 흐름:**
  1. `SuggestController.getSuggestionDetail()`은 로그인 사용자가 없을 수 있으므로 `resolveCurrentUserIdOrNull()`로 current user id를 nullable 값으로 계산합니다.
  2. `SuggestService.getSuggestionDetail()`은 기존 suggestion 상세 데이터와 함께 `DiscussionRepository.findAllWithUserBySuggestionId()`를 호출합니다.
  3. 각 discussion은 `DiscussionService.toDiscussionResponse(discussion, currentUserId)`로 변환됩니다.
  4. `toDiscussionResponse()`는 author display name, profile image, content, createdAt, `canManage`를 구성합니다.
- **데이터 상태 변이:** `SuggestionDetailResponse`와 프론트 `ApiSuggestionDetail` 타입에 `discussions: List<DiscussionResponse>`가 추가됩니다.
- **최종 반환 및 종료 상태:** suggestion 상세 응답은 discussion 목록을 생성 시각 오름차순으로 포함하고, 프론트는 각 discussion별 관리 권한을 별도 계산 없이 사용할 수 있습니다.

```kotlin
discussions = discussions.map { discussion ->
    discussionService.toDiscussionResponse(discussion, currentUserId)
}
```

### D. Discussion 프론트 서버 액션 연결
- **진입점 및 초기 조건:** `SuggestionDiscussionSection`의 작성, 저장, 삭제 이벤트는 `frontend/src/02_features/discussion/api/discussionActions.ts` 서버 액션을 호출합니다.
- **단계별 제어 흐름:**
  1. `submitSuggestionDiscussion()`은 `POST /posts/{postId}/suggestions/{suggestionId}/discussions`로 `{ content }`를 전송합니다.
  2. `updateSuggestionDiscussion()`은 `PATCH /posts/{postId}/suggestions/{suggestionId}/discussions/{discussionId}`로 `{ content }`를 전송합니다.
  3. `deleteSuggestionDiscussion()`은 같은 discussion resource에 `DELETE` 요청을 전송합니다.
  4. 생성/수정은 공통 `sendDiscussionMutation()`을 사용해 content trim, 빈 문자열 검증, cookie 전달, 401 redirect, error message 파싱을 동일하게 처리합니다.
- **데이터 상태 변이:** 성공한 생성/수정 응답은 `ApiDiscussion`으로 역직렬화되고, 삭제 성공 응답은 `{ ok: true }`로 변환됩니다.
- **최종 반환 및 종료 상태:** 프론트 컴포넌트는 comment action과 동일한 `{ ok, message }` 형태의 결과를 받아 composer error fallback과 local state 갱신에 사용합니다.

```ts
return sendDiscussionMutation(
  `${API_CONFIG.baseURL}/posts/${postId}/suggestions/${suggestionId}/discussions/${discussionId}`,
  "PATCH",
  content,
  "수정할 내용을 입력해주세요.",
  "댓글을 수정하는 중 문제가 발생했습니다.",
);
```

### E. Suggestion 상세 Discussion UI의 작성, 수정, 삭제 상태 관리
- **진입점 및 초기 조건:** `frontend/app/[username]/posts/[postSlug]/suggestions/[suggestionNumber]/page.tsx`는 상세 응답의 `discussions`를 `Suggestion.discussionComments`로 매핑하고, `postId`, `suggestionId`, 현재 사용자 avatar를 `SuggestionDetail`에 전달합니다.
- **단계별 제어 흐름:**
  1. `SuggestionDetail`은 기존 정적 discussion section 대신 `SuggestionDiscussionSection`을 렌더링합니다.
  2. `SuggestionDiscussionSection`은 `initialComments`를 `discussionItems` 상태로 보관합니다.
  3. 새 discussion 작성 성공 시 응답 discussion을 `DiscussionComment`로 변환한 뒤 목록 끝에 추가하고 `router.refresh()`를 호출합니다.
  4. 수정 버튼 클릭 시 해당 discussion card는 `DiscussionComposer` edit mode로 전환됩니다.
  5. 저장 성공 시 해당 id의 discussion item을 응답 값으로 교체하고 edit 상태를 해제합니다.
  6. 삭제 버튼 클릭 시 confirm 이후 삭제 API를 호출하고, 성공하면 local list에서 해당 item을 제거합니다.
- **데이터 상태 변이:** `discussionItems`, `editingDiscussionId`, `deletingDiscussionId`, `actionError` 상태가 사용자 조작에 따라 변경됩니다. 서버 갱신 성공 후에는 `router.refresh()`가 서버 컴포넌트 데이터를 다시 요청합니다.
- **최종 반환 및 종료 상태:** 본인이 작성한 discussion에는 `Edit`/`Delete`가 노출되고, 타인이 작성한 discussion에는 관리 버튼이 렌더링되지 않습니다.

```tsx
{canManage ? (
  <div className="flex items-center gap-2">
    <button type="button" onClick={onEdit}>Edit</button>
    <button type="button" onClick={onDelete}>Delete</button>
  </div>
) : null}
```

### F. Discussion 렌더링 표시값과 기존 comment 표시 정리
- **진입점 및 초기 조건:** discussion과 comment card header는 작성자명과 작성일을 `commented on {date}` 형식으로 표시합니다.
- **단계별 제어 흐름:**
  1. JSX에 직접 붙어 있던 마침표를 제거합니다.
  2. `Intl.DateTimeFormat("ko-KR")`가 반환하는 날짜 끝 마침표는 `.replace(/\.$/, "")`로 제거합니다.
  3. discussion 본문은 일반 문자열 렌더링 대신 `MarkdownContent`를 사용해 comment와 동일한 markdown 표시 경로를 탑니다.
- **데이터 상태 변이:** 화면 표시 문자열은 `2026. 5. 1.`에서 `2026. 5. 1`로 변환됩니다.
- **최종 반환 및 종료 상태:** discussion과 comment header의 날짜 뒤 중복 마침표가 제거되고, discussion 본문은 작성/미리보기와 동일한 markdown 렌더링 결과를 표시합니다.

---

## 4. 스크린샷 (선택)
- 없음

## 5. 테스트 및 검증 방법
- **테스트 환경:** macOS 로컬 환경, 기준 브랜치 `develop`, 작업 브랜치 `feature/discussion`
- **입력 시나리오:**
  1. `./gradlew :backend:test`
  2. `cd frontend && npm run lint`
  3. `cd frontend && npx tsc --noEmit`
- **출력 검증:** 백엔드 테스트는 `BUILD SUCCESSFUL`로 통과했습니다. 프론트 TypeScript 검사는 exit code 0으로 통과했습니다. 프론트 lint는 exit code 0으로 통과했으며 기존 `frontend/src/01_widgets/onboarding/ui/OnboardingView.tsx`의 미사용 `Image` warning 1건만 유지됩니다.

---

## 6. 리뷰어 참고 사항 (선택)
- **특이 구현 사항:** Discussion 작성, 수정, 삭제는 기존 comment UI와 같은 `DiscussionComposer`를 재사용합니다. 따라서 discussion 전용 입력 컴포넌트를 새로 만들지 않고, 서버 액션 결과 타입만 discussion 응답 구조에 맞게 분리했습니다.
- **파급 효과:** `CurrentUserResolver.resolveCurrentUser()`가 `UserRepository`에 의존하게 되어 인증된 mutation 요청은 user id 파싱뿐 아니라 실제 user row 존재까지 확인합니다. 관련 controller/service 테스트 fixture는 service가 user id 대신 `User` 엔티티를 받는 변경에 맞춰 수정됐습니다.

---

## 7. 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일 가이드를 준수합니다.
- [x] 변경 사항에 대한 테스트 코드를 작성하거나 통과했습니다.
- [x] 관련된 문서(README, API 명세 등)를 업데이트했습니다.
