### PR TITLE
[Feat] 팔로우 기능 추가

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,15 +1,11 @@
 name: Backend CI
 
 on:
-  push:
-    paths:
-      - "backend/**"
-      - "gradle/**"
-      - "gradlew"
-      - "gradlew.bat"
-      - "settings.gradle.kts"
-      - ".github/workflows/backend-ci.yml"
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
     paths:
       - "backend/**"
       - "gradle/**"

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,11 +1,11 @@
 name: Frontend CI
 
 on:
-  push:
-    paths:
-      - "frontend/**"
-      - ".github/workflows/frontend-ci.yml"
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
     paths:
       - "frontend/**"
       - ".github/workflows/frontend-ci.yml"

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/comment/repository/CommentRepository.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/comment/repository/CommentRepository.kt
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
 interface CommentRepository : JpaRepository<Comment, Long> {
+    //Todo: @EntityGraph로 수정
     @Query(
         """
         select c

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/FollowController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/FollowController.kt
@@ -1,21 +1,23 @@
 package io.github.kitae9999.openlog.follow
 
 import io.github.kitae9999.openlog.auth.CurrentUserResolver
+import io.github.kitae9999.openlog.follow.dto.FollowUserResponse
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("users/{username}/follow")
+@RequestMapping("users/{username}")
 class FollowController(
     private val followService: FollowService,
     private val currentUserResolver: CurrentUserResolver
 ) {
-    @PostMapping
+    @PostMapping("/follow")
     fun followUser(
         @PathVariable("username") targetUsername : String,
         request: HttpServletRequest
@@ -28,7 +30,7 @@ class FollowController(
         return ResponseEntity.noContent().build()
     }
 
-    @DeleteMapping
+    @DeleteMapping("/follow")
     fun unfollowUser(
         @PathVariable("username") targetUsername : String,
         request: HttpServletRequest
@@ -39,5 +41,19 @@ class FollowController(
             targetUsername = targetUsername
         )
         return ResponseEntity.noContent().build()
+    }
+
+    @GetMapping("/following")
+    fun getFollowing(
+        @PathVariable username: String
+    ): List<FollowUserResponse> {
+        return followService.getFollowing(username)
+    }
+
+    @GetMapping("/followers")
+    fun getFollowers(
+        @PathVariable username: String
+    ): List<FollowUserResponse> {
+        return followService.getFollowers(username)
     }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/FollowController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/FollowController.kt
@@ -1,0 +1,7 @@
+package io.github.kitae9999.openlog.follow
+
+import org.springframework.stereotype.Controller
+
+@Controller
+class FollowController {
+}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/FollowController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/FollowController.kt
@@ -3,6 +3,7 @@ package io.github.kitae9999.openlog.follow
 import io.github.kitae9999.openlog.auth.CurrentUserResolver
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -21,6 +22,19 @@ class FollowController(
     ): ResponseEntity<Void> {
         val currentUser = currentUserResolver.resolveCurrentUser(request)
         followService.followUser(
+            currentUser = currentUser,
+            targetUsername = targetUsername
+        )
+        return ResponseEntity.noContent().build()
+    }
+
+    @DeleteMapping
+    fun unfollowUser(
+        @PathVariable("username") targetUsername : String,
+        request: HttpServletRequest
+    ): ResponseEntity<Void> {
+        val currentUser = currentUserResolver.resolveCurrentUser(request)
+        followService.unfollowUser(
             currentUser = currentUser,
             targetUsername = targetUsername
         )

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/FollowController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/FollowController.kt
@@ -1,7 +1,29 @@
 package io.github.kitae9999.openlog.follow
 
-import org.springframework.stereotype.Controller
+import io.github.kitae9999.openlog.auth.CurrentUserResolver
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 
-@Controller
-class FollowController {
+@RestController
+@RequestMapping("users/{username}/follow")
+class FollowController(
+    private val followService: FollowService,
+    private val currentUserResolver: CurrentUserResolver
+) {
+    @PostMapping
+    fun followUser(
+        @PathVariable("username") targetUsername : String,
+        request: HttpServletRequest
+    ): ResponseEntity<Void> {
+        val currentUser = currentUserResolver.resolveCurrentUser(request)
+        followService.followUser(
+            currentUser = currentUser,
+            targetUsername = targetUsername
+        )
+        return ResponseEntity.noContent().build()
+    }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/FollowRepository.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/FollowRepository.kt
@@ -2,7 +2,17 @@ package io.github.kitae9999.openlog.follow
 
 import io.github.kitae9999.openlog.follow.entity.Follow
 import io.github.kitae9999.openlog.follow.entity.FollowId
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface FollowRepository: JpaRepository<Follow, FollowId> {
+    @EntityGraph(attributePaths = ["followingUser"])
+    fun findAllByFollowedUser_IdOrderByCreatedAtDesc(followedUserId: Long): List<Follow>
+
+    @EntityGraph(attributePaths = ["followedUser"])
+    fun findAllByFollowingUser_IdOrderByCreatedAtDesc(followingUserId: Long): List<Follow>
+
+    fun countByFollowedUser_Id(followedUserId: Long): Long
+
+    fun countByFollowingUser_Id(followingUserId: Long): Long
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/FollowRepository.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/FollowRepository.kt
@@ -1,0 +1,8 @@
+package io.github.kitae9999.openlog.follow
+
+import io.github.kitae9999.openlog.follow.entity.Follow
+import io.github.kitae9999.openlog.follow.entity.FollowId
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface FollowRepository: JpaRepository<Follow, FollowId> {
+}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/FollowService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/FollowService.kt
@@ -1,7 +1,48 @@
 package io.github.kitae9999.openlog.follow
 
+import io.github.kitae9999.openlog.common.exception.BadRequestException
+import io.github.kitae9999.openlog.common.exception.NotFoundException
+import io.github.kitae9999.openlog.follow.entity.Follow
+import io.github.kitae9999.openlog.follow.entity.FollowId
+import io.github.kitae9999.openlog.user.entity.User
+import io.github.kitae9999.openlog.user.repository.UserRepository
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
-class FollowService {
+class FollowService(
+    private val followRepository: FollowRepository,
+    private val userRepository: UserRepository
+) {
+    @Transactional
+    fun followUser(
+        targetUsername: String,
+        currentUser: User
+    ) {
+        val targetUser = userRepository.findByUsername(targetUsername) ?: throw NotFoundException("사용자를 찾을 수 없습니다.")
+
+        val currentUserId = requireNotNull(currentUser.id)
+        val targetUserId = requireNotNull(targetUser.id)
+
+        if (currentUserId == targetUserId) {
+            throw BadRequestException("자기 자신은 팔로우할 수 없습니다.")
+        }
+
+        val followId = FollowId(
+            followingUserId = currentUserId,
+            followedUserId = targetUserId,
+        )
+
+        if (followRepository.existsById(followId)) {
+            return
+        }
+
+        followRepository.save(
+            Follow(
+                followingUser = currentUser,
+                followedUser = targetUser,
+            )
+        )
+    }
+
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/FollowService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/FollowService.kt
@@ -19,19 +19,7 @@ class FollowService(
         targetUsername: String,
         currentUser: User
     ) {
-        val targetUser = userRepository.findByUsername(targetUsername) ?: throw NotFoundException("사용자를 찾을 수 없습니다.")
-
-        val currentUserId = requireNotNull(currentUser.id)
-        val targetUserId = requireNotNull(targetUser.id)
-
-        if (currentUserId == targetUserId) {
-            throw BadRequestException("자기 자신은 팔로우할 수 없습니다.")
-        }
-
-        val followId = FollowId(
-            followingUserId = currentUserId,
-            followedUserId = targetUserId,
-        )
+        val (targetUser, followId) = resolveTargetUserAndFollowId(targetUsername, currentUser)
 
         if (followRepository.existsById(followId)) {
             return
@@ -45,4 +33,36 @@ class FollowService(
         )
     }
 
+    @Transactional
+    fun unfollowUser(
+        targetUsername: String,
+        currentUser: User
+    ) {
+        val (_, followId) = resolveTargetUserAndFollowId(targetUsername, currentUser)
+
+        if (!followRepository.existsById(followId)) {
+            return
+        }
+
+        followRepository.deleteById(followId)
+    }
+
+    private fun resolveTargetUserAndFollowId(
+        targetUsername: String,
+        currentUser: User,
+    ): Pair<User, FollowId> {
+        val targetUser = userRepository.findByUsername(targetUsername) ?: throw NotFoundException("사용자를 찾을 수 없습니다.")
+
+        val currentUserId = requireNotNull(currentUser.id)
+        val targetUserId = requireNotNull(targetUser.id)
+
+        if (currentUserId == targetUserId) {
+            throw BadRequestException("자기 자신은 팔로우할 수 없습니다.")
+        }
+
+        return targetUser to FollowId( // User, FollowId 타입의 pair 생성
+            followingUserId = currentUserId,
+            followedUserId = targetUserId,
+        )
+    }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/FollowService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/FollowService.kt
@@ -1,0 +1,7 @@
+package io.github.kitae9999.openlog.follow
+
+import org.springframework.stereotype.Service
+
+@Service
+class FollowService {
+}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/FollowService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/FollowService.kt
@@ -2,6 +2,7 @@ package io.github.kitae9999.openlog.follow
 
 import io.github.kitae9999.openlog.common.exception.BadRequestException
 import io.github.kitae9999.openlog.common.exception.NotFoundException
+import io.github.kitae9999.openlog.follow.dto.FollowUserResponse
 import io.github.kitae9999.openlog.follow.entity.Follow
 import io.github.kitae9999.openlog.follow.entity.FollowId
 import io.github.kitae9999.openlog.user.entity.User
@@ -47,11 +48,34 @@ class FollowService(
         followRepository.deleteById(followId)
     }
 
+
+    @Transactional
+    fun getFollowers(
+        username: String
+    ): List<FollowUserResponse> {
+        val user = findUserByUsername(username)
+        val userId = requireNotNull(user.id)
+
+        return followRepository.findAllByFollowedUser_IdOrderByCreatedAtDesc(userId)
+            .map { it.followingUser.toFollowUserResponse() }
+    }
+
+    @Transactional
+    fun getFollowing(
+        username: String
+    ): List<FollowUserResponse> {
+        val user = findUserByUsername(username)
+        val userId = requireNotNull(user.id)
+
+        return followRepository.findAllByFollowingUser_IdOrderByCreatedAtDesc(userId)
+            .map { it.followedUser.toFollowUserResponse() }
+    }
+
     private fun resolveTargetUserAndFollowId(
         targetUsername: String,
         currentUser: User,
     ): Pair<User, FollowId> {
-        val targetUser = userRepository.findByUsername(targetUsername) ?: throw NotFoundException("사용자를 찾을 수 없습니다.")
+        val targetUser = findUserByUsername(targetUsername)
 
         val currentUserId = requireNotNull(currentUser.id)
         val targetUserId = requireNotNull(targetUser.id)
@@ -63,6 +87,18 @@ class FollowService(
         return targetUser to FollowId( // User, FollowId 타입의 pair 생성
             followingUserId = currentUserId,
             followedUserId = targetUserId,
+        )
+    }
+
+    private fun findUserByUsername(username: String): User {
+        return userRepository.findByUsername(username) ?: throw NotFoundException("사용자를 찾을 수 없습니다.")
+    }
+
+    private fun User.toFollowUserResponse(): FollowUserResponse {
+        return FollowUserResponse(
+            username = requireNotNull(username),
+            nickname = nickname,
+            profileImageUrl = profileImageUrl,
         )
     }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/dto/FollowUserResponse.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/dto/FollowUserResponse.kt
@@ -1,0 +1,7 @@
+package io.github.kitae9999.openlog.follow.dto
+
+data class FollowUserResponse(
+    val username: String,
+    val nickname: String?,
+    val profileImageUrl: String?,
+)

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/entity/Follow.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/entity/Follow.kt
@@ -1,0 +1,42 @@
+package io.github.kitae9999.openlog.follow.entity
+
+import io.github.kitae9999.openlog.user.entity.User
+import jakarta.persistence.Column
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.MapsId
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "follows")
+class Follow(
+    followingUser: User,
+    followedUser: User,
+) {
+    @EmbeddedId
+    var id: FollowId = FollowId(
+        followingUserId = requireNotNull(followingUser.id),
+        followedUserId = requireNotNull(followedUser.id),
+    )
+        protected set
+
+    @MapsId("followingUserId")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "following_user_id", nullable = false)
+    var followingUser: User = followingUser
+        protected set
+
+    @MapsId("followedUserId")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "followed_user_id", nullable = false)
+    var followedUser: User = followedUser
+        protected set
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now()
+        protected set
+}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/entity/FollowId.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/follow/entity/FollowId.kt
@@ -1,0 +1,14 @@
+package io.github.kitae9999.openlog.follow.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import java.io.Serializable
+
+@Embeddable
+data class FollowId(
+    @Column(name = "following_user_id")
+    val followingUserId: Long = 0L,
+
+    @Column(name = "followed_user_id")
+    val followedUserId: Long = 0L,
+) : Serializable

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserController.kt
@@ -24,8 +24,9 @@ class UserController(
     @GetMapping("{username}")
     fun getPublicProfile(
         @PathVariable username: String,
+        request: HttpServletRequest,
     ): PublicUserProfileResponse {
-        return userService.getPublicProfile(username)
+        return userService.getPublicProfile(username, resolveUserIdOrNull(request))
     }
 
     @GetMapping("{username}/posts")

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserService.kt
@@ -106,6 +106,8 @@ class UserService(
     }
 
     private fun toPublicUserProfileResponse(user: User, following: Boolean): PublicUserProfileResponse {
+        val userId = requireNotNull(user.id)
+
         return PublicUserProfileResponse(
             username = requireNotNull(user.username),
             nickname = user.nickname,
@@ -115,6 +117,8 @@ class UserService(
             websiteUrl = user.websiteUrl,
             joinedAt = user.createdAt.toString(),
             following = following,
+            followersCount = followRepository.countByFollowedUser_Id(userId),
+            followingCount = followRepository.countByFollowingUser_Id(userId),
         )
     }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserService.kt
@@ -2,6 +2,8 @@ package io.github.kitae9999.openlog.user
 
 import io.github.kitae9999.openlog.common.exception.ForbiddenException
 import io.github.kitae9999.openlog.common.exception.NotFoundException
+import io.github.kitae9999.openlog.follow.FollowRepository
+import io.github.kitae9999.openlog.follow.entity.FollowId
 import io.github.kitae9999.openlog.post.dto.PostDetailResponse
 import io.github.kitae9999.openlog.post.formatPublishedAtLabel
 import io.github.kitae9999.openlog.post.repository.PostRepository
@@ -21,12 +23,18 @@ class UserService(
     private val postRepository: PostRepository,
     private val postTopicRepository: PostTopicRepository,
     private val postLikeRepository: PostLikeRepository,
+    private val followRepository: FollowRepository,
 ) {
     @Transactional
-    fun getPublicProfile(username: String): PublicUserProfileResponse {
+    fun getPublicProfile(username: String, viewerId: Long?): PublicUserProfileResponse {
         val user = userRepository.findByUsername(username) ?: throw NotFoundException("사용자를 찾을 수 없습니다.")
+        val userId = requireNotNull(user.id)
+        val following = viewerId
+            ?.takeIf { it != userId }
+            ?.let { followRepository.existsById(FollowId(followingUserId = it, followedUserId = userId)) }
+            ?: false
 
-        return toPublicUserProfileResponse(user)
+        return toPublicUserProfileResponse(user, following)
     }
 
     @Transactional
@@ -94,10 +102,10 @@ class UserService(
             websiteUrl = websiteUrl?.trim()?.takeIf { it.isNotEmpty() },
         )
 
-        return toPublicUserProfileResponse(user)
+        return toPublicUserProfileResponse(user, following = false)
     }
 
-    private fun toPublicUserProfileResponse(user: User): PublicUserProfileResponse {
+    private fun toPublicUserProfileResponse(user: User, following: Boolean): PublicUserProfileResponse {
         return PublicUserProfileResponse(
             username = requireNotNull(user.username),
             nickname = user.nickname,
@@ -106,6 +114,7 @@ class UserService(
             location = user.location,
             websiteUrl = user.websiteUrl,
             joinedAt = user.createdAt.toString(),
+            following = following,
         )
     }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/dto/PublicUserProfileResponse.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/dto/PublicUserProfileResponse.kt
@@ -8,4 +8,5 @@ data class PublicUserProfileResponse(
     val location: String?,
     val websiteUrl: String?,
     val joinedAt: String,
+    val following: Boolean,
 )

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/dto/PublicUserProfileResponse.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/dto/PublicUserProfileResponse.kt
@@ -9,4 +9,6 @@ data class PublicUserProfileResponse(
     val websiteUrl: String?,
     val joinedAt: String,
     val following: Boolean,
+    val followersCount: Long,
+    val followingCount: Long,
 )

--- a/frontend/src/01_widgets/profile/ui/EditableProfileHeader.tsx
+++ b/frontend/src/01_widgets/profile/ui/EditableProfileHeader.tsx
@@ -11,11 +11,11 @@ import {
 } from "react";
 import type { PublicUserProfile } from "@/entities/user/api/getPublicUserProfile";
 import {
-  getUserFollowList,
   type FollowListType,
   type FollowUser,
 } from "@/entities/user/api/getUserFollowList";
 import {
+  getProfileFollowListAction,
   toggleFollowAction,
   updateProfileAction,
   type UpdateProfileActionState,
@@ -199,7 +199,10 @@ export function EditableProfileHeader({
     setIsFollowListLoading(true);
 
     try {
-      const users = await getUserFollowList(currentProfile.username, type);
+      const users = await getProfileFollowListAction(
+        currentProfile.username,
+        type,
+      );
       setFollowListUsers(users);
     } catch {
       setFollowListError("목록을 불러오지 못했습니다.");

--- a/frontend/src/01_widgets/profile/ui/EditableProfileHeader.tsx
+++ b/frontend/src/01_widgets/profile/ui/EditableProfileHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import {
   useOptimistic,
@@ -10,12 +11,18 @@ import {
 } from "react";
 import type { PublicUserProfile } from "@/entities/user/api/getPublicUserProfile";
 import {
+  getUserFollowList,
+  type FollowListType,
+  type FollowUser,
+} from "@/entities/user/api/getUserFollowList";
+import {
   toggleFollowAction,
   updateProfileAction,
   type UpdateProfileActionState,
   type UpdateProfileValues,
 } from "@/features/profile/api/profileActions";
 import { assets } from "@/shared/config/assets";
+import { buildPublicProfilePath } from "@/shared/lib/publicRoutes";
 
 type FieldName = "nickname" | "bio" | "location" | "websiteUrl";
 
@@ -46,6 +53,12 @@ export function EditableProfileHeader({
   const [isPending, startTransition] = useTransition();
   const [following, setFollowing] = useOptimistic(profile.following);
   const [isFollowPending, startFollowTransition] = useTransition();
+  const [followListType, setFollowListType] = useState<FollowListType | null>(
+    null,
+  );
+  const [followListUsers, setFollowListUsers] = useState<FollowUser[]>([]);
+  const [isFollowListLoading, setIsFollowListLoading] = useState(false);
+  const [followListError, setFollowListError] = useState<string | null>(null);
 
   const profileName = currentProfile.nickname ?? currentProfile.username;
 
@@ -179,6 +192,22 @@ export function EditableProfileHeader({
     });
   }
 
+  async function handleOpenFollowList(type: FollowListType) {
+    setFollowListType(type);
+    setFollowListUsers([]);
+    setFollowListError(null);
+    setIsFollowListLoading(true);
+
+    try {
+      const users = await getUserFollowList(currentProfile.username, type);
+      setFollowListUsers(users);
+    } catch {
+      setFollowListError("목록을 불러오지 못했습니다.");
+    } finally {
+      setIsFollowListLoading(false);
+    }
+  }
+
   if (isEditing) {
     return (
       <section className="rounded-[28px] border border-zinc-200/80 bg-white px-6 py-7 shadow-[0_1px_2px_rgba(16,24,40,0.04)] sm:px-8 sm:py-8">
@@ -187,7 +216,11 @@ export function EditableProfileHeader({
           className="flex flex-col gap-8 lg:flex-row lg:items-start"
         >
           <input type="hidden" name="username" value={currentProfile.username} />
-          <ProfileAvatar profile={currentProfile} profileName={profileName} />
+          <ProfileAvatar
+            profile={currentProfile}
+            profileName={profileName}
+            onOpenFollowList={handleOpenFollowList}
+          />
 
           <div className="min-w-0 flex-1">
             <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -261,7 +294,11 @@ export function EditableProfileHeader({
   return (
     <section className="rounded-[28px] border border-zinc-200/80 bg-white px-6 py-7 shadow-[0_1px_2px_rgba(16,24,40,0.04)] sm:px-8 sm:py-8">
       <div className="flex flex-col gap-8 lg:flex-row lg:items-start">
-        <ProfileAvatar profile={currentProfile} profileName={profileName} />
+        <ProfileAvatar
+          profile={currentProfile}
+          profileName={profileName}
+          onOpenFollowList={handleOpenFollowList}
+        />
 
         <div className="min-w-0 flex-1">
           <div className="min-w-0">
@@ -332,6 +369,15 @@ export function EditableProfileHeader({
           </div>
         </div>
       </div>
+      {followListType ? (
+        <FollowListModal
+          type={followListType}
+          users={followListUsers}
+          loading={isFollowListLoading}
+          error={followListError}
+          onClose={() => setFollowListType(null)}
+        />
+      ) : null}
     </section>
   );
 }
@@ -339,12 +385,14 @@ export function EditableProfileHeader({
 function ProfileAvatar({
   profile,
   profileName,
+  onOpenFollowList,
 }: {
   profile: PublicUserProfile;
   profileName: string;
+  onOpenFollowList: (type: FollowListType) => void;
 }) {
   return (
-    <div className="mx-auto lg:mx-0">
+    <div className="mx-auto flex shrink-0 flex-col items-center gap-4 lg:mx-0">
       <div className="rounded-full border-4 border-zinc-50 bg-white p-1">
         <Image
           src={profile.profileImageUrl ?? assets.defaultAvatar}
@@ -355,7 +403,157 @@ function ProfileAvatar({
           priority
         />
       </div>
+      <div className="flex items-center gap-4 text-sm text-zinc-500">
+        <button
+          type="button"
+          onClick={() => onOpenFollowList("followers")}
+          className="inline-flex cursor-pointer items-baseline gap-1 transition hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
+        >
+          <span className="font-semibold text-zinc-950">
+            {profile.followersCount}
+          </span>
+          <span>Followers</span>
+        </button>
+        <button
+          type="button"
+          onClick={() => onOpenFollowList("following")}
+          className="inline-flex cursor-pointer items-baseline gap-1 transition hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
+        >
+          <span className="font-semibold text-zinc-950">
+            {profile.followingCount}
+          </span>
+          <span>Following</span>
+        </button>
+      </div>
     </div>
+  );
+}
+
+function FollowListModal({
+  type,
+  users,
+  loading,
+  error,
+  onClose,
+}: {
+  type: FollowListType;
+  users: FollowUser[];
+  loading: boolean;
+  error: string | null;
+  onClose: () => void;
+}) {
+  const title = type === "followers" ? "Followers" : "Following";
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-950/30 px-4"
+      role="presentation"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="follow-list-title"
+        className="w-full max-w-sm rounded-2xl bg-white p-5 shadow-xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center justify-between gap-4">
+          <h2
+            id="follow-list-title"
+            className="text-base font-semibold text-zinc-950"
+          >
+            {title}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex size-8 cursor-pointer items-center justify-center rounded-full text-zinc-500 transition hover:bg-zinc-100 hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
+            aria-label="Close"
+          >
+            x
+          </button>
+        </div>
+        <FollowListContent
+          title={title}
+          users={users}
+          loading={loading}
+          error={error}
+          onClose={onClose}
+        />
+      </div>
+    </div>
+  );
+}
+
+function FollowListContent({
+  title,
+  users,
+  loading,
+  error,
+  onClose,
+}: {
+  title: string;
+  users: FollowUser[];
+  loading: boolean;
+  error: string | null;
+  onClose: () => void;
+}) {
+  if (loading) {
+    return (
+      <div className="mt-6 rounded-xl border border-dashed border-zinc-200 px-4 py-8 text-center text-sm text-zinc-500">
+        Loading {title.toLowerCase()}...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="mt-6 rounded-xl border border-rose-100 bg-rose-50 px-4 py-4 text-sm font-medium text-rose-700">
+        {error}
+      </div>
+    );
+  }
+
+  if (users.length === 0) {
+    return (
+      <div className="mt-6 rounded-xl border border-dashed border-zinc-200 px-4 py-8 text-center text-sm text-zinc-500">
+        No {title.toLowerCase()} yet.
+      </div>
+    );
+  }
+
+  return (
+    <ul className="mt-5 max-h-[360px] overflow-y-auto">
+      {users.map((user) => {
+        const name = user.nickname ?? user.username;
+
+        return (
+          <li key={user.username}>
+            <Link
+              href={buildPublicProfilePath(user.username)}
+              onClick={onClose}
+              className="flex items-center gap-3 rounded-xl px-2 py-3 transition hover:bg-zinc-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/10"
+            >
+              <Image
+                src={user.profileImageUrl ?? assets.defaultAvatar}
+                alt={`${name} avatar`}
+                width={40}
+                height={40}
+                className="size-10 rounded-full object-cover"
+              />
+              <span className="min-w-0">
+                <span className="block truncate text-sm font-semibold text-zinc-950">
+                  {name}
+                </span>
+                <span className="block truncate text-sm text-zinc-500">
+                  @{user.username}
+                </span>
+              </span>
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
   );
 }
 

--- a/frontend/src/01_widgets/profile/ui/EditableProfileHeader.tsx
+++ b/frontend/src/01_widgets/profile/ui/EditableProfileHeader.tsx
@@ -2,9 +2,15 @@
 
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { useState, useTransition, type FormEvent } from "react";
+import {
+  useOptimistic,
+  useState,
+  useTransition,
+  type FormEvent,
+} from "react";
 import type { PublicUserProfile } from "@/entities/user/api/getPublicUserProfile";
 import {
+  toggleFollowAction,
   updateProfileAction,
   type UpdateProfileActionState,
   type UpdateProfileValues,
@@ -38,6 +44,8 @@ export function EditableProfileHeader({
   >({});
   const [serverErrors, setServerErrors] = useState(initialState.errors);
   const [isPending, startTransition] = useTransition();
+  const [following, setFollowing] = useOptimistic(profile.following);
+  const [isFollowPending, startFollowTransition] = useTransition();
 
   const profileName = currentProfile.nickname ?? currentProfile.username;
 
@@ -152,6 +160,25 @@ export function EditableProfileHeader({
     });
   }
 
+  function handleFollowToggle() {
+    if (!canFollow || isFollowPending) {
+      return;
+    }
+
+    const currentFollowing = following;
+
+    startFollowTransition(async () => {
+      setFollowing(!currentFollowing);
+
+      try {
+        await toggleFollowAction(currentProfile.username, currentFollowing);
+        router.refresh();
+      } catch {
+        router.refresh();
+      }
+    });
+  }
+
   if (isEditing) {
     return (
       <section className="rounded-[28px] border border-zinc-200/80 bg-white px-6 py-7 shadow-[0_1px_2px_rgba(16,24,40,0.04)] sm:px-8 sm:py-8">
@@ -255,17 +282,29 @@ export function EditableProfileHeader({
               ) : canFollow ? (
                 <button
                   type="button"
-                  className="inline-flex shrink-0 cursor-pointer items-center gap-2 text-sm font-semibold text-zinc-950 transition hover:text-zinc-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
+                  onClick={handleFollowToggle}
+                  disabled={isFollowPending}
+                  className="inline-flex shrink-0 cursor-pointer items-center gap-1 text-sm font-semibold text-zinc-950 transition hover:text-zinc-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
                 >
-                  <Image
-                    src="/Users.svg"
-                    alt=""
-                    width={16}
-                    height={16}
-                    aria-hidden="true"
-                    className="size-4"
-                  />
-                  Follow
+                  {following ? (
+                    <Image
+                      src="/Users.svg"
+                      alt=""
+                      width={16}
+                      height={16}
+                      aria-hidden="true"
+                      className="size-4"
+                    />
+                  ) : (
+                    <span
+                      aria-hidden="true"
+                      className="relative inline-block size-3 shrink-0"
+                    >
+                      <span className="absolute left-1/2 top-1/2 h-[1.5px] w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-current" />
+                      <span className="absolute left-1/2 top-1/2 h-2.5 w-[1.5px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-current" />
+                    </span>
+                  )}
+                  {following ? "Following" : "Follow"}
                 </button>
               ) : null}
             </div>

--- a/frontend/src/01_widgets/profile/ui/EditableProfileHeader.tsx
+++ b/frontend/src/01_widgets/profile/ui/EditableProfileHeader.tsx
@@ -16,10 +16,12 @@ type FieldName = "nickname" | "bio" | "location" | "websiteUrl";
 export function EditableProfileHeader({
   profile,
   isViewer,
+  canFollow,
   joinedLabel,
 }: {
   profile: PublicUserProfile;
   isViewer: boolean;
+  canFollow: boolean;
   joinedLabel: string;
 }) {
   const router = useRouter();
@@ -249,6 +251,21 @@ export function EditableProfileHeader({
                 >
                   <IconPencil className="size-4" />
                   Edit
+                </button>
+              ) : canFollow ? (
+                <button
+                  type="button"
+                  className="inline-flex shrink-0 cursor-pointer items-center gap-2 text-sm font-semibold text-zinc-950 transition hover:text-zinc-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
+                >
+                  <Image
+                    src="/Users.svg"
+                    alt=""
+                    width={16}
+                    height={16}
+                    aria-hidden="true"
+                    className="size-4"
+                  />
+                  Follow
                 </button>
               ) : null}
             </div>

--- a/frontend/src/01_widgets/profile/ui/ProfileView.tsx
+++ b/frontend/src/01_widgets/profile/ui/ProfileView.tsx
@@ -44,6 +44,7 @@ export async function ProfileView({ username }: { username: string }) {
             <EditableProfileHeader
               profile={profile}
               isViewer={isViewer}
+              canFollow={!!viewer && !isViewer}
               joinedLabel={joinedLabel}
             />
           </div>

--- a/frontend/src/02_features/profile/api/profileActions.ts
+++ b/frontend/src/02_features/profile/api/profileActions.ts
@@ -4,6 +4,10 @@ import { revalidatePath } from "next/cache";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import type { PublicUserProfile } from "@/entities/user/api/getPublicUserProfile";
+import type {
+  FollowListType,
+  FollowUser,
+} from "@/entities/user/api/getUserFollowList";
 import { API_CONFIG } from "@/shared/api";
 import { buildPublicProfilePath } from "@/shared/lib/publicRoutes";
 
@@ -133,6 +137,24 @@ export async function toggleFollowAction(
   }
 
   throw new Error("팔로우 상태를 변경하는 중 문제가 발생했습니다.");
+}
+
+export async function getProfileFollowListAction(
+  username: string,
+  type: FollowListType,
+): Promise<FollowUser[]> {
+  const response = await fetch(
+    `${API_CONFIG.baseURL}/users/${encodeURIComponent(username)}/${type}`,
+    {
+      cache: "no-store",
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error("팔로우 목록을 불러오지 못했습니다.");
+  }
+
+  return (await response.json()) as FollowUser[];
 }
 
 function toUpdateProfileValues(profile: PublicUserProfile): UpdateProfileValues {

--- a/frontend/src/02_features/profile/api/profileActions.ts
+++ b/frontend/src/02_features/profile/api/profileActions.ts
@@ -1,9 +1,11 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import type { PublicUserProfile } from "@/entities/user/api/getPublicUserProfile";
 import { API_CONFIG } from "@/shared/api";
+import { buildPublicProfilePath } from "@/shared/lib/publicRoutes";
 
 export type UpdateProfileValues = {
   username: string;
@@ -103,6 +105,34 @@ export async function updateProfileAction(
     },
     profile: null,
   };
+}
+
+export async function toggleFollowAction(
+  username: string,
+  following: boolean,
+): Promise<void> {
+  const headerStore = await headers();
+  const response = await fetch(
+    `${API_CONFIG.baseURL}/users/${encodeURIComponent(username)}/follow`,
+    {
+      method: following ? "DELETE" : "POST",
+      cache: "no-store",
+      headers: {
+        cookie: headerStore.get("cookie") ?? "",
+      },
+    },
+  );
+
+  if (response.ok) {
+    revalidatePath(buildPublicProfilePath(username));
+    return;
+  }
+
+  if (response.status === 401) {
+    redirect("/");
+  }
+
+  throw new Error("팔로우 상태를 변경하는 중 문제가 발생했습니다.");
 }
 
 function toUpdateProfileValues(profile: PublicUserProfile): UpdateProfileValues {

--- a/frontend/src/03_entities/user/api/getPublicUserProfile.ts
+++ b/frontend/src/03_entities/user/api/getPublicUserProfile.ts
@@ -12,6 +12,8 @@ export type PublicUserProfile = {
   websiteUrl: string | null;
   joinedAt: string;
   following: boolean;
+  followersCount: number;
+  followingCount: number;
 };
 
 export async function getPublicUserProfile(username: string) {

--- a/frontend/src/03_entities/user/api/getPublicUserProfile.ts
+++ b/frontend/src/03_entities/user/api/getPublicUserProfile.ts
@@ -1,6 +1,7 @@
 import { API_CONFIG } from "@/shared/api";
 import { apiClient } from "@/shared/api/apiClient";
 import { ApiError } from "@/shared/model/ApiError";
+import { headers } from "next/headers";
 
 export type PublicUserProfile = {
   username: string;
@@ -10,14 +11,20 @@ export type PublicUserProfile = {
   location: string | null;
   websiteUrl: string | null;
   joinedAt: string;
+  following: boolean;
 };
 
 export async function getPublicUserProfile(username: string) {
+  const headerStore = await headers();
+
   try {
     return await apiClient<PublicUserProfile>(
       `${API_CONFIG.baseURL}/users/${encodeURIComponent(username)}`,
       {
         cache: "no-store",
+        headers: {
+          cookie: headerStore.get("cookie") ?? "",
+        },
       },
     );
   } catch (error) {

--- a/frontend/src/03_entities/user/api/getUserFollowList.ts
+++ b/frontend/src/03_entities/user/api/getUserFollowList.ts
@@ -1,0 +1,22 @@
+import { API_CONFIG } from "@/shared/api";
+import { apiClient } from "@/shared/api/apiClient";
+
+export type FollowListType = "followers" | "following";
+
+export type FollowUser = {
+  username: string;
+  nickname: string | null;
+  profileImageUrl: string | null;
+};
+
+export async function getUserFollowList(
+  username: string,
+  type: FollowListType,
+) {
+  return apiClient<FollowUser[]>(
+    `${API_CONFIG.baseURL}/users/${encodeURIComponent(username)}/${type}`,
+    {
+      cache: "no-store",
+    },
+  );
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #

---

## 1. PR 유형
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ✨ 새로운 기능 (New Feature)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 업데이트 (Documentation)
- [ ] ⚙️ 설정/빌드 변경 (Chore)

---

## 2. 작업 배경 및 목적
- **기존 상태:** 사용자 프로필에는 현재 로그인 사용자가 해당 사용자를 팔로우 중인지, 팔로워/팔로잉 수가 몇 명인지, 팔로워/팔로잉 목록이 무엇인지 표현하는 API와 UI가 없었다.
- **문제점:** 프로필 화면에서 사용자 간 관계를 표시하거나 변경할 수 없고, 팔로우 관계를 확인하려면 별도 데이터 흐름을 새로 만들어야 했다.
- **해결 목표:** `follows` 테이블 구조에 맞는 복합키 엔티티를 추가하고, 팔로우/언팔로우 및 팔로워/팔로잉 조회 API를 제공하며, 프로필 배너에서 팔로우 상태와 목록 모달을 조작할 수 있게 한다.

---

## 3. 상세 변경 내역 및 동작 흐름

### A. Follow 도메인 엔티티 및 API 추가
- **진입점 및 초기 조건:**
  - 로그인 사용자가 다른 사용자의 공개 프로필에서 Follow 또는 Following 버튼을 클릭한다.
  - 대상 사용자는 `username`으로 식별한다.
- **단계별 제어 흐름:**
  1. `POST /users/{username}/follow` 요청은 `CurrentUserResolver`로 현재 사용자를 조회한다.
  2. `FollowService`는 대상 사용자를 조회하고, 현재 사용자 id와 대상 사용자 id로 `FollowId`를 만든다.
  3. 자기 자신을 팔로우하려는 경우 `BadRequestException`을 반환한다.
  4. 이미 존재하는 관계면 저장을 생략하고, 없으면 `Follow` 엔티티를 저장한다.
  5. `DELETE /users/{username}/follow` 요청은 동일한 `FollowId` 기준으로 관계가 존재할 때만 삭제한다.
- **데이터 상태 변이:**
  - `follows.following_user_id`에는 팔로우를 수행한 사용자 id가 저장된다.
  - `follows.followed_user_id`에는 팔로우 대상 사용자 id가 저장된다.
  - 두 컬럼은 `FollowId` 복합키로 관리된다.
- **최종 반환 및 종료 상태:**
  - follow/unfollow 요청은 성공 시 `204 No Content`로 종료한다.
  - 중복 follow와 존재하지 않는 관계에 대한 unfollow는 멱등적으로 처리한다.

### B. 공개 프로필 응답에 팔로우 상태와 카운트 추가
- **진입점 및 초기 조건:**
  - 프론트엔드가 `GET /users/{username}`로 공개 프로필을 조회한다.
  - 요청 쿠키에 로그인 토큰이 있으면 viewer id를 계산하고, 없으면 익명 사용자로 처리한다.
- **단계별 제어 흐름:**
  1. `UserController`는 인증 실패 예외를 삼켜 `viewerId: Long?`를 만든다.
  2. `UserService.getPublicProfile`은 대상 사용자를 조회한다.
  3. `viewerId`가 있고 대상 사용자와 다르면 `FollowId(viewerId, targetUserId)` 기준으로 팔로우 여부를 확인한다.
  4. 대상 사용자 id 기준으로 `followersCount`, `followingCount`를 각각 집계한다.
- **데이터 상태 변이:**
  - 프로필 조회는 DB 상태를 변경하지 않는다.
  - 응답 DTO에 `following`, `followersCount`, `followingCount`가 추가된다.
- **최종 반환 및 종료 상태:**
  - 비로그인 사용자는 `following=false`를 받는다.
  - 로그인 사용자는 실제 관계 존재 여부에 따른 `following` 값을 받는다.

### C. 팔로워/팔로잉 목록 조회 API 추가
- **진입점 및 초기 조건:**
  - 사용자가 프로필 배너의 Followers 또는 Following 숫자를 클릭한다.
- **단계별 제어 흐름:**
  1. `GET /users/{username}/followers`는 `{username}` 사용자를 팔로우하는 사용자 목록을 조회한다.
  2. `GET /users/{username}/following`은 `{username}` 사용자가 팔로우하는 사용자 목록을 조회한다.
  3. Repository 조회에는 `@EntityGraph`를 적용해 목록 렌더링에 필요한 사용자 엔티티를 함께 가져온다.
  4. 서비스는 각 `User`를 `FollowUserResponse(username, nickname, profileImageUrl)`로 변환한다.
- **데이터 상태 변이:**
  - 목록 조회는 DB 상태를 변경하지 않는다.
- **최종 반환 및 종료 상태:**
  - 대상 사용자가 없으면 기존 예외 흐름에 따라 Not Found 응답을 반환한다.
  - 목록이 없으면 빈 배열을 반환한다.

### D. 프로필 배너 UI 및 모달 연결
- **진입점 및 초기 조건:**
  - `ProfileView`가 현재 사용자와 공개 프로필 정보를 조회한다.
  - 현재 사용자가 프로필 소유자가 아니고 로그인 상태이면 팔로우 버튼을 렌더링한다.
- **단계별 제어 흐름:**
  1. Follow 상태에서는 `+` 아이콘과 `Follow` 텍스트를 표시한다.
  2. Following 상태에서는 기존 사용자 아이콘과 `Following` 텍스트를 표시한다.
  3. 버튼 클릭 시 `toggleFollowAction`이 현재 상태에 따라 `POST` 또는 `DELETE`를 선택한다.
  4. 성공 후 공개 프로필 경로를 revalidate하고 `router.refresh()`로 최신 상태를 반영한다.
  5. Followers 또는 Following 카운트 클릭 시 모달을 열고, server action을 통해 목록 API를 호출한다.
- **데이터 상태 변이:**
  - 버튼은 `useOptimistic`으로 클릭 직후 UI 상태를 먼저 갱신한다.
  - 서버 응답 후 refresh된 프로필 응답이 최종 상태 기준이 된다.
- **최종 반환 및 종료 상태:**
  - 비로그인 사용자는 팔로우 버튼을 보지 않는다.
  - 팔로워/팔로잉 모달은 로딩, 에러, 빈 목록, 사용자 목록 상태를 표시한다.
  - 목록 사용자를 클릭하면 해당 공개 프로필 경로로 이동한다.

---

## 4. 스크린샷 (선택)
- 생략

## 5. 테스트 및 검증 방법
- **테스트 환경:**
  - 로컬 개발 환경
  - 백엔드 Spring Boot 애플리케이션
  - 프론트엔드 Next.js 애플리케이션
- **입력 시나리오:**
  - 로그인 사용자가 다른 사용자 프로필에서 Follow 버튼을 클릭한다.
  - Following 상태에서 버튼을 다시 클릭한다.
  - Followers 및 Following 숫자를 클릭해 목록 모달을 연다.
  - 비로그인 상태로 공개 프로필을 조회한다.
- **출력 검증:**
  - `./gradlew :backend:compileKotlin` 성공
  - `./gradlew :backend:test` 성공
  - `npm run lint` 성공
    - 기존 `frontend/src/01_widgets/onboarding/ui/OnboardingView.tsx`의 미사용 `Image` import 경고는 남아 있음
  - `npm run build` 성공
  - follow/unfollow 성공 시 API는 `204 No Content`를 반환한다.
  - 비로그인 공개 프로필 조회 시 팔로우 버튼은 렌더링되지 않고 `following=false`로 처리된다.

---

## 6. 리뷰어 참고 사항 (선택)
- **특이 구현 사항:**
  - 팔로우 여부 확인은 저장 키와 같은 `FollowId(followingUserId, followedUserId)` 기준으로 수행한다.
  - 팔로워/팔로잉 목록 모달의 데이터 조회는 브라우저 직접 호출 대신 Next server action을 경유한다.
- **파급 효과:**
  - `PublicUserProfileResponse`에 `following`, `followersCount`, `followingCount`가 추가되어 공개 프로필 응답을 사용하는 클라이언트 타입이 함께 변경되었다.
  - `CommentRepository`에는 별도 TODO 주석 변경이 포함되어 있으며 follow 기능 동작과 직접적인 런타임 의존성은 없다.

---

## 7. 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일 가이드를 준수합니다.
- [x] 변경 사항에 대한 테스트 코드를 작성하거나 통과했습니다.
- [x] 관련된 문서(README, API 명세 등)를 업데이트했습니다.
