### PR TITLE
[Feat] 로그아웃 

### DIFF
--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AccessTokenCookieFactory.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AccessTokenCookieFactory.kt
@@ -3,6 +3,7 @@ package io.github.kitae9999.openlog.auth
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.ResponseCookie
 import org.springframework.stereotype.Component
+import java.time.Duration
 
 @Component
 class AccessTokenCookieFactory(
@@ -24,6 +25,16 @@ class AccessTokenCookieFactory(
             .sameSite("Lax")
             .path("/")
             .maxAge(jwtTokenService.accessTokenTtl())
+            .build()
+    }
+
+    fun expire(): ResponseCookie {
+        return withCookieDomain(ResponseCookie.from(accessTokenCookieName, ""))
+            .httpOnly(true)
+            .secure(accessTokenCookieSecure)
+            .sameSite("Lax")
+            .path("/")
+            .maxAge(Duration.ZERO)
             .build()
     }
 

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthController.kt
@@ -37,10 +37,8 @@ class AuthController(
 
     @PostMapping("logout")
     fun logOut(
-        request: HttpServletRequest,
         response: HttpServletResponse
     ): ResponseEntity<Void>{
-        currentUserResolver.resolveCurrentUser(request)
         val cookie = accessTokenCookieFactory.expire()
 
         response.addHeader(

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthController.kt
@@ -6,6 +6,7 @@ import io.github.kitae9999.openlog.auth.exception.OAuthAuthenticationException
 import io.github.kitae9999.openlog.user.entity.User
 import jakarta.validation.Valid
 import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
@@ -33,6 +34,23 @@ class AuthController(
     @Value("\${app.frontend-home-url:http://localhost:3030}")
     private val frontendHomeUrl: String,
 ) {
+
+    @PostMapping("logout")
+    fun logOut(
+        request: HttpServletRequest,
+        response: HttpServletResponse
+    ): ResponseEntity<Void>{
+        val currentUser = currentUserResolver.resolveCurrentUser(request)
+        val cookie = authService.logOut()
+
+        response.addHeader(
+            HttpHeaders.SET_COOKIE,
+            cookie.toString()
+        )
+
+        return ResponseEntity.noContent().build()
+    }
+
     @GetMapping("me")
     fun getMe(
         request: HttpServletRequest
@@ -135,8 +153,6 @@ class AuthController(
         )
     }
 
-//    @GetMapping("github")
-//    fun redirectToGithubOAuth(){
-//
-//    }
+
+
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthController.kt
@@ -40,8 +40,8 @@ class AuthController(
         request: HttpServletRequest,
         response: HttpServletResponse
     ): ResponseEntity<Void>{
-        val currentUser = currentUserResolver.resolveCurrentUser(request)
-        val cookie = authService.logOut()
+        currentUserResolver.resolveCurrentUser(request)
+        val cookie = accessTokenCookieFactory.expire()
 
         response.addHeader(
             HttpHeaders.SET_COOKIE,

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthService.kt
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
+import org.springframework.http.ResponseCookie
 import org.springframework.stereotype.Service
 import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.client.RestClient
@@ -236,4 +237,21 @@ class AuthService(
 
     private fun buildStateKey(flowId: String): String =
         "$GOOGLE_STATE_KEY_PREFIX$flowId"
+
+    //Todo: refresh token 적용하면 로직 구체화, 현재는 쿠키날리기만
+    fun logOut(): ResponseCookie{
+        val cookie = expireCookie("openlog_access_token")
+        return cookie
+    }
+
+
+    private fun expireCookie(name: String): ResponseCookie{
+        return ResponseCookie.from(name, "")
+            .path("/")
+            .httpOnly(true)
+            .secure(true)
+            .sameSite("None")
+            .maxAge(0)
+            .build()
+    }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthService.kt
@@ -18,7 +18,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
-import org.springframework.http.ResponseCookie
 import org.springframework.stereotype.Service
 import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.client.RestClient
@@ -237,21 +236,4 @@ class AuthService(
 
     private fun buildStateKey(flowId: String): String =
         "$GOOGLE_STATE_KEY_PREFIX$flowId"
-
-    //Todo: refresh token 적용하면 로직 구체화, 현재는 쿠키날리기만
-    fun logOut(): ResponseCookie{
-        val cookie = expireCookie("openlog_access_token")
-        return cookie
-    }
-
-
-    private fun expireCookie(name: String): ResponseCookie{
-        return ResponseCookie.from(name, "")
-            .path("/")
-            .httpOnly(true)
-            .secure(true)
-            .sameSite("None")
-            .maxAge(0)
-            .build()
-    }
 }

--- a/backend/src/test/kotlin/io/github/kitae9999/openlog/auth/AccessTokenCookieFactoryTest.kt
+++ b/backend/src/test/kotlin/io/github/kitae9999/openlog/auth/AccessTokenCookieFactoryTest.kt
@@ -1,0 +1,48 @@
+package io.github.kitae9999.openlog.auth
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class AccessTokenCookieFactoryTest {
+    private val jwtTokenService = JwtTokenService(
+        secret = "openlog-local-jwt-secret-openlog-local-jwt-secret",
+        issuer = "openlog",
+        accessTokenExpirationSeconds = 3600,
+    )
+
+    @Test
+    fun `expire creates a local development delete cookie`() {
+        val factory = AccessTokenCookieFactory(
+            jwtTokenService = jwtTokenService,
+            accessTokenCookieName = "openlog_access_token",
+            accessTokenCookieSecure = false,
+            accessTokenCookieDomain = "",
+        )
+
+        val cookie = factory.expire().toString()
+
+        assertThat(cookie).startsWith("openlog_access_token=")
+        assertThat(cookie).contains("Path=/")
+        assertThat(cookie).contains("Max-Age=0")
+        assertThat(cookie).contains("HttpOnly")
+        assertThat(cookie).contains("SameSite=Lax")
+        assertThat(cookie).doesNotContain("Secure")
+        assertThat(cookie).doesNotContain("Domain=")
+    }
+
+    @Test
+    fun `expire preserves configured secure and domain settings`() {
+        val factory = AccessTokenCookieFactory(
+            jwtTokenService = jwtTokenService,
+            accessTokenCookieName = "openlog_access_token",
+            accessTokenCookieSecure = true,
+            accessTokenCookieDomain = ".openlog.dev",
+        )
+
+        val cookie = factory.expire().toString()
+
+        assertThat(cookie).contains("Domain=.openlog.dev")
+        assertThat(cookie).contains("Secure")
+        assertThat(cookie).contains("SameSite=Lax")
+    }
+}

--- a/frontend/src/01_widgets/chrome/ui/Header.tsx
+++ b/frontend/src/01_widgets/chrome/ui/Header.tsx
@@ -4,8 +4,8 @@ import { assets } from "@/shared/config/assets";
 import { cn } from "@/shared/lib/cn";
 import { GuestActions } from "@/features/auth/ui";
 import { logoMarkClassName, logoWordmarkClassName, navLinks } from "./brand";
+import { ProfileMenu } from "./ProfileMenu";
 import { SearchBar } from "./SearchBar";
-// import { getUser } from "@/features/auth/api/getUser";
 
 export function Header({
   isLoggedIn,
@@ -89,19 +89,10 @@ export function Header({
                 <span className="absolute right-[9px] top-[9px] size-2 rounded-full border-2 border-white bg-red-500" />
               </button>
 
-              <Link
-                href={profileHref ?? "/"}
-                aria-label="Your profile"
-                className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
-              >
-                <Image
-                  src={resolvedProfileImageUrl}
-                  alt="Profile avatar"
-                  width={32}
-                  height={32}
-                  className="size-8 rounded-full border border-zinc-200 object-cover"
-                />
-              </Link>
+              <ProfileMenu
+                profileHref={profileHref ?? "/"}
+                profileImageUrl={resolvedProfileImageUrl}
+              />
             </>
           ) : (
             <GuestActions />

--- a/frontend/src/01_widgets/chrome/ui/ProfileMenu.tsx
+++ b/frontend/src/01_widgets/chrome/ui/ProfileMenu.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+import { useFormStatus } from "react-dom";
+import { logOut } from "@/features/auth/api/logOutActions";
+
+export function ProfileMenu({
+  profileHref,
+  profileImageUrl,
+}: {
+  profileHref: string;
+  profileImageUrl: string;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    function handlePointerDown(event: PointerEvent) {
+      if (!menuRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    }
+
+    window.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
+
+  return (
+    <div ref={menuRef} className="relative">
+      <button
+        type="button"
+        aria-label="Open profile menu"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        onClick={() => setIsOpen((current) => !current)}
+        className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
+      >
+        <Image
+          src={profileImageUrl}
+          alt="Profile avatar"
+          width={32}
+          height={32}
+          className="size-8 rounded-full border border-zinc-200 object-cover transition hover:border-zinc-400"
+        />
+      </button>
+
+      {isOpen ? (
+        <div
+          role="menu"
+          aria-label="Profile menu"
+          className="absolute right-0 top-[calc(100%+7px)] z-50 w-36 rounded-xl border border-zinc-200 bg-white p-1 shadow-[0_18px_45px_rgba(24,24,27,0.14)] before:pointer-events-none before:absolute before:-top-[6px] before:right-[10px] before:size-3 before:rotate-45 before:border-l before:border-t before:border-zinc-200 before:bg-white before:content-['']"
+        >
+          <Link
+            href={profileHref}
+            role="menuitem"
+            onClick={() => setIsOpen(false)}
+            className="flex h-10 items-center rounded-lg px-3 text-sm font-medium text-zinc-700 transition hover:bg-zinc-100 hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
+          >
+            Profile
+          </Link>
+
+          <form action={logOut}>
+            <LogoutMenuItem />
+          </form>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function LogoutMenuItem() {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      type="submit"
+      role="menuitem"
+      disabled={pending}
+      className="flex h-10 w-full items-center rounded-lg px-3 text-left text-sm font-medium text-zinc-700 transition hover:bg-zinc-100 hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20 disabled:cursor-wait disabled:opacity-60"
+    >
+      {pending ? "Logging out..." : "Logout"}
+    </button>
+  );
+}

--- a/frontend/src/02_features/auth/api/logOutActions.ts
+++ b/frontend/src/02_features/auth/api/logOutActions.ts
@@ -1,0 +1,24 @@
+"use server";
+
+import { API_CONFIG } from "@/shared/api";
+import { cookies, headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+const ACCESS_TOKEN_COOKIE_NAME = "openlog_access_token";
+
+export async function logOut() {
+  const headerStore = await headers();
+  const response = await fetch(`${API_CONFIG.baseURL}/auth/logout`, {
+    method: "POST",
+    cache: "no-store",
+    headers: {
+      cookie: headerStore.get("cookie") ?? "",
+    },
+  });
+
+  if (response.ok || response.status === 401) {
+    const cookieStore = await cookies();
+    cookieStore.delete(ACCESS_TOKEN_COOKIE_NAME);
+    redirect("/");
+  }
+}

--- a/frontend/src/02_features/auth/api/logOutActions.ts
+++ b/frontend/src/02_features/auth/api/logOutActions.ts
@@ -1,22 +1,18 @@
 "use server";
 
 import { API_CONFIG } from "@/shared/api";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
 const ACCESS_TOKEN_COOKIE_NAME = "openlog_access_token";
 
 export async function logOut() {
-  const headerStore = await headers();
   const response = await fetch(`${API_CONFIG.baseURL}/auth/logout`, {
     method: "POST",
     cache: "no-store",
-    headers: {
-      cookie: headerStore.get("cookie") ?? "",
-    },
   });
 
-  if (response.ok || response.status === 401) {
+  if (response.ok) {
     const cookieStore = await cookies();
     cookieStore.delete(ACCESS_TOKEN_COOKIE_NAME);
     redirect("/");


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #

---

## 1. PR 유형
- [x] 🐛 버그 수정 (Bug Fix)
- [x] ✨ 새로운 기능 (New Feature)
- [ ] ♻️ 리팩토링 (Refactoring)
- [x] 📝 문서 업데이트 (Documentation)
- [ ] ⚙️ 설정/빌드 변경 (Chore)

---

## 2. 작업 배경 및 목적
- **기존 상태:** 로그인 사용자는 헤더의 프로필 이미지로 프로필 페이지에 이동할 수 있었지만, 로그아웃을 수행하는 사용자 흐름이 프론트엔드와 연결되어 있지 않았다. 백엔드에도 `openlog_access_token` 쿠키를 만료시키는 공통 쿠키 생성 경로가 없었다.
- **문제점:** 로그아웃 API가 없으면 사용자가 브라우저 쿠키를 직접 제거하지 않는 한 세션을 종료할 수 없다. 또한 쿠키 삭제 응답의 `Secure`, `SameSite`, `Domain`, `Path` 속성이 로그인 쿠키와 다르면 브라우저가 기존 쿠키를 삭제하지 못할 수 있다.
- **해결 목표:** `POST /auth/logout`에서 로그인 쿠키와 동일한 속성 조합의 만료 쿠키를 내려보낸다. 프론트엔드는 프로필 이미지 클릭 시 `Profile`, `Logout` 메뉴를 열고, `Logout` 선택 시 서버 액션으로 API를 호출한 뒤 홈으로 이동한다.

---

## 3. 상세 변경 내역 및 동작 흐름

### A. 로그아웃 API 및 쿠키 만료 응답 추가
- **진입점 및 초기 조건:** 사용자가 `POST /auth/logout` 요청을 보낸다. 요청에 `openlog_access_token` 쿠키가 없거나 만료되어 있어도 동일한 쿠키 삭제 응답을 생성한다.
- **단계별 제어 흐름:**
  1. `AuthController.logOut()`가 사용자 조회 없이 `AccessTokenCookieFactory.expire()`를 호출한다.
  2. `expire()`는 로그인 쿠키 생성 로직과 같은 `cookie-name`, `secure`, `domain`, `SameSite=Lax`, `Path=/` 설정을 사용하되 값은 빈 문자열, `Max-Age=0`으로 만든다.
  3. 컨트롤러는 `Set-Cookie` 헤더에 만료 쿠키를 추가하고 `204 No Content`를 반환한다.
- **데이터 상태 변이:** 서버 DB 상태는 변경하지 않는다. 브라우저의 `openlog_access_token` 쿠키만 만료되어 이후 인증 요청에서 더 이상 전달되지 않는다.
- **최종 반환 및 종료 상태:** 요청자는 기존 인증 쿠키 상태와 관계없이 `204 No Content`와 만료 쿠키를 받는다.

### B. 프론트엔드 로그아웃 서버 액션 연결
- **진입점 및 초기 조건:** 로그인 사용자가 헤더 프로필 메뉴에서 `Logout`을 선택한다.
- **단계별 제어 흐름:**
  1. `ProfileMenu`의 form action이 `logOut()` 서버 액션을 실행한다.
  2. 서버 액션은 별도 쿠키 전달 없이 백엔드 `POST /auth/logout` 요청을 보낸다.
  3. 백엔드 응답이 성공이면 Next 쿠키 저장소에서 `openlog_access_token`을 삭제한다.
  4. 서버 액션은 `/`로 redirect한다.
- **데이터 상태 변이:** Next 응답에도 쿠키 삭제가 반영되어, 백엔드 만료 쿠키와 프론트 응답 쿠키 삭제가 같은 로그아웃 결과를 만든다.
- **최종 반환 및 종료 상태:** 사용자는 홈 화면으로 이동하고, 이후 SSR `getUser()` 요청은 인증 쿠키 없이 실행되어 비로그인 상태로 렌더링된다.

### C. 헤더 프로필 메뉴 UI 추가
- **진입점 및 초기 조건:** 로그인 상태의 헤더에 프로필 이미지가 표시된다.
- **단계별 제어 흐름:**
  1. 사용자가 프로필 이미지를 클릭하면 `ProfileMenu`가 `aria-haspopup="menu"` 상태로 메뉴를 연다.
  2. 메뉴는 프로필 이미지 아래 오른쪽에 배치되고, 상단 꼬리 형태의 `before` 요소로 프로필 이미지와 시각적으로 연결된다.
  3. `Profile` 선택 시 기존 프로필 경로로 이동한다.
  4. `Logout` 선택 시 서버 액션 form이 제출되고, 제출 중에는 버튼 텍스트를 `Logging out...`으로 바꾼다.
  5. 메뉴 바깥 pointer down 또는 Escape 입력 시 메뉴를 닫는다.
- **데이터 상태 변이:** UI 내부에서는 메뉴 열림 여부 상태만 변경된다. `Logout` 제출 전까지 인증 상태는 변경하지 않는다.
- **최종 반환 및 종료 상태:** 사용자는 프로필 이동과 로그아웃 중 하나를 같은 프로필 메뉴에서 선택할 수 있다.

### D. 쿠키 만료 설정 테스트 추가
- **진입점 및 초기 조건:** `AccessTokenCookieFactory.expire()`를 로컬 개발 설정과 운영형 domain/secure 설정으로 각각 호출한다.
- **단계별 제어 흐름:**
  1. 로컬 설정은 `secure=false`, `domain=""`으로 만료 쿠키를 생성한다.
  2. 테스트는 `Path=/`, `Max-Age=0`, `HttpOnly`, `SameSite=Lax`가 포함되고 `Secure`, `Domain=`이 포함되지 않는지 검증한다.
  3. 운영형 설정은 `secure=true`, `domain=".openlog.dev"`로 만료 쿠키를 생성한다.
  4. 테스트는 `Domain=.openlog.dev`, `Secure`, `SameSite=Lax`가 포함되는지 검증한다.
- **데이터 상태 변이:** 테스트는 쿠키 문자열 생성 결과만 검증하며 외부 상태를 변경하지 않는다.
- **최종 반환 및 종료 상태:** 로그인 쿠키와 삭제 쿠키의 속성 조합이 환경 설정에 따라 일관되게 유지되는지 회귀 검증한다.

---

## 4. 스크린샷 (선택)
- 없음

## 5. 테스트 및 검증 방법
- **테스트 환경:** macOS 로컬 환경, Spring Boot backend, Next.js frontend
- **입력 시나리오:**
  1. 로그인 쿠키 유무와 관계없이 `POST /auth/logout` 호출
  2. 헤더 프로필 이미지 클릭
  3. 프로필 메뉴에서 `Profile` 또는 `Logout` 선택
  4. 로컬/운영형 쿠키 설정으로 `AccessTokenCookieFactory.expire()` 호출
- **출력 검증:**
  - `./gradlew :backend:compileKotlin`
  - `./gradlew :backend:test`
  - `npm exec tsc -- --noEmit`
  - `npm run lint`
  - `curl -I http://localhost:3030` 응답 `200 OK` 확인
  - frontend lint는 통과했지만 기존 파일 `frontend/src/01_widgets/onboarding/ui/OnboardingView.tsx`의 unused `Image` warning은 남아 있다.

---

## 6. 리뷰어 참고 사항 (선택)
- **특이 구현 사항:** 백엔드 쿠키 만료는 `AccessTokenCookieFactory`에 통합해 로그인 쿠키와 삭제 쿠키의 `secure`, `domain`, `SameSite`, `path` 설정이 분리되지 않도록 했다.
- **파급 효과:** 프론트 서버 액션은 현재 쿠키 이름 `openlog_access_token`을 직접 삭제한다. 향후 `auth.jwt.cookie-name`을 변경하면 프론트 삭제 대상 이름도 함께 맞춰야 한다.

---

## 7. 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일 가이드를 준수합니다.
- [x] 변경 사항에 대한 테스트 코드를 작성하거나 통과했습니다.
- [x] 관련된 문서(README, API 명세 등)를 업데이트했습니다.
