### PR TITLE
[Feat] Spring Security로 깃헙 OAuth 구현

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
     implementation("tools.jackson.module:jackson-module-kotlin")
     implementation("com.google.api-client:google-api-client:2.7.0")
     implementation("io.jsonwebtoken:jjwt-api:0.12.7")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
     testImplementation("org.springframework.boot:spring-boot-starter-cache-test")
     testImplementation("org.springframework.boot:spring-boot-starter-data-jpa-test")
     testImplementation("org.springframework.boot:spring-boot-starter-data-redis-test")

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AccessTokenCookieFactory.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AccessTokenCookieFactory.kt
@@ -1,0 +1,39 @@
+package io.github.kitae9999.openlog.auth
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.ResponseCookie
+import org.springframework.stereotype.Component
+
+@Component
+class AccessTokenCookieFactory(
+    private val jwtTokenService: JwtTokenService,
+    @Value("\${auth.jwt.cookie-name:openlog_access_token}")
+    private val accessTokenCookieName: String,
+    @Value("\${auth.jwt.cookie-secure:false}")
+    private val accessTokenCookieSecure: Boolean,
+    @Value("\${auth.jwt.cookie-domain:}")
+    private val accessTokenCookieDomain: String,
+) {
+    /**
+     * JWT을 받아서 응답 Cookie 인스턴스 생성
+     */
+    fun create(accessToken: String): ResponseCookie {
+        return withCookieDomain(ResponseCookie.from(accessTokenCookieName, accessToken))
+            .httpOnly(true)
+            .secure(accessTokenCookieSecure)
+            .sameSite("Lax")
+            .path("/")
+            .maxAge(jwtTokenService.accessTokenTtl())
+            .build()
+    }
+
+    private fun withCookieDomain(
+        builder: ResponseCookie.ResponseCookieBuilder
+    ): ResponseCookie.ResponseCookieBuilder {
+        return if (accessTokenCookieDomain.isBlank()) {
+            builder
+        } else {
+            builder.domain(accessTokenCookieDomain)
+        }
+    }
+}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthController.kt
@@ -27,12 +27,9 @@ class AuthController(
     private val authService: AuthService,
     private val currentUserResolver: CurrentUserResolver,
     private val jwtTokenService: JwtTokenService,
-    @Value("\${auth.jwt.cookie-name:openlog_access_token}")
-    private val accessTokenCookieName: String,
+    private val accessTokenCookieFactory: AccessTokenCookieFactory,
     @Value("\${auth.jwt.cookie-secure:false}")
     private val accessTokenCookieSecure: Boolean,
-    @Value("\${auth.jwt.cookie-domain:}")
-    private val accessTokenCookieDomain: String,
     @Value("\${app.frontend-home-url:http://localhost:3030}")
     private val frontendHomeUrl: String,
 ) {
@@ -110,13 +107,7 @@ class AuthController(
             email = email,
         )
         val issuedJwt = jwtTokenService.createAccessToken(currentUser)
-        val authCookie = withCookieDomain(ResponseCookie.from(accessTokenCookieName, issuedJwt))
-            .httpOnly(true)
-            .secure(accessTokenCookieSecure)
-            .sameSite("Lax")
-            .path("/")
-            .maxAge(jwtTokenService.accessTokenTtl())
-            .build()
+        val authCookie = accessTokenCookieFactory.create(issuedJwt)
 
         return ResponseEntity.status(HttpStatus.FOUND)
             .header(HttpHeaders.SET_COOKIE, deleteCookie.toString(), authCookie.toString())
@@ -142,16 +133,6 @@ class AuthController(
             bio = bio,
             isOnboardingComplete = isOnboardingComplete(),
         )
-    }
-
-    private fun withCookieDomain(
-        builder: ResponseCookie.ResponseCookieBuilder
-    ): ResponseCookie.ResponseCookieBuilder {
-        return if (accessTokenCookieDomain.isBlank()) {
-            builder
-        } else {
-            builder.domain(accessTokenCookieDomain)
-        }
     }
 
 //    @GetMapping("github")

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthService.kt
@@ -158,8 +158,23 @@ class AuthService(
         picture: String?,
         email: String?,
     ): User {
+        return findOrCreateOAuthUser(
+            provider = "google",
+            providerUserId = sub,
+            picture = picture,
+            email = email,
+        )
+    }
+
+    @Transactional
+    fun findOrCreateOAuthUser(
+        provider: String,
+        providerUserId: String,
+        picture: String?,
+        email: String?,
+    ): User {
         val existingAccount = oauthAccountRepository
-            .findByProviderAndProviderUserId("google", sub)
+            .findByProviderAndProviderUserId(provider, providerUserId)
 
         if (existingAccount != null) {
             return existingAccount.user
@@ -175,8 +190,8 @@ class AuthService(
         oauthAccountRepository.save(
             OauthAccount(
                 user = user,
-                provider = "google",
-                providerUserId = sub,
+                provider = provider,
+                providerUserId = providerUserId,
             )
         )
 

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/GithubOAuthSuccessHandler.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/GithubOAuthSuccessHandler.kt
@@ -1,19 +1,80 @@
 package io.github.kitae9999.openlog.auth
 
+import io.github.kitae9999.openlog.auth.exception.OAuthAuthenticationException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpHeaders
+import org.springframework.http.ResponseCookie
 import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler
 import org.springframework.stereotype.Component
+import java.net.URI
 
 @Component
 class GithubOAuthSuccessHandler(
-
+    private val authService: AuthService,
+    private val jwtTokenService: JwtTokenService,
+    @Value("\${auth.jwt.cookie-name:openlog_access_token}")
+    private val accessTokenCookieName: String,
+    @Value("\${auth.jwt.cookie-secure:false}")
+    private val accessTokenCookieSecure: Boolean,
+    @Value("\${auth.jwt.cookie-domain:}")
+    private val accessTokenCookieDomain: String,
+    @Value("\${app.frontend-home-url:http://localhost:3030}")
+    private val frontendHomeUrl: String,
 ): AuthenticationSuccessHandler {
     override fun onAuthenticationSuccess(
         request: HttpServletRequest,
         response: HttpServletResponse,
         authentication: Authentication
     ) {
+        val oauthToken = authentication as? OAuth2AuthenticationToken
+            ?: throw OAuthAuthenticationException()
+        val principal = oauthToken.principal // 사용자 정보가 없으면 에러
+            ?: throw OAuthAuthenticationException()
+
+        val attributes = principal.attributes
+
+        val providerUserId = attributes["id"]?.toString() // id가 null이면 에러
+            ?: throw OAuthAuthenticationException()
+
+        val email = attributes["email"] as? String // as로 타입캐스팅 실패하면 null반환
+        val avatarUrl = attributes["avatar_url"] as? String
+
+        val currentUser = authService.findOrCreateOAuthUser(
+            provider = oauthToken.authorizedClientRegistrationId,
+            providerUserId = providerUserId,
+            picture = avatarUrl,
+            email = email,
+        )
+        val issuedJwt = jwtTokenService.createAccessToken(currentUser)
+        val authCookie = withCookieDomain(ResponseCookie.from(accessTokenCookieName, issuedJwt))
+            .httpOnly(true)
+            .secure(accessTokenCookieSecure)
+            .sameSite("Lax")
+            .path("/")
+            .maxAge(jwtTokenService.accessTokenTtl())
+            .build()
+
+        response.addHeader(HttpHeaders.SET_COOKIE, authCookie.toString())
+        response.sendRedirect(
+            if (currentUser.isOnboardingComplete()) {
+                frontendHomeUrl
+            } else {
+                URI.create(frontendHomeUrl).resolve("/onboarding").toString()
+            },
+        )
+    }
+
+    private fun withCookieDomain(
+        builder: ResponseCookie.ResponseCookieBuilder
+    ): ResponseCookie.ResponseCookieBuilder {
+        return if (accessTokenCookieDomain.isBlank()) {
+            builder
+        } else {
+            builder.domain(accessTokenCookieDomain)
+        }
     }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/GithubOAuthSuccessHandler.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/GithubOAuthSuccessHandler.kt
@@ -1,0 +1,19 @@
+package io.github.kitae9999.openlog.auth
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.Authentication
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler
+import org.springframework.stereotype.Component
+
+@Component
+class GithubOAuthSuccessHandler(
+
+): AuthenticationSuccessHandler {
+    override fun onAuthenticationSuccess(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authentication: Authentication
+    ) {
+    }
+}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/GithubOAuthSuccessHandler.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/GithubOAuthSuccessHandler.kt
@@ -5,7 +5,6 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
-import org.springframework.http.ResponseCookie
 import org.springframework.security.core.Authentication
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler
@@ -16,12 +15,7 @@ import java.net.URI
 class GithubOAuthSuccessHandler(
     private val authService: AuthService,
     private val jwtTokenService: JwtTokenService,
-    @Value("\${auth.jwt.cookie-name:openlog_access_token}")
-    private val accessTokenCookieName: String,
-    @Value("\${auth.jwt.cookie-secure:false}")
-    private val accessTokenCookieSecure: Boolean,
-    @Value("\${auth.jwt.cookie-domain:}")
-    private val accessTokenCookieDomain: String,
+    private val accessTokenCookieFactory: AccessTokenCookieFactory,
     @Value("\${app.frontend-home-url:http://localhost:3030}")
     private val frontendHomeUrl: String,
 ): AuthenticationSuccessHandler {
@@ -50,13 +44,7 @@ class GithubOAuthSuccessHandler(
             email = email,
         )
         val issuedJwt = jwtTokenService.createAccessToken(currentUser)
-        val authCookie = withCookieDomain(ResponseCookie.from(accessTokenCookieName, issuedJwt))
-            .httpOnly(true)
-            .secure(accessTokenCookieSecure)
-            .sameSite("Lax")
-            .path("/")
-            .maxAge(jwtTokenService.accessTokenTtl())
-            .build()
+        val authCookie = accessTokenCookieFactory.create(issuedJwt)
 
         response.addHeader(HttpHeaders.SET_COOKIE, authCookie.toString())
         response.sendRedirect(
@@ -68,13 +56,4 @@ class GithubOAuthSuccessHandler(
         )
     }
 
-    private fun withCookieDomain(
-        builder: ResponseCookie.ResponseCookieBuilder
-    ): ResponseCookie.ResponseCookieBuilder {
-        return if (accessTokenCookieDomain.isBlank()) {
-            builder
-        } else {
-            builder.domain(accessTokenCookieDomain)
-        }
-    }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/config/SecurityConfig.kt
@@ -1,0 +1,40 @@
+package io.github.kitae9999.openlog.config
+
+import io.github.kitae9999.openlog.auth.GithubOAuthSuccessHandler
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfig (
+    private val githubOAuthSuccessHandler: GithubOAuthSuccessHandler
+){
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain { // @EnableWebSecurity로 지정된 클래스안에서 등록된 SecurityFilterChain 타입의 빈을 Spring Security가 보안 필터 체인으로 사용함
+        http
+            .csrf { it.disable() }
+            .sessionManagement {
+                it.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
+            }
+            .authorizeHttpRequests {
+                it
+                    .requestMatchers( // 일단 모든 요청에 대해 인증여부 필터링걸어두지않음. todo: post생성, suggest생성같은 로그인 권한이 필요한 경로에 authenticated걸어두기
+                        "/oauth2/**",
+                        "/login/oauth2/**",
+                        "/auth/google",
+                        "/auth/google/callback",
+                    ).permitAll()
+                    .anyRequest().permitAll()
+
+            }
+            .oauth2Login {
+                it.successHandler(githubOAuthSuccessHandler)
+            }
+
+        return http.build()
+    }
+}

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -7,6 +7,10 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "lh3.googleusercontent.com",
       },
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+      },
     ],
   },
 };

--- a/frontend/src/02_features/auth/api/handleOAuth.ts
+++ b/frontend/src/02_features/auth/api/handleOAuth.ts
@@ -1,9 +1,9 @@
 import { API_CONFIG } from "@/shared/api";
 import type { OAuthProvider } from "@/features/auth/model/auth.type";
 
-const providerPath = {
-  GOOGLE: "google",
-  GITHUB: "github",
+const providerOAuthPath = {
+  GOOGLE: "/api/auth/google",
+  GITHUB: "/api/oauth2/authorization/github",
 } satisfies Record<OAuthProvider, string>;
 
 export const handleOAuth = (provider: OAuthProvider) => {
@@ -12,7 +12,7 @@ export const handleOAuth = (provider: OAuthProvider) => {
   }
 
   const endpoint = new URL(
-    `/api/auth/${providerPath[provider]}`,
+    providerOAuthPath[provider],
     API_CONFIG.baseURL,
   );
 


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #

---

## 1. PR 유형
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ✨ 새로운 기능 (New Feature)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 업데이트 (Documentation)
- [x] ⚙️ 설정/빌드 변경 (Chore)

---

## 2. 작업 배경 및 목적
- **기존 상태:** Openlog의 OAuth 로그인은 Google provider를 직접 구현한 `/auth/google` 및 `/auth/google/callback` 흐름에만 연결되어 있었습니다. 프론트 로그인 모달에는 GitHub 버튼이 존재했지만, 백엔드에는 GitHub authorization code callback을 처리하거나 GitHub 사용자 정보를 서비스 사용자로 매핑하는 실행 경로가 없었습니다.
- **문제점:** GitHub 버튼이 기존 provider path 규칙대로 `/api/auth/github`를 호출하면 실제 OAuth 인증 필터 또는 컨트롤러가 요청을 처리하지 못했습니다. 또한 GitHub avatar URL은 Next Image remote pattern에 포함되어 있지 않아 GitHub 인증이 완료되어도 프로필 이미지 렌더링 단계에서 차단될 수 있었습니다.
- **해결 목표:** Spring Security OAuth2 Login으로 GitHub OAuth 프로토콜 처리를 위임하고, 인증 성공 시 기존 `users`/`oauth_accounts` 저장 구조와 자체 JWT 쿠키 발급 흐름에 연결합니다. Google 직접 구현 흐름은 유지하되, JWT 쿠키 생성 로직은 공통 팩토리로 분리해 Google과 GitHub가 동일한 쿠키 속성을 사용하도록 정리합니다.

---

## 3. 상세 변경 내역 및 동작 흐름

### A. Spring Security OAuth2 Login 기반 GitHub 인증 진입점 추가
- **진입점 및 초기 조건:** 프론트에서 GitHub 로그인 버튼을 클릭하면 `handleOAuth("GITHUB")`가 `NEXT_PUBLIC_API_BASE_URL`을 기준으로 `/api/oauth2/authorization/github` URL을 생성합니다.
- **단계별 제어 흐름:**
  1. `frontend/src/02_features/auth/api/handleOAuth.ts`는 Google과 GitHub의 OAuth 시작 path를 provider별 상수로 분리합니다.
  2. Google은 기존 직접 구현 경로인 `/api/auth/google`로 이동합니다.
  3. GitHub는 Spring Security OAuth2 Login 기본 authorization endpoint인 `/api/oauth2/authorization/github`로 이동합니다.
  4. `SecurityConfig.securityFilterChain()`은 `/oauth2/**`, `/login/oauth2/**`, 기존 Google callback 경로를 permit 처리하고 `oauth2Login` success handler를 등록합니다.
  5. Spring Security 내부 필터는 GitHub authorization URL 생성, state 검증, authorization code 교환, userinfo 조회를 수행합니다.
- **데이터 상태 변이:** 브라우저 location은 provider별 OAuth 시작 URL로 이동하고, GitHub OAuth 처리 중 Spring Security는 `OAuth2AuthenticationToken`을 생성합니다.
- **최종 반환 및 종료 상태:** GitHub OAuth 인증이 성공하면 `GithubOAuthSuccessHandler.onAuthenticationSuccess()`가 호출됩니다.

```kotlin
.oauth2Login {
    it.successHandler(githubOAuthSuccessHandler)
}
```

### B. GitHub OAuth 사용자 정보를 Openlog 사용자와 JWT 쿠키로 변환
- **진입점 및 초기 조건:** Spring Security가 GitHub OAuth 인증을 완료하면 `GithubOAuthSuccessHandler`에 `Authentication` 인자를 전달합니다.
- **단계별 제어 흐름:**
  1. success handler는 `Authentication`을 `OAuth2AuthenticationToken`으로 안전 캐스팅합니다.
  2. `principal.attributes`에서 GitHub 사용자 고유 id, email, avatar URL을 추출합니다.
  3. `authorizedClientRegistrationId` 값을 provider로 사용해 `AuthService.findOrCreateOAuthUser()`를 호출합니다.
  4. `JwtTokenService.createAccessToken()`이 영속화된 `User.id`를 subject로 하는 Openlog access token을 생성합니다.
  5. `AccessTokenCookieFactory.create()`가 JWT를 `HttpOnly`, `SameSite=Lax`, configured domain/secure 속성을 가진 `ResponseCookie`로 변환합니다.
  6. handler는 `Set-Cookie` 헤더를 추가하고, 온보딩 완료 여부에 따라 홈 또는 `/onboarding`으로 redirect합니다.
- **데이터 상태 변이:** 신규 GitHub 사용자라면 `users` row와 `oauth_accounts(provider="github", provider_user_id=<github id>)` row가 생성됩니다. 기존 사용자라면 저장된 OAuth account의 `user`가 재사용됩니다.
- **최종 반환 및 종료 상태:** 브라우저는 `openlog_access_token` 쿠키를 저장한 뒤 프론트 페이지로 이동하고, 이후 API 요청은 기존 JWT 기반 `CurrentUserResolver` 흐름을 그대로 사용합니다.

```kotlin
val currentUser = authService.findOrCreateOAuthUser(
    provider = oauthToken.authorizedClientRegistrationId,
    providerUserId = providerUserId,
    picture = avatarUrl,
    email = email,
)
```

### C. OAuth provider 공통 사용자 생성 로직과 JWT 쿠키 생성 팩토리 분리
- **진입점 및 초기 조건:** Google callback 또는 GitHub success handler가 OAuth provider 사용자 정보를 확보한 뒤 Openlog 사용자로 변환해야 합니다.
- **단계별 제어 흐름:**
  1. 기존 `findOrCreateGoogleUser()`는 Google 전용 조회/생성 구현을 직접 수행하지 않고 `findOrCreateOAuthUser()`에 위임합니다.
  2. `findOrCreateOAuthUser()`는 provider와 provider user id 조합으로 `OauthAccountRepository.findByProviderAndProviderUserId()`를 호출합니다.
  3. OAuth account가 존재하면 연결된 `User`를 반환합니다.
  4. 존재하지 않으면 `User(profileImageUrl, email)`을 저장한 뒤 같은 transaction에서 `OauthAccount`를 저장합니다.
  5. 기존 `AuthController` 내부의 JWT cookie builder 중복 로직은 `AccessTokenCookieFactory`로 이동합니다.
- **데이터 상태 변이:** OAuth account 조회 기준이 `"google"` 상수에서 provider 파라미터로 확장됩니다. JWT cookie 속성은 Google callback과 GitHub success handler가 같은 factory 설정을 공유합니다.
- **최종 반환 및 종료 상태:** provider가 추가되어도 user/account 생성 로직과 access token cookie 생성 로직은 동일한 코드 경로를 재사용합니다.

```kotlin
fun create(accessToken: String): ResponseCookie {
    return withCookieDomain(ResponseCookie.from(accessTokenCookieName, accessToken))
        .httpOnly(true)
        .secure(accessTokenCookieSecure)
        .sameSite("Lax")
        .path("/")
        .maxAge(jwtTokenService.accessTokenTtl())
        .build()
}
```

### D. GitHub 프로필 이미지 렌더링과 빌드 의존성 설정
- **진입점 및 초기 조건:** GitHub OAuth success handler가 `avatar_url`을 사용자 `profileImageUrl`로 저장하면 프론트의 `next/image`가 해당 remote image URL을 렌더링합니다.
- **단계별 제어 흐름:**
  1. `backend/build.gradle.kts`에 `spring-boot-starter-security`와 `spring-boot-starter-oauth2-client` 의존성을 추가합니다.
  2. `frontend/next.config.ts`의 `images.remotePatterns`에 `avatars.githubusercontent.com`을 추가합니다.
  3. 기존 Google avatar host인 `lh3.googleusercontent.com`은 유지합니다.
- **데이터 상태 변이:** 백엔드 클래스패스에는 Spring Security OAuth2 Client 구성이 포함되고, Next Image optimizer는 GitHub avatar host를 허용합니다.
- **최종 반환 및 종료 상태:** GitHub OAuth 인증 후 저장된 profile image URL이 Next Image에서 차단되지 않고 렌더링됩니다.

```ts
{
  protocol: "https",
  hostname: "avatars.githubusercontent.com",
}
```

---

## 4. 스크린샷 (선택)
- 없음

## 5. 테스트 및 검증 방법
- **테스트 환경:** macOS 로컬 환경, 기준 브랜치 `develop`, 작업 브랜치 `feature/github-oauth`
- **입력 시나리오:**
  1. `./gradlew :backend:compileKotlin`
  2. `cd frontend && npm run lint`
  3. 브라우저에서 `http://localhost:8080/api/oauth2/authorization/github` 인증 흐름 진입
- **출력 검증:** 백엔드 Kotlin 컴파일은 `BUILD SUCCESSFUL`로 통과했습니다. 프론트 lint는 exit code 0으로 통과했으며 기존 `frontend/src/01_widgets/onboarding/ui/OnboardingView.tsx`의 미사용 `Image` warning 1건만 유지됩니다. GitHub OAuth App callback URL을 `http://localhost:8080/api/login/oauth2/code/github`로 맞춘 뒤 authorize 및 JWT cookie 발급 흐름이 진행됨을 확인했고, GitHub avatar host 미허용 오류는 `next.config.ts` remote pattern 추가로 해소했습니다.

---

## 6. 리뷰어 참고 사항 (선택)
- **특이 구현 사항:** Google OAuth는 기존 직접 구현 흐름을 유지하고, GitHub OAuth만 Spring Security OAuth2 Login에 위임합니다. 따라서 일시적으로 Google은 `/auth/google` 컨트롤러 기반, GitHub는 `/oauth2/authorization/github` 필터 기반으로 진입점이 분리됩니다.
- **파급 효과:** Spring Security 기본 OAuth2 Login은 authorization request 저장에 session을 사용하므로 `SecurityConfig`는 `SessionCreationPolicy.IF_REQUIRED`를 사용합니다. API 인증 자체는 기존 Openlog JWT cookie 흐름을 유지합니다. GitHub email은 provider 응답에서 null일 수 있으므로, private email을 필수로 수집해야 하는 요구가 생기면 GitHub email API 호출 로직을 별도 추가해야 합니다.

---

## 7. 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일 가이드를 준수합니다.
- [x] 변경 사항에 대한 테스트 코드를 작성하거나 통과했습니다.
- [x] 관련된 문서(README, API 명세 등)를 업데이트했습니다.
