### PR TITLE
[Feat] 메인페이지 

### DIFF
--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/comment/repository/CommentRepository.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/comment/repository/CommentRepository.kt
@@ -17,4 +17,19 @@ interface CommentRepository : JpaRepository<Comment, Long> {
         """
     )
     fun findAllWithUserByPostId(@Param("postId") postId: Long): List<Comment>
+
+    @Query(
+        """
+        select c.post.id as postId, count(c) as count
+        from Comment c
+        where c.post.id in :postIds
+        group by c.post.id
+        """
+    )
+    fun countAllByPostIdIn(@Param("postIds") postIds: Collection<Long>): List<CommentCount>
+}
+
+interface CommentCount {
+    val postId: Long
+    val count: Long
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/common/cursor/DateTimeIdCursor.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/common/cursor/DateTimeIdCursor.kt
@@ -1,0 +1,36 @@
+package io.github.kitae9999.openlog.common.cursor
+
+import io.github.kitae9999.openlog.common.exception.BadRequestException
+import java.time.LocalDateTime
+import java.util.Base64
+
+data class DateTimeIdCursor(
+    val createdAt: LocalDateTime,
+    val id: Long,
+)
+
+object DateTimeIdCursorCodec {
+    fun encode(createdAt: LocalDateTime, id: Long): String {
+        val rawCursor = "$createdAt|$id"
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(rawCursor.toByteArray())
+    }
+
+    fun decode(cursor: String): DateTimeIdCursor {
+        val decodedCursor = runCatching {
+            String(Base64.getUrlDecoder().decode(cursor))
+        }.getOrElse {
+            throw BadRequestException("유효하지 않은 커서입니다.")
+        }
+        val delimiterIndex = decodedCursor.lastIndexOf('|')
+        if (delimiterIndex < 1 || delimiterIndex == decodedCursor.lastIndex) {
+            throw BadRequestException("유효하지 않은 커서입니다.")
+        }
+
+        return DateTimeIdCursor(
+            createdAt = runCatching { LocalDateTime.parse(decodedCursor.substring(0, delimiterIndex)) }
+                .getOrElse { throw BadRequestException("유효하지 않은 커서입니다.") },
+            id = decodedCursor.substring(delimiterIndex + 1).toLongOrNull()
+                ?: throw BadRequestException("유효하지 않은 커서입니다."),
+        )
+    }
+}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostController.kt
@@ -3,17 +3,20 @@ package io.github.kitae9999.openlog.post
 import io.github.kitae9999.openlog.auth.CurrentUserResolver
 import io.github.kitae9999.openlog.post.command.PostLinkWriteCommand
 import io.github.kitae9999.openlog.post.command.PostWriteCommand
+import io.github.kitae9999.openlog.post.dto.RecentPostCursorResponse
 import io.github.kitae9999.openlog.post.dto.PostWriteResponse
 import io.github.kitae9999.openlog.post.dto.PostWriteRequest
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -22,6 +25,16 @@ class PostController(
     private val postService: PostService,
     private val currentUserResolver: CurrentUserResolver,
 ) {
+    @GetMapping()
+    fun getRecentPosts(
+        @RequestParam(required = false) cursor: String?,
+        @RequestParam(defaultValue = "10") size: Int,
+    ): RecentPostCursorResponse {
+        val recentPosts = postService.getRecentPosts(cursor, size)
+
+        return recentPosts
+    }
+
     @PostMapping()
     fun createPost(
         request: HttpServletRequest,

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostService.kt
@@ -1,7 +1,7 @@
 package io.github.kitae9999.openlog.post
 
 import io.github.kitae9999.openlog.comment.repository.CommentRepository
-import io.github.kitae9999.openlog.common.exception.BadRequestException
+import io.github.kitae9999.openlog.common.cursor.DateTimeIdCursorCodec
 import io.github.kitae9999.openlog.common.exception.ForbiddenException
 import io.github.kitae9999.openlog.common.exception.NotFoundException
 import io.github.kitae9999.openlog.post.command.PostWriteCommand
@@ -22,8 +22,6 @@ import io.github.kitae9999.openlog.user.entity.User
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDateTime
-import java.util.Base64
 import kotlin.jvm.optionals.getOrNull
 
 @Service
@@ -39,7 +37,7 @@ class PostService(
     @Transactional(readOnly = true)
     fun getRecentPosts(cursor: String?, size: Int): RecentPostCursorResponse {
         val safeSize = size.coerceIn(1, RECENT_POSTS_PAGE_SIZE)
-        val cursorMarker = cursor?.let(::decodeRecentPostCursor)
+        val cursorMarker = cursor?.let(DateTimeIdCursorCodec::decode)
         val recentPosts = if (cursorMarker == null) {
             postRepository.findAllByOrderByCreatedAtDescIdDesc(PageRequest.of(0, safeSize + 1))
         } else {
@@ -74,7 +72,7 @@ class PostService(
             size = safeSize,
             nextCursor = posts.lastOrNull()
                 ?.takeIf { hasNext }
-                ?.let(::encodeRecentPostCursor),
+                ?.let { post -> DateTimeIdCursorCodec.encode(post.createdAt, requireNotNull(post.id)) },
             hasNext = hasNext,
         )
     }
@@ -348,30 +346,6 @@ class PostService(
         return commentRepository.countAllByPostIdIn(postIds).associate { it.postId to it.count }
     }
 
-    private fun encodeRecentPostCursor(post: Post): String {
-        val rawCursor = "${post.createdAt}|${requireNotNull(post.id)}"
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(rawCursor.toByteArray())
-    }
-
-    private fun decodeRecentPostCursor(cursor: String): RecentPostCursor {
-        val decodedCursor = runCatching {
-            String(Base64.getUrlDecoder().decode(cursor))
-        }.getOrElse {
-            throw BadRequestException("유효하지 않은 커서입니다.")
-        }
-        val delimiterIndex = decodedCursor.lastIndexOf('|')
-        if (delimiterIndex < 1 || delimiterIndex == decodedCursor.lastIndex) {
-            throw BadRequestException("유효하지 않은 커서입니다.")
-        }
-
-        return RecentPostCursor(
-            createdAt = runCatching { LocalDateTime.parse(decodedCursor.substring(0, delimiterIndex)) }
-                .getOrElse { throw BadRequestException("유효하지 않은 커서입니다.") },
-            id = decodedCursor.substring(delimiterIndex + 1).toLongOrNull()
-                ?: throw BadRequestException("유효하지 않은 커서입니다."),
-        )
-    }
-
     private fun slugify(title: String): String {
         val slug = NON_SLUG_CHARACTERS.replace(title.trim().lowercase(), "-")
             .trim('-')
@@ -383,9 +357,4 @@ class PostService(
         private val NON_SLUG_CHARACTERS = Regex("[^\\p{L}\\p{N}]+")
         private val WIKI_LINK_PATTERN = Regex("\\[\\[([^\\[\\]\\n]+)]]")
     }
-
-    private data class RecentPostCursor(
-        val createdAt: LocalDateTime,
-        val id: Long,
-    )
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostService.kt
@@ -1,21 +1,29 @@
 package io.github.kitae9999.openlog.post
 
+import io.github.kitae9999.openlog.comment.repository.CommentRepository
+import io.github.kitae9999.openlog.common.exception.BadRequestException
 import io.github.kitae9999.openlog.common.exception.ForbiddenException
 import io.github.kitae9999.openlog.common.exception.NotFoundException
 import io.github.kitae9999.openlog.post.command.PostWriteCommand
+import io.github.kitae9999.openlog.post.dto.RecentPostCursorResponse
+import io.github.kitae9999.openlog.post.dto.RecentPostResponse
 import io.github.kitae9999.openlog.post.entity.PostLink
 import io.github.kitae9999.openlog.post.dto.PostWriteResponse
 import io.github.kitae9999.openlog.post.entity.Post
 import io.github.kitae9999.openlog.post.repository.PostLinkRepository
 import io.github.kitae9999.openlog.post.repository.PostRepository
+import io.github.kitae9999.openlog.postlike.PostLikeRepository
 import io.github.kitae9999.openlog.posttopic.entity.PostTopic
 import io.github.kitae9999.openlog.posttopic.repository.PostTopicRepository
 import io.github.kitae9999.openlog.suggest.repository.SuggestionRepository
 import io.github.kitae9999.openlog.topic.entity.Topic
 import io.github.kitae9999.openlog.topic.repository.TopicRepository
 import io.github.kitae9999.openlog.user.entity.User
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.util.Base64
 import kotlin.jvm.optionals.getOrNull
 
 @Service
@@ -25,7 +33,53 @@ class PostService(
     private val postTopicRepository: PostTopicRepository,
     private val suggestionRepository: SuggestionRepository,
     private val topicRepository: TopicRepository,
+    private val postLikeRepository: PostLikeRepository,
+    private val commentRepository: CommentRepository,
 ) {
+    @Transactional(readOnly = true)
+    fun getRecentPosts(cursor: String?, size: Int): RecentPostCursorResponse {
+        val safeSize = size.coerceIn(1, RECENT_POSTS_PAGE_SIZE)
+        val cursorMarker = cursor?.let(::decodeRecentPostCursor)
+        val recentPosts = if (cursorMarker == null) {
+            postRepository.findAllByOrderByCreatedAtDescIdDesc(PageRequest.of(0, safeSize + 1))
+        } else {
+            postRepository.findRecentPostsAfterCursor(
+                createdAt = cursorMarker.createdAt,
+                id = cursorMarker.id,
+                pageable = PageRequest.of(0, safeSize + 1),
+            )
+        }
+        val hasNext = recentPosts.size > safeSize
+        val posts = recentPosts.take(safeSize)
+        val postIds = posts.mapNotNull { it.id } // 람다 결과가 null인 것들은 제외한 리스트 반환
+        val likeCounts = getPostLikeCounts(postIds)
+        val commentCounts = getPostCommentCounts(postIds)
+
+        return RecentPostCursorResponse(
+            posts = posts.map { post ->
+                val postId = requireNotNull(post.id)
+                RecentPostResponse(
+                    id = postId,
+                    slug = post.slug,
+                    title = post.title,
+                    description = post.description,
+                    publishedAtLabel = formatPublishedAtLabel(post),
+                    authorUsername = requireNotNull(post.author.username),
+                    authorName = resolveAuthorName(post),
+                    authorAvatarSrc = post.author.profileImageUrl,
+                    likes = likeCounts[postId]?.toInt() ?: 0,
+                    comments = commentCounts[postId]?.toInt() ?: 0,
+                )
+            },
+            size = safeSize,
+            nextCursor = posts.lastOrNull()
+                ?.takeIf { hasNext }
+                ?.let(::encodeRecentPostCursor),
+            hasNext = hasNext,
+        )
+    }
+
+
     @Transactional
     fun createPost(user: User, postWriteCommand: PostWriteCommand): PostWriteResponse {
         val userId = requireNotNull(user.id)
@@ -278,6 +332,46 @@ class PostService(
         }
     }
 
+    private fun getPostLikeCounts(postIds: List<Long>): Map<Long, Long> {
+        if (postIds.isEmpty()) {
+            return emptyMap()
+        }
+
+        return postLikeRepository.countAllByPostIdIn(postIds).associate { it.postId to it.count }
+    }
+
+    private fun getPostCommentCounts(postIds: List<Long>): Map<Long, Long> {
+        if (postIds.isEmpty()) {
+            return emptyMap()
+        }
+
+        return commentRepository.countAllByPostIdIn(postIds).associate { it.postId to it.count }
+    }
+
+    private fun encodeRecentPostCursor(post: Post): String {
+        val rawCursor = "${post.createdAt}|${requireNotNull(post.id)}"
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(rawCursor.toByteArray())
+    }
+
+    private fun decodeRecentPostCursor(cursor: String): RecentPostCursor {
+        val decodedCursor = runCatching {
+            String(Base64.getUrlDecoder().decode(cursor))
+        }.getOrElse {
+            throw BadRequestException("유효하지 않은 커서입니다.")
+        }
+        val delimiterIndex = decodedCursor.lastIndexOf('|')
+        if (delimiterIndex < 1 || delimiterIndex == decodedCursor.lastIndex) {
+            throw BadRequestException("유효하지 않은 커서입니다.")
+        }
+
+        return RecentPostCursor(
+            createdAt = runCatching { LocalDateTime.parse(decodedCursor.substring(0, delimiterIndex)) }
+                .getOrElse { throw BadRequestException("유효하지 않은 커서입니다.") },
+            id = decodedCursor.substring(delimiterIndex + 1).toLongOrNull()
+                ?: throw BadRequestException("유효하지 않은 커서입니다."),
+        )
+    }
+
     private fun slugify(title: String): String {
         val slug = NON_SLUG_CHARACTERS.replace(title.trim().lowercase(), "-")
             .trim('-')
@@ -285,7 +379,13 @@ class PostService(
     }
 
     companion object {
+        private const val RECENT_POSTS_PAGE_SIZE = 10
         private val NON_SLUG_CHARACTERS = Regex("[^\\p{L}\\p{N}]+")
         private val WIKI_LINK_PATTERN = Regex("\\[\\[([^\\[\\]\\n]+)]]")
     }
+
+    private data class RecentPostCursor(
+        val createdAt: LocalDateTime,
+        val id: Long,
+    )
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/dto/RecentPostCursorResponse.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/dto/RecentPostCursorResponse.kt
@@ -1,0 +1,9 @@
+package io.github.kitae9999.openlog.post.dto
+
+data class RecentPostCursorResponse(
+    val posts: List<RecentPostResponse>,
+    val size: Int,
+    val nextCursor: String?,
+    val hasNext: Boolean,
+)
+

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/dto/RecentPostResponse.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/dto/RecentPostResponse.kt
@@ -1,0 +1,14 @@
+package io.github.kitae9999.openlog.post.dto
+
+data class RecentPostResponse(
+    val id: Long,
+    val slug: String,
+    val title: String,
+    val description: String,
+    val publishedAtLabel: String,
+    val authorUsername: String,
+    val authorName: String,
+    val authorAvatarSrc: String?,
+    val likes: Int,
+    val comments: Int,
+)

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/repository/PostRepository.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/repository/PostRepository.kt
@@ -1,7 +1,12 @@
 package io.github.kitae9999.openlog.post.repository
 
 import io.github.kitae9999.openlog.post.entity.Post
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDateTime
 
 interface PostRepository: JpaRepository<Post, Long> {
     fun existsByAuthorIdAndSlug(authorId: Long, slug: String): Boolean
@@ -9,4 +14,27 @@ interface PostRepository: JpaRepository<Post, Long> {
     fun findByAuthorIdAndSlug(authorId: Long, slug: String): Post?
     fun findAllByAuthorIdAndTitle(authorId: Long, title: String): List<Post>
     fun findAllByAuthorIdOrderByCreatedAtDesc(authorId: Long): List<Post>
+
+    @EntityGraph(attributePaths = ["author"])
+    fun findAllByOrderByCreatedAtDescIdDesc(pageable: Pageable): List<Post>
+
+
+    /**
+     * createdAt과 커서값인 포스트의 pk값보다 작은 즉, 더 이전에 작성된 포스트들 불러옴
+     */
+    @EntityGraph(attributePaths = ["author"])
+    @Query(
+        """
+        select p
+        from Post p
+        where p.createdAt < :createdAt
+           or (p.createdAt = :createdAt and p.id < :id)
+        order by p.createdAt desc, p.id desc
+        """
+    )
+    fun findRecentPostsAfterCursor(
+        @Param("createdAt") createdAt: LocalDateTime,
+        @Param("id") id: Long,
+        pageable: Pageable,
+    ): List<Post>
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/postlike/PostLikeRepository.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/postlike/PostLikeRepository.kt
@@ -1,10 +1,65 @@
 package io.github.kitae9999.openlog.postlike
 
 import io.github.kitae9999.openlog.postlike.entity.PostLike
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDateTime
 
 interface PostLikeRepository : JpaRepository<PostLike, Long> {
     fun findByPostIdAndUserId(postId: Long, userId: Long): PostLike?
     fun existsByPostIdAndUserId(postId: Long, userId: Long): Boolean
     fun countByPostId(postId: Long): Long
+
+    @Query(
+        """
+        select pl
+        from PostLike pl
+        join fetch pl.post p
+        join fetch p.author
+        where pl.user.id = :userId
+        order by pl.createdAt desc, pl.id desc
+        """
+    )
+    fun findLikedPostsByUserId(
+        @Param("userId") userId: Long,
+        pageable: Pageable,
+    ): List<PostLike>
+
+    @Query(
+        """
+        select pl
+        from PostLike pl
+        join fetch pl.post p
+        join fetch p.author
+        where pl.user.id = :userId
+          and (
+            pl.createdAt < :createdAt
+            or (pl.createdAt = :createdAt and pl.id < :id)
+          )
+        order by pl.createdAt desc, pl.id desc
+        """
+    )
+    fun findLikedPostsAfterCursor(
+        @Param("userId") userId: Long,
+        @Param("createdAt") createdAt: LocalDateTime,
+        @Param("id") id: Long,
+        pageable: Pageable,
+    ): List<PostLike>
+
+    @Query(
+        """
+        select pl.post.id as postId, count(pl) as count
+        from PostLike pl
+        where pl.post.id in :postIds
+        group by pl.post.id
+        """
+    )
+    fun countAllByPostIdIn(@Param("postIds") postIds: Collection<Long>): List<PostLikeCount>
+}
+
+interface PostLikeCount {
+    val postId: Long
+    val count: Long
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserController.kt
@@ -3,6 +3,7 @@ package io.github.kitae9999.openlog.user
 import io.github.kitae9999.openlog.auth.CurrentUserResolver
 import io.github.kitae9999.openlog.auth.exception.OAuthAuthenticationException
 import io.github.kitae9999.openlog.post.dto.PostDetailResponse
+import io.github.kitae9999.openlog.post.dto.RecentPostCursorResponse
 import io.github.kitae9999.openlog.user.dto.PublicUserPostSummaryResponse
 import io.github.kitae9999.openlog.user.dto.PublicUserPostGraphResponse
 import io.github.kitae9999.openlog.user.dto.PublicUserProfileResponse
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -22,6 +24,18 @@ class UserController(
     private val userService: UserService,
     private val currentUserResolver: CurrentUserResolver,
 ) {
+    @GetMapping("me/liked-posts")
+    fun getLikedPosts(
+        request: HttpServletRequest,
+        @RequestParam(required = false) cursor: String?,
+        @RequestParam(defaultValue = "10") size: Int,
+    ): RecentPostCursorResponse {
+        val currentUser = currentUserResolver.resolveCurrentUser(request)
+        val likedPosts = userService.getLikedPosts(requireNotNull(currentUser.id), cursor, size)
+
+        return likedPosts
+    }
+
     @GetMapping("{username}")
     fun getPublicProfile(
         @PathVariable username: String,

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserService.kt
@@ -1,7 +1,7 @@
 package io.github.kitae9999.openlog.user
 
 import io.github.kitae9999.openlog.comment.repository.CommentRepository
-import io.github.kitae9999.openlog.common.exception.BadRequestException
+import io.github.kitae9999.openlog.common.cursor.DateTimeIdCursorCodec
 import io.github.kitae9999.openlog.common.exception.ForbiddenException
 import io.github.kitae9999.openlog.common.exception.NotFoundException
 import io.github.kitae9999.openlog.follow.FollowRepository
@@ -15,7 +15,6 @@ import io.github.kitae9999.openlog.post.repository.PostLinkRepository
 import io.github.kitae9999.openlog.post.repository.PostRepository
 import io.github.kitae9999.openlog.post.resolveAuthorName
 import io.github.kitae9999.openlog.postlike.PostLikeRepository
-import io.github.kitae9999.openlog.postlike.entity.PostLike
 import io.github.kitae9999.openlog.posttopic.repository.PostTopicRepository
 import io.github.kitae9999.openlog.user.dto.PublicUserPostSummaryResponse
 import io.github.kitae9999.openlog.user.dto.PublicUserPostGraphEdgeResponse
@@ -27,8 +26,6 @@ import io.github.kitae9999.openlog.user.repository.UserRepository
 import jakarta.transaction.Transactional
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
-import java.time.LocalDateTime
-import java.util.Base64
 
 @Service
 class UserService(
@@ -43,7 +40,7 @@ class UserService(
     @Transactional
     fun getLikedPosts(userId: Long, cursor: String?, size: Int): RecentPostCursorResponse {
         val safeSize = size.coerceIn(1, LIKED_POSTS_PAGE_SIZE)
-        val cursorMarker = cursor?.let(::decodeLikedPostCursor)
+        val cursorMarker = cursor?.let(DateTimeIdCursorCodec::decode)
         val postLikes = if (cursorMarker == null) {
             postLikeRepository.findLikedPostsByUserId(
                 userId = userId,
@@ -83,7 +80,7 @@ class UserService(
             size = safeSize,
             nextCursor = pageItems.lastOrNull()
                 ?.takeIf { hasNext }
-                ?.let(::encodeLikedPostCursor),
+                ?.let { postLike -> DateTimeIdCursorCodec.encode(postLike.createdAt, requireNotNull(postLike.id)) },
             hasNext = hasNext,
         )
     }
@@ -242,36 +239,7 @@ class UserService(
         return commentRepository.countAllByPostIdIn(postIds).associate { it.postId to it.count }
     }
 
-    private fun encodeLikedPostCursor(postLike: PostLike): String {
-        val rawCursor = "${postLike.createdAt}|${requireNotNull(postLike.id)}"
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(rawCursor.toByteArray())
-    }
-
-    private fun decodeLikedPostCursor(cursor: String): LikedPostCursor {
-        val decodedCursor = runCatching {
-            String(Base64.getUrlDecoder().decode(cursor))
-        }.getOrElse {
-            throw BadRequestException("유효하지 않은 커서입니다.")
-        }
-        val delimiterIndex = decodedCursor.lastIndexOf('|')
-        if (delimiterIndex < 1 || delimiterIndex == decodedCursor.lastIndex) {
-            throw BadRequestException("유효하지 않은 커서입니다.")
-        }
-
-        return LikedPostCursor(
-            createdAt = runCatching { LocalDateTime.parse(decodedCursor.substring(0, delimiterIndex)) }
-                .getOrElse { throw BadRequestException("유효하지 않은 커서입니다.") },
-            id = decodedCursor.substring(delimiterIndex + 1).toLongOrNull()
-                ?: throw BadRequestException("유효하지 않은 커서입니다."),
-        )
-    }
-
     private companion object {
         const val LIKED_POSTS_PAGE_SIZE = 10
     }
-
-    private data class LikedPostCursor(
-        val createdAt: LocalDateTime,
-        val id: Long,
-    )
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserService.kt
@@ -1,16 +1,21 @@
 package io.github.kitae9999.openlog.user
 
+import io.github.kitae9999.openlog.comment.repository.CommentRepository
+import io.github.kitae9999.openlog.common.exception.BadRequestException
 import io.github.kitae9999.openlog.common.exception.ForbiddenException
 import io.github.kitae9999.openlog.common.exception.NotFoundException
 import io.github.kitae9999.openlog.follow.FollowRepository
 import io.github.kitae9999.openlog.follow.entity.FollowId
 import io.github.kitae9999.openlog.post.dto.PostDetailResponse
+import io.github.kitae9999.openlog.post.dto.RecentPostCursorResponse
+import io.github.kitae9999.openlog.post.dto.RecentPostResponse
 import io.github.kitae9999.openlog.post.dto.PostWikiLinkResponse
 import io.github.kitae9999.openlog.post.formatPublishedAtLabel
 import io.github.kitae9999.openlog.post.repository.PostLinkRepository
 import io.github.kitae9999.openlog.post.repository.PostRepository
 import io.github.kitae9999.openlog.post.resolveAuthorName
 import io.github.kitae9999.openlog.postlike.PostLikeRepository
+import io.github.kitae9999.openlog.postlike.entity.PostLike
 import io.github.kitae9999.openlog.posttopic.repository.PostTopicRepository
 import io.github.kitae9999.openlog.user.dto.PublicUserPostSummaryResponse
 import io.github.kitae9999.openlog.user.dto.PublicUserPostGraphEdgeResponse
@@ -20,7 +25,10 @@ import io.github.kitae9999.openlog.user.dto.PublicUserProfileResponse
 import io.github.kitae9999.openlog.user.entity.User
 import io.github.kitae9999.openlog.user.repository.UserRepository
 import jakarta.transaction.Transactional
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+import java.util.Base64
 
 @Service
 class UserService(
@@ -29,8 +37,57 @@ class UserService(
     private val postLinkRepository: PostLinkRepository,
     private val postTopicRepository: PostTopicRepository,
     private val postLikeRepository: PostLikeRepository,
+    private val commentRepository: CommentRepository,
     private val followRepository: FollowRepository,
 ) {
+    @Transactional
+    fun getLikedPosts(userId: Long, cursor: String?, size: Int): RecentPostCursorResponse {
+        val safeSize = size.coerceIn(1, LIKED_POSTS_PAGE_SIZE)
+        val cursorMarker = cursor?.let(::decodeLikedPostCursor)
+        val postLikes = if (cursorMarker == null) {
+            postLikeRepository.findLikedPostsByUserId(
+                userId = userId,
+                pageable = PageRequest.of(0, safeSize + 1),
+            )
+        } else {
+            postLikeRepository.findLikedPostsAfterCursor(
+                userId = userId,
+                createdAt = cursorMarker.createdAt,
+                id = cursorMarker.id,
+                pageable = PageRequest.of(0, safeSize + 1),
+            )
+        }
+        val hasNext = postLikes.size > safeSize
+        val pageItems = postLikes.take(safeSize)
+        val postIds = pageItems.mapNotNull { it.post.id }
+        val likeCounts = getPostLikeCounts(postIds)
+        val commentCounts = getPostCommentCounts(postIds)
+
+        return RecentPostCursorResponse(
+            posts = pageItems.map { postLike ->
+                val post = postLike.post
+                val postId = requireNotNull(post.id)
+                RecentPostResponse(
+                    id = postId,
+                    slug = post.slug,
+                    title = post.title,
+                    description = post.description,
+                    publishedAtLabel = formatPublishedAtLabel(post),
+                    authorUsername = requireNotNull(post.author.username),
+                    authorName = resolveAuthorName(post),
+                    authorAvatarSrc = post.author.profileImageUrl,
+                    likes = likeCounts[postId]?.toInt() ?: 0,
+                    comments = commentCounts[postId]?.toInt() ?: 0,
+                )
+            },
+            size = safeSize,
+            nextCursor = pageItems.lastOrNull()
+                ?.takeIf { hasNext }
+                ?.let(::encodeLikedPostCursor),
+            hasNext = hasNext,
+        )
+    }
+
     @Transactional
     fun getPublicProfile(username: String, viewerId: Long?): PublicUserProfileResponse {
         val user = userRepository.findByUsername(username) ?: throw NotFoundException("사용자를 찾을 수 없습니다.")
@@ -168,4 +225,53 @@ class UserService(
             followingCount = followRepository.countByFollowingUser_Id(userId),
         )
     }
+
+    private fun getPostLikeCounts(postIds: List<Long>): Map<Long, Long> {
+        if (postIds.isEmpty()) {
+            return emptyMap()
+        }
+
+        return postLikeRepository.countAllByPostIdIn(postIds).associate { it.postId to it.count }
+    }
+
+    private fun getPostCommentCounts(postIds: List<Long>): Map<Long, Long> {
+        if (postIds.isEmpty()) {
+            return emptyMap()
+        }
+
+        return commentRepository.countAllByPostIdIn(postIds).associate { it.postId to it.count }
+    }
+
+    private fun encodeLikedPostCursor(postLike: PostLike): String {
+        val rawCursor = "${postLike.createdAt}|${requireNotNull(postLike.id)}"
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(rawCursor.toByteArray())
+    }
+
+    private fun decodeLikedPostCursor(cursor: String): LikedPostCursor {
+        val decodedCursor = runCatching {
+            String(Base64.getUrlDecoder().decode(cursor))
+        }.getOrElse {
+            throw BadRequestException("유효하지 않은 커서입니다.")
+        }
+        val delimiterIndex = decodedCursor.lastIndexOf('|')
+        if (delimiterIndex < 1 || delimiterIndex == decodedCursor.lastIndex) {
+            throw BadRequestException("유효하지 않은 커서입니다.")
+        }
+
+        return LikedPostCursor(
+            createdAt = runCatching { LocalDateTime.parse(decodedCursor.substring(0, delimiterIndex)) }
+                .getOrElse { throw BadRequestException("유효하지 않은 커서입니다.") },
+            id = decodedCursor.substring(delimiterIndex + 1).toLongOrNull()
+                ?: throw BadRequestException("유효하지 않은 커서입니다."),
+        )
+    }
+
+    private companion object {
+        const val LIKED_POSTS_PAGE_SIZE = 10
+    }
+
+    private data class LikedPostCursor(
+        val createdAt: LocalDateTime,
+        val id: Long,
+    )
 }

--- a/backend/src/test/kotlin/io/github/kitae9999/openlog/post/PostServiceTest.kt
+++ b/backend/src/test/kotlin/io/github/kitae9999/openlog/post/PostServiceTest.kt
@@ -1,5 +1,6 @@
 package io.github.kitae9999.openlog.post
 
+import io.github.kitae9999.openlog.comment.repository.CommentRepository
 import io.github.kitae9999.openlog.common.exception.ForbiddenException
 import io.github.kitae9999.openlog.common.exception.NotFoundException
 import io.github.kitae9999.openlog.post.command.PostLinkWriteCommand
@@ -8,12 +9,15 @@ import io.github.kitae9999.openlog.post.entity.Post
 import io.github.kitae9999.openlog.post.entity.PostLink
 import io.github.kitae9999.openlog.post.repository.PostLinkRepository
 import io.github.kitae9999.openlog.post.repository.PostRepository
+import io.github.kitae9999.openlog.postlike.PostLikeCount
+import io.github.kitae9999.openlog.postlike.PostLikeRepository
 import io.github.kitae9999.openlog.posttopic.entity.PostTopic
 import io.github.kitae9999.openlog.posttopic.repository.PostTopicRepository
 import io.github.kitae9999.openlog.suggest.repository.SuggestionRepository
 import io.github.kitae9999.openlog.topic.entity.Topic
 import io.github.kitae9999.openlog.topic.repository.TopicRepository
 import io.github.kitae9999.openlog.user.entity.User
+import io.github.kitae9999.openlog.comment.repository.CommentCount
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
@@ -30,6 +34,8 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.Mockito.verifyNoMoreInteractions
 import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.data.domain.PageRequest
+import java.util.Base64
 import java.util.Optional
 
 @ExtendWith(MockitoExtension::class)
@@ -49,6 +55,12 @@ class PostServiceTest {
     @Mock
     private lateinit var topicRepository: TopicRepository
 
+    @Mock
+    private lateinit var postLikeRepository: PostLikeRepository
+
+    @Mock
+    private lateinit var commentRepository: CommentRepository
+
     private lateinit var postService: PostService
 
     @BeforeEach
@@ -59,6 +71,8 @@ class PostServiceTest {
             postTopicRepository = postTopicRepository,
             suggestionRepository = suggestionRepository,
             topicRepository = topicRepository,
+            postLikeRepository = postLikeRepository,
+            commentRepository = commentRepository,
         )
         lenient().`when`(postLinkRepository.findAllBySourcePostId(anyLong())).thenReturn(emptyList())
     }
@@ -80,6 +94,91 @@ class PostServiceTest {
         assertThat(postCaptor.value.author).isSameAs(user)
         assertThat(postCaptor.value.slug).isEqualTo("hello-openlog")
         assertThat(postCaptor.value.title).isEqualTo("Hello OpenLog")
+    }
+
+    @Test
+    fun `getRecentPosts returns first cursor page with capped page size`() {
+        val user = User(
+            id = 1L,
+            username = "alice",
+            nickname = "Alice",
+            profileImageUrl = "https://example.com/alice.png",
+        )
+        val post = Post(
+            id = 10L,
+            author = user,
+            slug = "hello-openlog",
+            title = "Hello OpenLog",
+            description = "A short intro",
+            content = "Content",
+        )
+        given(postRepository.findAllByOrderByCreatedAtDescIdDesc(PageRequest.of(0, 11)))
+            .willReturn(listOf(post))
+        given(postLikeRepository.countAllByPostIdIn(listOf(10L))).willReturn(
+            listOf(object : PostLikeCount {
+                override val postId = 10L
+                override val count = 3L
+            })
+        )
+        given(commentRepository.countAllByPostIdIn(listOf(10L))).willReturn(
+            listOf(object : CommentCount {
+                override val postId = 10L
+                override val count = 2L
+            })
+        )
+
+        val response = postService.getRecentPosts(cursor = null, size = 30)
+
+        assertThat(response.size).isEqualTo(10)
+        assertThat(response.nextCursor).isNull()
+        assertThat(response.hasNext).isFalse()
+        val summary = response.posts.single()
+        assertThat(summary.id).isEqualTo(10L)
+        assertThat(summary.slug).isEqualTo("hello-openlog")
+        assertThat(summary.authorUsername).isEqualTo("alice")
+        assertThat(summary.authorName).isEqualTo("Alice")
+        assertThat(summary.authorAvatarSrc).isEqualTo("https://example.com/alice.png")
+        assertThat(summary.likes).isEqualTo(3)
+        assertThat(summary.comments).isEqualTo(2)
+    }
+
+    @Test
+    fun `getRecentPosts loads next cursor page`() {
+        val user = User(id = 1L, username = "alice", nickname = "Alice")
+        val cursorPost = Post(
+            id = 20L,
+            author = user,
+            slug = "cursor-post",
+            title = "Cursor Post",
+            description = "Cursor",
+            content = "Content",
+        )
+        val nextPost = Post(
+            id = 19L,
+            author = user,
+            slug = "next-post",
+            title = "Next Post",
+            description = "Next",
+            content = "Content",
+        )
+        val cursor = Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString("${cursorPost.createdAt}|20".toByteArray())
+        given(
+            postRepository.findRecentPostsAfterCursor(
+                cursorPost.createdAt,
+                20L,
+                PageRequest.of(0, 11),
+            )
+        ).willReturn(listOf(nextPost))
+        given(postLikeRepository.countAllByPostIdIn(listOf(19L))).willReturn(emptyList())
+        given(commentRepository.countAllByPostIdIn(listOf(19L))).willReturn(emptyList())
+
+        val response = postService.getRecentPosts(cursor = cursor, size = 10)
+
+        assertThat(response.posts.single().id).isEqualTo(19L)
+        assertThat(response.nextCursor).isNull()
+        assertThat(response.hasNext).isFalse()
     }
 
     @Test

--- a/frontend/app/[username]/posts/[postSlug]/page.tsx
+++ b/frontend/app/[username]/posts/[postSlug]/page.tsx
@@ -99,7 +99,7 @@ export default async function PublicPostPage({
             }
             authorHref={authorHref}
             currentUserAvatarSrc={viewer?.profileImageUrl}
-            backHref="/?tab=trending"
+            backHref="/"
             articleHref={articleHref}
             suggestsHref={suggestsHref}
             suggestCount={suggestions.length}
@@ -151,7 +151,7 @@ export default async function PublicPostPage({
           contributors={contributors}
           authorHref={authorHref}
           currentUserAvatarSrc={viewer?.profileImageUrl}
-          backHref="/?tab=trending"
+          backHref="/"
           articleHref={articleHref}
           suggestsHref={suggestsHref}
           suggestCount={entry.suggestCount}

--- a/frontend/app/[username]/posts/[postSlug]/suggestions/page.tsx
+++ b/frontend/app/[username]/posts/[postSlug]/suggestions/page.tsx
@@ -56,7 +56,10 @@ export default async function PublicPostSuggestsPage({
   ]);
 
   const articleHref = buildPublicPostPath(authorUsername, canonicalPostSlug);
-  const suggestsHref = buildPublicSuggestsPath(authorUsername, canonicalPostSlug);
+  const suggestsHref = buildPublicSuggestsPath(
+    authorUsername,
+    canonicalPostSlug,
+  );
   const suggestEditHref = buildPublicSuggestNewPath(
     authorUsername,
     canonicalPostSlug,
@@ -70,7 +73,9 @@ export default async function PublicPostSuggestsPage({
         <Header
           isLoggedIn={!!viewer}
           profileImageUrl={viewer?.profileImageUrl}
-          profileHref={viewer ? buildViewerProfileHref(viewer.username) : undefined}
+          profileHref={
+            viewer ? buildViewerProfileHref(viewer.username) : undefined
+          }
         />
 
         <main className="mx-auto w-full max-w-[1083px] px-4 pb-16 pt-6 sm:px-8">
@@ -97,7 +102,7 @@ export default async function PublicPostSuggestsPage({
                 list,
               ),
             )}
-            backHref="/?tab=trending"
+            backHref="/"
             articleHref={articleHref}
             suggestsHref={suggestsHref}
             suggestEditHref={suggestEditHref}
@@ -121,14 +126,16 @@ export default async function PublicPostSuggestsPage({
       <Header
         isLoggedIn={!!viewer}
         profileImageUrl={viewer?.profileImageUrl}
-        profileHref={viewer ? buildViewerProfileHref(viewer.username) : undefined}
+        profileHref={
+          viewer ? buildViewerProfileHref(viewer.username) : undefined
+        }
       />
 
       <main className="mx-auto w-full max-w-[1083px] px-4 pb-16 pt-6 sm:px-8">
         <PostSuggests
           post={entry.post}
           suggestions={entry.suggestions}
-          backHref="/?tab=trending"
+          backHref="/"
           articleHref={articleHref}
           suggestsHref={suggestsHref}
           suggestEditHref={suggestEditHref}

--- a/frontend/app/api/posts/route.ts
+++ b/frontend/app/api/posts/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { API_CONFIG } from "@/shared/api";
+
+export async function GET(request: NextRequest) {
+  const cursor = request.nextUrl.searchParams.get("cursor");
+  const size = request.nextUrl.searchParams.get("size") ?? "10";
+  const params = new URLSearchParams({ size });
+  if (cursor) {
+    params.set("cursor", cursor);
+  }
+
+  const response = await fetch(`${API_CONFIG.baseURL}/posts?${params}`, {
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    return NextResponse.json(
+      { message: "Failed to load recent posts." },
+      { status: response.status },
+    );
+  }
+
+  return NextResponse.json(await response.json());
+}

--- a/frontend/app/api/users/me/liked-posts/route.ts
+++ b/frontend/app/api/users/me/liked-posts/route.ts
@@ -1,0 +1,32 @@
+import { headers } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+import { API_CONFIG } from "@/shared/api";
+
+export async function GET(request: NextRequest) {
+  const headerStore = await headers();
+  const cursor = request.nextUrl.searchParams.get("cursor");
+  const size = request.nextUrl.searchParams.get("size") ?? "10";
+  const params = new URLSearchParams({ size });
+  if (cursor) {
+    params.set("cursor", cursor);
+  }
+
+  const response = await fetch(
+    `${API_CONFIG.baseURL}/users/me/liked-posts?${params}`,
+    {
+      cache: "no-store",
+      headers: {
+        cookie: headerStore.get("cookie") ?? "",
+      },
+    },
+  );
+
+  if (!response.ok) {
+    return NextResponse.json(
+      { message: "Failed to load liked posts." },
+      { status: response.status },
+    );
+  }
+
+  return NextResponse.json(await response.json());
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -29,6 +29,11 @@ body {
     "Segoe UI Emoji";
 }
 
+html,
+body {
+  overscroll-behavior-y: none;
+}
+
 @keyframes openlog-caret-blink {
   0%,
   49% {

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -12,7 +12,7 @@ export default async function Home({
 }
 
 function normalizeTab(value: string | undefined) {
-  if (value === "home" || value === "following") {
+  if (value === "home" || value === "following" || value === "liked") {
     return value;
   }
   return "home";

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -12,8 +12,8 @@ export default async function Home({
 }
 
 function normalizeTab(value: string | undefined) {
-  if (value === "latest" || value === "following" || value === "trending") {
+  if (value === "home" || value === "following") {
     return value;
   }
-  return "trending";
+  return "home";
 }

--- a/frontend/public/feed/knowledge-graph.svg
+++ b/frontend/public/feed/knowledge-graph.svg
@@ -1,0 +1,40 @@
+<svg
+  width="368"
+  height="236"
+  viewBox="0 0 368 236"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <rect width="368" height="236" fill="#f6f7f9" />
+  <path
+    d="M103 118h78M181 118l70-50M181 118l68 56M103 118l-34 52M103 118 70 66"
+    stroke="#2f3437"
+    stroke-width="4"
+  />
+  <circle cx="181" cy="118" r="30" fill="#2f3437" />
+  <circle cx="103" cy="118" r="22" fill="#dfb553" />
+  <circle cx="251" cy="68" r="22" fill="#7b9588" />
+  <circle cx="249" cy="174" r="22" fill="#c9634b" />
+  <circle
+    cx="70"
+    cy="66"
+    r="16"
+    fill="#ffffff"
+    stroke="#2f3437"
+    stroke-width="4"
+  />
+  <circle
+    cx="69"
+    cy="170"
+    r="16"
+    fill="#ffffff"
+    stroke="#2f3437"
+    stroke-width="4"
+  />
+  <path
+    d="M168 114h26M176 127h18"
+    stroke="#ffffff"
+    stroke-width="5"
+    stroke-linecap="round"
+  />
+</svg>

--- a/frontend/public/feed/operational-notes.svg
+++ b/frontend/public/feed/operational-notes.svg
@@ -1,0 +1,33 @@
+<svg
+  width="368"
+  height="236"
+  viewBox="0 0 368 236"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <rect width="368" height="236" fill="#f4f1ea" />
+  <rect
+    x="28"
+    y="28"
+    width="312"
+    height="180"
+    rx="14"
+    fill="#fffaf0"
+    stroke="#222222"
+    stroke-width="2"
+  />
+  <rect x="52" y="54" width="128" height="14" rx="7" fill="#222222" />
+  <rect x="52" y="86" width="264" height="10" rx="5" fill="#d7d0c4" />
+  <rect x="52" y="112" width="214" height="10" rx="5" fill="#d7d0c4" />
+  <rect x="52" y="138" width="244" height="10" rx="5" fill="#d7d0c4" />
+  <path d="M241 57h55v55h-55V57Z" fill="#e7bf5f" />
+  <path
+    d="M255 72h27M255 86h20M255 100h31"
+    stroke="#222222"
+    stroke-width="4"
+    stroke-linecap="round"
+  />
+  <circle cx="77" cy="177" r="13" fill="#222222" />
+  <circle cx="115" cy="177" r="13" fill="#6c8778" />
+  <circle cx="153" cy="177" r="13" fill="#d35b42" />
+</svg>

--- a/frontend/public/feed/quiet-interfaces.svg
+++ b/frontend/public/feed/quiet-interfaces.svg
@@ -1,0 +1,21 @@
+<svg
+  width="368"
+  height="236"
+  viewBox="0 0 368 236"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <rect width="368" height="236" fill="#f3f4f2" />
+  <rect x="44" y="44" width="280" height="148" rx="12" fill="#222222" />
+  <rect x="68" y="70" width="96" height="14" rx="7" fill="#f4f1ea" />
+  <rect x="68" y="104" width="232" height="8" rx="4" fill="#7d817c" />
+  <rect x="68" y="128" width="186" height="8" rx="4" fill="#7d817c" />
+  <rect x="68" y="152" width="212" height="8" rx="4" fill="#7d817c" />
+  <rect x="238" y="64" width="56" height="56" rx="10" fill="#d9b45f" />
+  <path
+    d="M252 92h28M266 78v28"
+    stroke="#222222"
+    stroke-width="5"
+    stroke-linecap="round"
+  />
+</svg>

--- a/frontend/public/feed/review-cadence.svg
+++ b/frontend/public/feed/review-cadence.svg
@@ -1,0 +1,40 @@
+<svg
+  width="368"
+  height="236"
+  viewBox="0 0 368 236"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <rect width="368" height="236" fill="#eef3f1" />
+  <rect
+    x="38"
+    y="34"
+    width="292"
+    height="168"
+    rx="18"
+    fill="#ffffff"
+    stroke="#1f2933"
+    stroke-width="2"
+  />
+  <path
+    d="M74 164V94M128 164V72M182 164v-42M236 164V58M290 164v-66"
+    stroke="#1f2933"
+    stroke-width="10"
+    stroke-linecap="round"
+  />
+  <path
+    d="M64 166h236"
+    stroke="#1f2933"
+    stroke-width="3"
+    stroke-linecap="round"
+  />
+  <path
+    d="M69 86c39 19 77 20 113 4 35-16 71-14 108 6"
+    stroke="#c95d43"
+    stroke-width="6"
+    stroke-linecap="round"
+  />
+  <circle cx="69" cy="86" r="7" fill="#c95d43" />
+  <circle cx="182" cy="90" r="7" fill="#c95d43" />
+  <circle cx="290" cy="96" r="7" fill="#c95d43" />
+</svg>

--- a/frontend/src/01_widgets/chrome/ui/Header.tsx
+++ b/frontend/src/01_widgets/chrome/ui/Header.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Image from "next/image";
 import Link from "next/link";
 import { assets } from "@/shared/config/assets";
@@ -12,11 +14,15 @@ export function Header({
   profileImageUrl,
   profileHref,
   showWriteAction = true,
+  isSidebarOpen,
+  onSidebarToggle,
 }: {
   isLoggedIn: boolean;
   profileImageUrl?: string | null;
   profileHref?: string;
   showWriteAction?: boolean;
+  isSidebarOpen?: boolean;
+  onSidebarToggle?: () => void;
 }) {
   const resolvedProfileImageUrl = profileImageUrl ?? assets.defaultAvatar;
 
@@ -24,20 +30,34 @@ export function Header({
     <header className="sticky top-0 z-40 border-b border-zinc-200/70 bg-white/80 backdrop-blur">
       <div className="mx-auto flex h-16 w-full max-w-[1083px] items-center justify-between gap-4 px-4 sm:px-8">
         <div className="flex items-center gap-8">
-          <Link
-            href="/"
-            className="flex items-center gap-2 rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
-          >
-            <span
-              className={cn(
-                "grid size-7 place-items-center rounded-lg bg-black text-[16px] text-white",
-                logoMarkClassName,
-              )}
+          <div className="flex items-center gap-3">
+            {onSidebarToggle ? (
+              <button
+                type="button"
+                aria-label={isSidebarOpen ? "Close sidebar" : "Open sidebar"}
+                aria-expanded={isSidebarOpen}
+                onClick={onSidebarToggle}
+                className="grid size-10 place-items-center rounded-full text-zinc-700 transition hover:bg-zinc-100 hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
+              >
+                <IconMenu isOpen={!!isSidebarOpen} className="size-5" />
+              </button>
+            ) : null}
+
+            <Link
+              href="/"
+              className="flex items-center gap-2 rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
             >
-              O
-            </span>
-            <span className={logoWordmarkClassName}>OpenLog</span>
-          </Link>
+              <span
+                className={cn(
+                  "grid size-7 place-items-center rounded-lg bg-black text-[16px] text-white",
+                  logoMarkClassName,
+                )}
+              >
+                O
+              </span>
+              <span className={logoWordmarkClassName}>OpenLog</span>
+            </Link>
+          </div>
 
           <nav
             aria-label="Primary"
@@ -49,7 +69,7 @@ export function Header({
                 href={item.href}
                 className={cn(
                   "text-sm font-medium text-zinc-600 transition-colors hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20",
-                  item.label === "Trending" && "text-zinc-950",
+                  item.label === "Home" && "text-zinc-950",
                 )}
               >
                 {item.label}
@@ -100,6 +120,51 @@ export function Header({
         </div>
       </div>
     </header>
+  );
+}
+
+function IconMenu({
+  isOpen,
+  className,
+}: {
+  isOpen: boolean;
+  className?: string;
+}) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M4 7h16"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        className={cn(
+          "origin-center transition-transform duration-300",
+          isOpen && "translate-y-[5px] rotate-45",
+        )}
+      />
+      <path
+        d="M4 12h16"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        className={cn("transition-opacity duration-200", isOpen && "opacity-0")}
+      />
+      <path
+        d="M4 17h16"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        className={cn(
+          "origin-center transition-transform duration-300",
+          isOpen && "-translate-y-[5px] -rotate-45",
+        )}
+      />
+    </svg>
   );
 }
 

--- a/frontend/src/01_widgets/chrome/ui/Header.tsx
+++ b/frontend/src/01_widgets/chrome/ui/Header.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { assets } from "@/shared/config/assets";
 import { cn } from "@/shared/lib/cn";
 import { GuestActions } from "@/features/auth/ui";
-import { logoMarkClassName, logoWordmarkClassName, navLinks } from "./brand";
+import { logoMarkClassName, logoWordmarkClassName } from "./brand";
 import { ProfileMenu } from "./ProfileMenu";
 import { SearchBar } from "./SearchBar";
 
@@ -39,7 +39,7 @@ export function Header({
                 onClick={onSidebarToggle}
                 className="grid size-10 place-items-center rounded-full text-zinc-700 transition hover:bg-zinc-100 hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
               >
-                <IconMenu isOpen={!!isSidebarOpen} className="size-5" />
+                <IconMenu className="size-5" />
               </button>
             ) : null}
 
@@ -58,24 +58,6 @@ export function Header({
               <span className={logoWordmarkClassName}>OpenLog</span>
             </Link>
           </div>
-
-          <nav
-            aria-label="Primary"
-            className="hidden items-center gap-6 md:flex"
-          >
-            {navLinks.map((item) => (
-              <Link
-                key={item.label}
-                href={item.href}
-                className={cn(
-                  "text-sm font-medium text-zinc-600 transition-colors hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20",
-                  item.label === "Home" && "text-zinc-950",
-                )}
-              >
-                {item.label}
-              </Link>
-            ))}
-          </nav>
         </div>
 
         <div className="flex items-center gap-3">
@@ -123,13 +105,7 @@ export function Header({
   );
 }
 
-function IconMenu({
-  isOpen,
-  className,
-}: {
-  isOpen: boolean;
-  className?: string;
-}) {
+function IconMenu({ className }: { className?: string }) {
   return (
     <svg
       viewBox="0 0 24 24"
@@ -142,27 +118,18 @@ function IconMenu({
         stroke="currentColor"
         strokeWidth="2"
         strokeLinecap="round"
-        className={cn(
-          "origin-center transition-transform duration-300",
-          isOpen && "translate-y-[5px] rotate-45",
-        )}
       />
       <path
         d="M4 12h16"
         stroke="currentColor"
         strokeWidth="2"
         strokeLinecap="round"
-        className={cn("transition-opacity duration-200", isOpen && "opacity-0")}
       />
       <path
         d="M4 17h16"
         stroke="currentColor"
         strokeWidth="2"
         strokeLinecap="round"
-        className={cn(
-          "origin-center transition-transform duration-300",
-          isOpen && "-translate-y-[5px] -rotate-45",
-        )}
       />
     </svg>
   );

--- a/frontend/src/01_widgets/chrome/ui/Header.tsx
+++ b/frontend/src/01_widgets/chrome/ui/Header.tsx
@@ -27,7 +27,7 @@ export function Header({
   const resolvedProfileImageUrl = profileImageUrl ?? assets.defaultAvatar;
 
   return (
-    <header className="sticky top-0 z-40 border-b border-zinc-200/70 bg-white/80 backdrop-blur">
+    <header className="sticky top-0 z-50 border-b border-zinc-200/70 bg-white/80 backdrop-blur">
       <div className="mx-auto flex h-16 w-full max-w-[1083px] items-center justify-between gap-4 px-4 sm:px-8">
         <div className="flex items-center gap-8">
           <div className="flex items-center gap-3">

--- a/frontend/src/01_widgets/chrome/ui/brand.ts
+++ b/frontend/src/01_widgets/chrome/ui/brand.ts
@@ -1,7 +1,6 @@
 export const navLinks = [
-  { href: "/?tab=trending", label: "Trending" },
-  { href: "/explore", label: "Explore" },
-  { href: "/topics", label: "Topics" },
+  { href: "/", label: "Home" },
+  { href: "/?tab=following", label: "Following" },
 ] as const;
 
 export const logoWordmarkClassName =

--- a/frontend/src/01_widgets/chrome/ui/brand.ts
+++ b/frontend/src/01_widgets/chrome/ui/brand.ts
@@ -1,8 +1,3 @@
-export const navLinks = [
-  { href: "/", label: "Home" },
-  { href: "/?tab=following", label: "Following" },
-] as const;
-
 export const logoWordmarkClassName =
   "text-[24px] font-bold leading-none [font-family:Georgia,serif]";
 

--- a/frontend/src/01_widgets/home-feed/ui/FeedTabs.tsx
+++ b/frontend/src/01_widgets/home-feed/ui/FeedTabs.tsx
@@ -1,29 +1,18 @@
-import Image from "next/image";
 import Link from "next/link";
 import { cn } from "@/shared/lib/cn";
 import { tabs, type TabKey } from "./data";
 
-export function FeedTabs({
-  active,
-  isLoggedIn,
-}: {
-  active: TabKey;
-  isLoggedIn: boolean;
-}) {
-  const visibleTabs = isLoggedIn
-    ? tabs
-    : tabs.filter((tab) => tab.key !== "following");
-
+export function FeedTabs({ active }: { active: TabKey }) {
   return (
     <div className="border-b border-zinc-200/70">
       <div className="flex gap-6">
-        {visibleTabs.map((tab) => {
+        {tabs.map((tab) => {
           const isActive = tab.key === active;
 
           return (
             <Link
               key={tab.key}
-              href={`/?tab=${tab.key}`}
+              href={tab.key === "home" ? "/" : "/?tab=following"}
               className={cn(
                 "relative -mb-px inline-flex items-center gap-2 py-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20",
                 isActive
@@ -31,17 +20,6 @@ export function FeedTabs({
                   : "text-zinc-500 hover:text-zinc-950",
               )}
             >
-              <Image
-                src={tab.iconSrc}
-                alt=""
-                width={16}
-                height={16}
-                aria-hidden="true"
-                className={cn(
-                  "size-4",
-                  isActive ? "brightness-0" : "opacity-70",
-                )}
-              />
               {tab.label}
               {isActive ? (
                 <span className="absolute inset-x-0 -bottom-px h-0.5 bg-zinc-950" />

--- a/frontend/src/01_widgets/home-feed/ui/FeedTabs.tsx
+++ b/frontend/src/01_widgets/home-feed/ui/FeedTabs.tsx
@@ -12,7 +12,7 @@ export function FeedTabs({ active }: { active: TabKey }) {
           return (
             <Link
               key={tab.key}
-              href={tab.key === "home" ? "/" : "/?tab=following"}
+              href={getTabHref(tab.key)}
               className={cn(
                 "relative -mb-px inline-flex items-center gap-2 py-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20",
                 isActive
@@ -30,4 +30,8 @@ export function FeedTabs({ active }: { active: TabKey }) {
       </div>
     </div>
   );
+}
+
+function getTabHref(tab: TabKey) {
+  return tab === "home" ? "/" : `/?tab=${tab}`;
 }

--- a/frontend/src/01_widgets/home-feed/ui/HomeFeed.tsx
+++ b/frontend/src/01_widgets/home-feed/ui/HomeFeed.tsx
@@ -1,5 +1,7 @@
 import { Footer } from "@/widgets/chrome/ui";
 import type { TabKey } from "./data";
+import { getLikedPosts } from "@/entities/post/api/getLikedPosts";
+import { getRecentPosts } from "@/entities/post/api/getRecentPosts";
 import { getUserOrRedirectToOnboarding } from "@/features/auth/api/requireOnboarding";
 import type { User } from "@/entities/user/model/User";
 import { buildViewerProfileHref } from "@/shared/lib/publicRoutes";
@@ -14,6 +16,10 @@ export async function HomeFeed({
 }) {
   const data =
     viewer === undefined ? await getUserOrRedirectToOnboarding() : viewer;
+  const recentPosts =
+    activeTab === "home" ? await getRecentPosts(null, 10) : undefined;
+  const likedPosts =
+    activeTab === "liked" && data ? await getLikedPosts(null, 10) : undefined;
 
   const isLoggedIn = !!data; // data 있으면 true, 없으면 false
 
@@ -21,6 +27,12 @@ export async function HomeFeed({
     <HomeFeedShell
       activeTab={activeTab}
       isLoggedIn={isLoggedIn}
+      initialHomePosts={recentPosts?.posts ?? []}
+      initialHomeNextCursor={recentPosts?.nextCursor ?? null}
+      initialHomeHasNext={recentPosts?.hasNext ?? false}
+      initialLikedPosts={likedPosts?.posts ?? []}
+      initialLikedNextCursor={likedPosts?.nextCursor ?? null}
+      initialLikedHasNext={likedPosts?.hasNext ?? false}
       profileImageUrl={data?.profileImageUrl}
       profileHref={data ? buildViewerProfileHref(data.username) : undefined}
       footer={<Footer />}

--- a/frontend/src/01_widgets/home-feed/ui/HomeFeed.tsx
+++ b/frontend/src/01_widgets/home-feed/ui/HomeFeed.tsx
@@ -1,18 +1,12 @@
-import { Footer, Header } from "@/widgets/chrome/ui";
-import { ContributeCard } from "./ContributeCard";
-import { FeedTabs } from "./FeedTabs";
-import { FeaturedPostCard } from "./FeaturedPostCard";
-import { KnowledgeGraphCard } from "./KnowledgeGraphCard";
-import { PostRow } from "./PostRow";
-import { RecommendedTopics } from "./RecommendedTopics";
-import { TopContributors } from "./TopContributors";
+import { Footer } from "@/widgets/chrome/ui";
 import type { TabKey } from "./data";
 import { getUserOrRedirectToOnboarding } from "@/features/auth/api/requireOnboarding";
 import type { User } from "@/entities/user/model/User";
 import { buildViewerProfileHref } from "@/shared/lib/publicRoutes";
+import { HomeFeedShell } from "./HomeFeedShell";
 
 export async function HomeFeed({
-  activeTab = "trending",
+  activeTab = "home",
   viewer,
 }: {
   activeTab?: TabKey;
@@ -23,36 +17,13 @@ export async function HomeFeed({
 
   const isLoggedIn = !!data; // data 있으면 true, 없으면 false
 
-  const resolvedActiveTab =
-    !isLoggedIn && activeTab === "following" ? "trending" : activeTab;
-
   return (
-    <div className="min-h-dvh bg-white text-zinc-950">
-      <Header
-        isLoggedIn={isLoggedIn}
-        profileImageUrl={data?.profileImageUrl}
-        profileHref={data ? buildViewerProfileHref(data.username) : undefined}
-      />
-      <main className="mx-auto w-full max-w-[1083px] px-4 pb-16 pt-6 sm:px-8">
-        <div className="grid grid-cols-1 gap-10 lg:grid-cols-[minmax(0,1fr)_340px]">
-          <section aria-label="Feed" className="min-w-0">
-            <FeedTabs active={resolvedActiveTab} isLoggedIn={isLoggedIn} />
-
-            <div className="mt-6 space-y-10">
-              <FeaturedPostCard />
-              <PostRow />
-            </div>
-          </section>
-
-          <aside aria-label="Sidebar" className="space-y-10">
-            <KnowledgeGraphCard />
-            <RecommendedTopics />
-            <TopContributors />
-            <ContributeCard />
-          </aside>
-        </div>
-      </main>
-      <Footer />
-    </div>
+    <HomeFeedShell
+      activeTab={activeTab}
+      isLoggedIn={isLoggedIn}
+      profileImageUrl={data?.profileImageUrl}
+      profileHref={data ? buildViewerProfileHref(data.username) : undefined}
+      footer={<Footer />}
+    />
   );
 }

--- a/frontend/src/01_widgets/home-feed/ui/HomeFeedShell.tsx
+++ b/frontend/src/01_widgets/home-feed/ui/HomeFeedShell.tsx
@@ -1,0 +1,385 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect, useState, type ReactNode } from "react";
+import { Header } from "@/widgets/chrome/ui";
+import { cn } from "@/shared/lib/cn";
+import {
+  feedPosts,
+  followingPosts,
+  tabs,
+  type FeedPost,
+  type TabKey,
+} from "./data";
+
+export function HomeFeedShell({
+  activeTab,
+  isLoggedIn,
+  profileImageUrl,
+  profileHref,
+  footer,
+}: {
+  activeTab: TabKey;
+  isLoggedIn: boolean;
+  profileImageUrl?: string | null;
+  profileHref?: string;
+  footer: ReactNode;
+}) {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const posts = activeTab === "following" ? followingPosts : feedPosts;
+
+  useEffect(() => {
+    const query = window.matchMedia("(min-width: 1024px)");
+
+    function syncSidebar(event: MediaQueryList | MediaQueryListEvent) {
+      setIsSidebarOpen(event.matches);
+    }
+
+    syncSidebar(query);
+    query.addEventListener("change", syncSidebar);
+
+    return () => {
+      query.removeEventListener("change", syncSidebar);
+    };
+  }, []);
+
+  return (
+    <div className="flex min-h-dvh flex-col bg-white text-zinc-950">
+      <Header
+        isLoggedIn={isLoggedIn}
+        profileImageUrl={profileImageUrl}
+        profileHref={profileHref}
+        isSidebarOpen={isSidebarOpen}
+        onSidebarToggle={() => setIsSidebarOpen((current) => !current)}
+      />
+
+      <div className="relative flex flex-1 overflow-hidden border-b border-zinc-200/70">
+        <button
+          type="button"
+          aria-label="Close navigation overlay"
+          className={cn(
+            "fixed bottom-0 left-[282px] right-0 top-16 z-30 bg-zinc-950/20 backdrop-blur-[2px] transition-opacity duration-300 lg:hidden",
+            isSidebarOpen ? "opacity-100" : "pointer-events-none opacity-0",
+          )}
+          onClick={() => setIsSidebarOpen(false)}
+        />
+
+        <HomeSidebar
+          activeTab={activeTab}
+          isOpen={isSidebarOpen}
+          onNavigate={() => {
+            if (!window.matchMedia("(min-width: 1024px)").matches) {
+              setIsSidebarOpen(false);
+            }
+          }}
+        />
+
+        <main
+          className={cn(
+            "min-w-0 flex-1 transition-[margin] duration-300 ease-out",
+            isSidebarOpen ? "lg:ml-[282px]" : "lg:ml-0",
+          )}
+        >
+          <section
+            aria-label="New posts"
+            className="mx-auto w-full max-w-[1012px] px-5 pb-16 pt-9 sm:px-8 lg:px-12"
+          >
+            <FeedNav activeTab={activeTab} />
+
+            <div className="divide-y divide-zinc-200/80">
+              {posts.map((post) => (
+                <ArticleCard key={post.id} post={post} />
+              ))}
+            </div>
+          </section>
+        </main>
+      </div>
+
+      {footer}
+    </div>
+  );
+}
+
+function HomeSidebar({
+  activeTab,
+  isOpen,
+  onNavigate,
+}: {
+  activeTab: TabKey;
+  isOpen: boolean;
+  onNavigate: () => void;
+}) {
+  return (
+    <aside
+      aria-label="Feed navigation"
+      className={cn(
+        "fixed bottom-0 left-0 top-16 z-40 w-[282px] border-r border-zinc-200/80 bg-white transition-transform duration-300 ease-out",
+        isOpen ? "translate-x-0" : "-translate-x-full",
+      )}
+    >
+      <nav className="flex h-full flex-col px-5 py-8">
+        <div className="space-y-1">
+          {tabs.map((tab) => {
+            const isActive = tab.key === activeTab;
+
+            return (
+              <Link
+                key={tab.key}
+                href={tab.key === "home" ? "/" : "/?tab=following"}
+                aria-current={isActive ? "page" : undefined}
+                onClick={onNavigate}
+                className={cn(
+                  "flex h-12 items-center gap-4 rounded-lg px-3 text-[15px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20",
+                  isActive
+                    ? "bg-zinc-100 text-zinc-950"
+                    : "text-zinc-600 hover:bg-zinc-50 hover:text-zinc-950",
+                )}
+              >
+                {tab.key === "home" ? (
+                  <IconHome className="size-5" />
+                ) : (
+                  <IconUsers className="size-5" />
+                )}
+                {tab.label}
+              </Link>
+            );
+          })}
+        </div>
+
+        <div className="mt-auto border-t border-zinc-200 pt-6 text-[13px] leading-6 text-zinc-500">
+          New writing from the OpenLog community, arranged for steady reading.
+        </div>
+      </nav>
+    </aside>
+  );
+}
+
+function FeedNav({ activeTab }: { activeTab: TabKey }) {
+  return (
+    <div className="sticky top-16 z-10 border-b border-zinc-200/80 bg-white/95 pt-2 backdrop-blur">
+      <div className="flex items-end gap-9">
+        {tabs.map((tab) => {
+          const isActive = tab.key === activeTab;
+
+          return (
+            <Link
+              key={tab.key}
+              href={tab.key === "home" ? "/" : "/?tab=following"}
+              aria-current={isActive ? "page" : undefined}
+              className={cn(
+                "relative -mb-px py-4 text-[15px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20",
+                isActive
+                  ? "text-zinc-950"
+                  : "text-zinc-500 hover:text-zinc-950",
+              )}
+            >
+              {tab.label}
+              {isActive ? (
+                <span className="absolute inset-x-0 bottom-0 h-px bg-zinc-950" />
+              ) : null}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function ArticleCard({ post }: { post: FeedPost }) {
+  return (
+    <article className="py-8">
+      <Link
+        href={post.href}
+        className="group grid gap-5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20 sm:grid-cols-[minmax(0,1fr)_184px] sm:items-center"
+      >
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[13px] text-zinc-600">
+            <span className="grid size-6 place-items-center rounded-full bg-zinc-950 text-[11px] font-semibold text-white">
+              {post.author.charAt(0)}
+            </span>
+            {post.publication ? (
+              <>
+                <span>In {post.publication}</span>
+                <span className="text-zinc-300">by</span>
+              </>
+            ) : null}
+            <span className="font-medium text-zinc-800">{post.author}</span>
+          </div>
+
+          <h2 className="mt-4 max-w-[680px] text-[24px] font-bold leading-[1.16] tracking-tight text-zinc-950 transition-colors group-hover:text-zinc-700 sm:text-[30px]">
+            {post.title}
+          </h2>
+
+          <p className="mt-3 max-w-[650px] text-[16px] leading-7 text-zinc-600">
+            {post.description}
+          </p>
+        </div>
+
+        <div className="relative h-[126px] w-full overflow-hidden rounded-md border border-zinc-200 bg-zinc-100 sm:h-[118px]">
+          <Image
+            src={post.thumbnailSrc}
+            alt=""
+            fill
+            sizes="(min-width: 640px) 184px, 100vw"
+            className="object-cover transition duration-300 group-hover:scale-[1.03]"
+          />
+        </div>
+      </Link>
+
+      <div className="mt-5 flex items-center justify-between gap-4 text-[13px] text-zinc-500">
+        <div className="flex flex-wrap items-center gap-3">
+          <IconSparkle className="size-4 text-amber-500" />
+          <span>{post.dateLabel}</span>
+          <span className="inline-flex items-center gap-1.5">
+            <IconClap className="size-4" />
+            {post.readCount}
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            <IconComment className="size-4" />
+            {post.commentCount}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-2 text-zinc-500">
+          <button
+            type="button"
+            aria-label={`Save ${post.title}`}
+            className="grid size-8 place-items-center rounded-full transition hover:bg-zinc-100 hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
+          >
+            <IconBookmark className="size-5" />
+          </button>
+          <button
+            type="button"
+            aria-label={`More actions for ${post.title}`}
+            className="grid size-8 place-items-center rounded-full transition hover:bg-zinc-100 hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
+          >
+            <IconDots className="size-5" />
+          </button>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function IconHome({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M4 10.5 12 4l8 6.5V20a1 1 0 0 1-1 1h-5v-6h-4v6H5a1 1 0 0 1-1-1v-9.5Z"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function IconUsers({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M8.5 11a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7ZM2.5 20a6 6 0 0 1 12 0M17 10.5a3 3 0 1 0-1.2-5.75M16.5 14.5A5 5 0 0 1 21.5 20"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function IconClap({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M7.5 11.5 5.8 8.1a1.4 1.4 0 0 1 2.5-1.25l1.85 3.7M10.2 10.6 7.9 5.8a1.45 1.45 0 0 1 2.6-1.25l2.55 5.35M13 10.2l-1.8-3.8a1.45 1.45 0 0 1 2.62-1.25L17.6 13M17.6 13l.95-2.65a1.35 1.35 0 0 1 2.6.68c-.9 5.5-3.3 8.15-7.25 8.15H12c-2.9 0-5.35-1.65-6.55-4.3l-1.2-2.65a1.45 1.45 0 0 1 2.6-1.28l1.15 2.1"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function IconComment({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M6.5 18.5 3 21V5.5A2.5 2.5 0 0 1 5.5 3h13A2.5 2.5 0 0 1 21 5.5V16a2.5 2.5 0 0 1-2.5 2.5h-12Z"
+        stroke="currentColor"
+        strokeWidth="1.7"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function IconSparkle({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M12 2.75 14.42 9.58 21.25 12l-6.83 2.42L12 21.25l-2.42-6.83L2.75 12l6.83-2.42L12 2.75Z" />
+    </svg>
+  );
+}
+
+function IconBookmark({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M6.5 4.5A1.5 1.5 0 0 1 8 3h8a1.5 1.5 0 0 1 1.5 1.5V21L12 17.5 6.5 21V4.5Z"
+        stroke="currentColor"
+        strokeWidth="1.7"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function IconDots({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M6.5 12h.01M12 12h.01M17.5 12h.01"
+        stroke="currentColor"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/frontend/src/01_widgets/home-feed/ui/HomeFeedShell.tsx
+++ b/frontend/src/01_widgets/home-feed/ui/HomeFeedShell.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/shared/lib/cn";
 import {
   feedPosts,
   followingPosts,
+  likedPosts,
   tabs,
   type FeedPost,
   type TabKey,
@@ -27,7 +28,7 @@ export function HomeFeedShell({
   footer: ReactNode;
 }) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-  const posts = activeTab === "following" ? followingPosts : feedPosts;
+  const posts = getPostsForTab(activeTab);
 
   useEffect(() => {
     const query = window.matchMedia("(min-width: 1024px)");
@@ -83,9 +84,14 @@ export function HomeFeedShell({
         >
           <section
             aria-label="New posts"
-            className="mx-auto w-full max-w-[1012px] px-5 pb-16 pt-9 sm:px-8 lg:px-12"
+            className="mx-auto w-full max-w-[1012px] px-5 pb-16 pt-6 sm:px-8 lg:px-12"
           >
-            <FeedNav activeTab={activeTab} />
+            {activeTab === "home" ? (
+              <div className="flex items-center gap-2 border-b border-zinc-200/80 pb-4 text-[15px] font-semibold text-zinc-950">
+                <IconClock className="size-5 text-zinc-600" />
+                <h1>Recent</h1>
+              </div>
+            ) : null}
 
             <div className="divide-y divide-zinc-200/80">
               {posts.map((post) => (
@@ -126,7 +132,7 @@ function HomeSidebar({
             return (
               <Link
                 key={tab.key}
-                href={tab.key === "home" ? "/" : "/?tab=following"}
+                href={getTabHref(tab.key)}
                 aria-current={isActive ? "page" : undefined}
                 onClick={onNavigate}
                 className={cn(
@@ -138,8 +144,10 @@ function HomeSidebar({
               >
                 {tab.key === "home" ? (
                   <IconHome className="size-5" />
-                ) : (
+                ) : tab.key === "following" ? (
                   <IconUsers className="size-5" />
+                ) : (
+                  <IconHeart className="size-5" />
                 )}
                 {tab.label}
               </Link>
@@ -152,37 +160,6 @@ function HomeSidebar({
         </div>
       </nav>
     </aside>
-  );
-}
-
-function FeedNav({ activeTab }: { activeTab: TabKey }) {
-  return (
-    <div className="sticky top-16 z-10 border-b border-zinc-200/80 bg-white/95 pt-2 backdrop-blur">
-      <div className="flex items-end gap-9">
-        {tabs.map((tab) => {
-          const isActive = tab.key === activeTab;
-
-          return (
-            <Link
-              key={tab.key}
-              href={tab.key === "home" ? "/" : "/?tab=following"}
-              aria-current={isActive ? "page" : undefined}
-              className={cn(
-                "relative -mb-px py-4 text-[15px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20",
-                isActive
-                  ? "text-zinc-950"
-                  : "text-zinc-500 hover:text-zinc-950",
-              )}
-            >
-              {tab.label}
-              {isActive ? (
-                <span className="absolute inset-x-0 bottom-0 h-px bg-zinc-950" />
-              ) : null}
-            </Link>
-          );
-        })}
-      </div>
-    </div>
   );
 }
 
@@ -262,6 +239,22 @@ function ArticleCard({ post }: { post: FeedPost }) {
   );
 }
 
+function getPostsForTab(tab: TabKey) {
+  if (tab === "following") {
+    return followingPosts;
+  }
+
+  if (tab === "liked") {
+    return likedPosts;
+  }
+
+  return feedPosts;
+}
+
+function getTabHref(tab: TabKey) {
+  return tab === "home" ? "/" : `/?tab=${tab}`;
+}
+
 function IconHome({ className }: { className?: string }) {
   return (
     <svg
@@ -293,6 +286,45 @@ function IconUsers({ className }: { className?: string }) {
         stroke="currentColor"
         strokeWidth="1.8"
         strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function IconHeart({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M20.3 5.7a5.1 5.1 0 0 0-7.2 0L12 6.8l-1.1-1.1a5.1 5.1 0 1 0-7.2 7.2L12 21l8.3-8.1a5.1 5.1 0 0 0 0-7.2Z"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.8"
+      />
+    </svg>
+  );
+}
+
+function IconClock({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="8.5" stroke="currentColor" strokeWidth="1.8" />
+      <path
+        d="M12 7.5V12l3 2"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.8"
       />
     </svg>
   );

--- a/frontend/src/01_widgets/home-feed/ui/HomeFeedShell.tsx
+++ b/frontend/src/01_widgets/home-feed/ui/HomeFeedShell.tsx
@@ -2,13 +2,24 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useEffect, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { Header } from "@/widgets/chrome/ui";
+import type {
+  RecentPostCursorPage,
+  RecentPostSummary,
+} from "@/entities/post/api/getRecentPosts";
+import { assets } from "@/shared/config/assets";
 import { cn } from "@/shared/lib/cn";
+import { buildPublicPostPath } from "@/shared/lib/publicRoutes";
 import {
   feedPosts,
   followingPosts,
-  likedPosts,
   tabs,
   type FeedPost,
   type TabKey,
@@ -17,18 +28,60 @@ import {
 export function HomeFeedShell({
   activeTab,
   isLoggedIn,
+  initialHomePosts,
+  initialHomeNextCursor,
+  initialHomeHasNext,
+  initialLikedPosts,
+  initialLikedNextCursor,
+  initialLikedHasNext,
   profileImageUrl,
   profileHref,
   footer,
 }: {
   activeTab: TabKey;
   isLoggedIn: boolean;
+  initialHomePosts: RecentPostSummary[];
+  initialHomeNextCursor: string | null;
+  initialHomeHasNext: boolean;
+  initialLikedPosts: RecentPostSummary[];
+  initialLikedNextCursor: string | null;
+  initialLikedHasNext: boolean;
   profileImageUrl?: string | null;
   profileHref?: string;
   footer: ReactNode;
 }) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-  const posts = getPostsForTab(activeTab);
+  const [homePosts, setHomePosts] = useState<FeedPost[]>(() =>
+    initialHomePosts.map(toFeedPost),
+  );
+  const [likedFeedPosts, setLikedFeedPosts] = useState<FeedPost[]>(() =>
+    initialLikedPosts.map(toFeedPost),
+  );
+  const [homeNextCursor, setHomeNextCursor] = useState<string | null>(
+    initialHomeNextCursor,
+  );
+  const [likedNextCursor, setLikedNextCursor] = useState<string | null>(
+    initialLikedNextCursor,
+  );
+  const [hasNextHomePage, setHasNextHomePage] = useState(initialHomeHasNext);
+  const [hasNextLikedPage, setHasNextLikedPage] =
+    useState(initialLikedHasNext);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const isLoadingMoreRef = useRef(false);
+  const posts =
+    activeTab === "home"
+      ? homePosts
+      : activeTab === "liked"
+        ? likedFeedPosts
+        : getPostsForTab(activeTab);
+  const hasNextActivePage =
+    activeTab === "home"
+      ? hasNextHomePage
+      : activeTab === "liked"
+        ? hasNextLikedPage
+        : false;
 
   useEffect(() => {
     const query = window.matchMedia("(min-width: 1024px)");
@@ -44,6 +97,115 @@ export function HomeFeedShell({
       query.removeEventListener("change", syncSidebar);
     };
   }, []);
+
+  useEffect(() => {
+    if (!isSidebarOpen || window.matchMedia("(min-width: 1024px)").matches) {
+      return;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    const previousOverscrollBehaviorY = document.body.style.overscrollBehaviorY;
+    document.body.style.overflow = "hidden";
+    document.body.style.overscrollBehaviorY = "none";
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.body.style.overscrollBehaviorY = previousOverscrollBehaviorY;
+    };
+  }, [isSidebarOpen]);
+
+  useEffect(() => {
+    setHomePosts(initialHomePosts.map(toFeedPost));
+    setHomeNextCursor(initialHomeNextCursor);
+    setHasNextHomePage(initialHomeHasNext);
+    setLoadError(null);
+  }, [initialHomePosts, initialHomeNextCursor, initialHomeHasNext]);
+
+  useEffect(() => {
+    setLikedFeedPosts(initialLikedPosts.map(toFeedPost));
+    setLikedNextCursor(initialLikedNextCursor);
+    setHasNextLikedPage(initialLikedHasNext);
+    setLoadError(null);
+  }, [initialLikedPosts, initialLikedNextCursor, initialLikedHasNext]);
+
+  const loadMorePosts = useCallback(async () => {
+    const endpoint =
+      activeTab === "home"
+        ? "/api/posts"
+        : activeTab === "liked"
+          ? "/api/users/me/liked-posts"
+          : null;
+    const cursor = activeTab === "home" ? homeNextCursor : likedNextCursor;
+
+    if (!endpoint || !hasNextActivePage || !cursor || isLoadingMoreRef.current) {
+      return;
+    }
+
+    isLoadingMoreRef.current = true;
+    setIsLoadingMore(true);
+    setLoadError(null);
+
+    try {
+      const params = new URLSearchParams({
+        cursor,
+        size: "10",
+      });
+      const response = await fetch(`${endpoint}?${params}`);
+
+      if (!response.ok) {
+        throw new Error("Failed to load posts.");
+      }
+
+      const page = (await response.json()) as RecentPostCursorPage;
+
+      if (activeTab === "home") {
+        setHomePosts((current) => [
+          ...current,
+          ...page.posts.map(toFeedPost),
+        ]);
+        setHomeNextCursor(page.nextCursor);
+        setHasNextHomePage(page.hasNext);
+      } else {
+        setLikedFeedPosts((current) => [
+          ...current,
+          ...page.posts.map(toFeedPost),
+        ]);
+        setLikedNextCursor(page.nextCursor);
+        setHasNextLikedPage(page.hasNext);
+      }
+    } catch {
+      setLoadError("Could not load more posts.");
+    } finally {
+      isLoadingMoreRef.current = false;
+      setIsLoadingMore(false);
+    }
+  }, [activeTab, hasNextActivePage, homeNextCursor, likedNextCursor]);
+
+  useEffect(() => {
+    if ((activeTab !== "home" && activeTab !== "liked") || !hasNextActivePage) {
+      return;
+    }
+
+    const sentinel = sentinelRef.current;
+    if (!sentinel) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          void loadMorePosts();
+        }
+      },
+      { rootMargin: "360px 0px" },
+    );
+
+    observer.observe(sentinel);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [activeTab, hasNextActivePage, loadMorePosts]);
 
   return (
     <div className="flex min-h-dvh flex-col bg-white text-zinc-950">
@@ -98,6 +260,26 @@ export function HomeFeedShell({
                 <ArticleCard key={post.id} post={post} />
               ))}
             </div>
+
+            {activeTab === "home" || activeTab === "liked" ? (
+              <div
+                ref={sentinelRef}
+                className="flex min-h-24 items-center justify-center py-6 text-sm text-zinc-500"
+                aria-live="polite"
+              >
+                {isLoadingMore
+                  ? "Loading posts..."
+                  : loadError
+                    ? loadError
+                    : posts.length === 0
+                      ? activeTab === "liked" && !isLoggedIn
+                        ? "Log in to see liked posts."
+                        : "No posts yet."
+                      : hasNextActivePage
+                        ? ""
+                        : "No more posts."}
+              </div>
+            ) : null}
           </section>
         </main>
       </div>
@@ -120,7 +302,7 @@ function HomeSidebar({
     <aside
       aria-label="Feed navigation"
       className={cn(
-        "fixed bottom-0 left-0 top-16 z-40 w-[282px] border-r border-zinc-200/80 bg-white transition-transform duration-300 ease-out",
+        "fixed bottom-0 left-0 top-16 z-40 w-[282px] border-r border-t border-zinc-200/80 bg-white transition-transform duration-300 ease-out",
         isOpen ? "translate-x-0" : "-translate-x-full",
       )}
     >
@@ -171,20 +353,18 @@ function ArticleCard({ post }: { post: FeedPost }) {
         className="group grid gap-5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20 sm:grid-cols-[minmax(0,1fr)_184px] sm:items-center"
       >
         <div className="min-w-0">
-          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[13px] text-zinc-600">
-            <span className="grid size-6 place-items-center rounded-full bg-zinc-950 text-[11px] font-semibold text-white">
-              {post.author.charAt(0)}
-            </span>
-            {post.publication ? (
-              <>
-                <span>In {post.publication}</span>
-                <span className="text-zinc-300">by</span>
-              </>
-            ) : null}
-            <span className="font-medium text-zinc-800">{post.author}</span>
+          <div className="flex items-center gap-2 text-[13px] text-zinc-600">
+            <Image
+              src={post.profileImageSrc}
+              alt=""
+              width={24}
+              height={24}
+              className="size-6 rounded-full border border-zinc-200 object-cover"
+            />
+            <span className="font-medium text-zinc-800">{post.nickname}</span>
           </div>
 
-          <h2 className="mt-4 max-w-[680px] text-[24px] font-bold leading-[1.16] tracking-tight text-zinc-950 transition-colors group-hover:text-zinc-700 sm:text-[30px]">
+          <h2 className="mt-4 max-w-[680px] text-[24px] font-bold leading-[1.16] tracking-tight text-zinc-950 transition-colors group-hover:text-zinc-700 sm:text-[30px] [font-family:Georgia,serif]">
             {post.title}
           </h2>
 
@@ -204,36 +384,16 @@ function ArticleCard({ post }: { post: FeedPost }) {
         </div>
       </Link>
 
-      <div className="mt-5 flex items-center justify-between gap-4 text-[13px] text-zinc-500">
-        <div className="flex flex-wrap items-center gap-3">
-          <IconSparkle className="size-4 text-amber-500" />
-          <span>{post.dateLabel}</span>
-          <span className="inline-flex items-center gap-1.5">
-            <IconClap className="size-4" />
-            {post.readCount}
-          </span>
-          <span className="inline-flex items-center gap-1.5">
-            <IconComment className="size-4" />
-            {post.commentCount}
-          </span>
-        </div>
-
-        <div className="flex items-center gap-2 text-zinc-500">
-          <button
-            type="button"
-            aria-label={`Save ${post.title}`}
-            className="grid size-8 place-items-center rounded-full transition hover:bg-zinc-100 hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
-          >
-            <IconBookmark className="size-5" />
-          </button>
-          <button
-            type="button"
-            aria-label={`More actions for ${post.title}`}
-            className="grid size-8 place-items-center rounded-full transition hover:bg-zinc-100 hover:text-zinc-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20"
-          >
-            <IconDots className="size-5" />
-          </button>
-        </div>
+      <div className="mt-5 flex flex-wrap items-center gap-3 text-[13px] text-zinc-500">
+        <span>{post.dateLabel}</span>
+        <span className="inline-flex items-center gap-1.5">
+          <IconComment className="size-4" />
+          {post.commentCount}
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <IconHeart className="size-4" />
+          {post.likeCount}
+        </span>
       </div>
     </article>
   );
@@ -244,11 +404,36 @@ function getPostsForTab(tab: TabKey) {
     return followingPosts;
   }
 
-  if (tab === "liked") {
-    return likedPosts;
-  }
-
   return feedPosts;
+}
+
+const FEED_THUMBNAILS = [
+  "/feed/operational-notes.svg",
+  "/feed/review-cadence.svg",
+  "/feed/knowledge-graph.svg",
+  "/feed/quiet-interfaces.svg",
+] as const;
+
+function toFeedPost(post: RecentPostSummary): FeedPost {
+  return {
+    id: String(post.id),
+    nickname: post.authorName,
+    profileImageSrc: post.authorAvatarSrc || assets.defaultAvatar,
+    title: post.title,
+    description: post.description,
+    dateLabel: post.publishedAtLabel,
+    commentCount: formatCompactCount(post.comments),
+    likeCount: formatCompactCount(post.likes),
+    thumbnailSrc: FEED_THUMBNAILS[post.id % FEED_THUMBNAILS.length],
+    href: buildPublicPostPath(post.authorUsername, post.slug),
+  };
+}
+
+function formatCompactCount(value: number) {
+  return new Intl.NumberFormat("en", {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value);
 }
 
 function getTabHref(tab: TabKey) {
@@ -330,25 +515,6 @@ function IconClock({ className }: { className?: string }) {
   );
 }
 
-function IconClap({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      className={className}
-      aria-hidden="true"
-    >
-      <path
-        d="M7.5 11.5 5.8 8.1a1.4 1.4 0 0 1 2.5-1.25l1.85 3.7M10.2 10.6 7.9 5.8a1.45 1.45 0 0 1 2.6-1.25l2.55 5.35M13 10.2l-1.8-3.8a1.45 1.45 0 0 1 2.62-1.25L17.6 13M17.6 13l.95-2.65a1.35 1.35 0 0 1 2.6.68c-.9 5.5-3.3 8.15-7.25 8.15H12c-2.9 0-5.35-1.65-6.55-4.3l-1.2-2.65a1.45 1.45 0 0 1 2.6-1.28l1.15 2.1"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
 function IconComment({ className }: { className?: string }) {
   return (
     <svg
@@ -362,55 +528,6 @@ function IconComment({ className }: { className?: string }) {
         stroke="currentColor"
         strokeWidth="1.7"
         strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function IconSparkle({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="currentColor"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="M12 2.75 14.42 9.58 21.25 12l-6.83 2.42L12 21.25l-2.42-6.83L2.75 12l6.83-2.42L12 2.75Z" />
-    </svg>
-  );
-}
-
-function IconBookmark({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      className={className}
-      aria-hidden="true"
-    >
-      <path
-        d="M6.5 4.5A1.5 1.5 0 0 1 8 3h8a1.5 1.5 0 0 1 1.5 1.5V21L12 17.5 6.5 21V4.5Z"
-        stroke="currentColor"
-        strokeWidth="1.7"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function IconDots({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      className={className}
-      aria-hidden="true"
-    >
-      <path
-        d="M6.5 12h.01M12 12h.01M17.5 12h.01"
-        stroke="currentColor"
-        strokeWidth="3"
-        strokeLinecap="round"
       />
     </svg>
   );

--- a/frontend/src/01_widgets/home-feed/ui/data.ts
+++ b/frontend/src/01_widgets/home-feed/ui/data.ts
@@ -1,16 +1,83 @@
 import { assets } from "@/shared/config/assets";
 
-export type TabKey = "trending" | "latest" | "following";
+export type TabKey = "home" | "following";
+
+export type FeedPost = {
+  id: string;
+  author: string;
+  publication?: string;
+  title: string;
+  description: string;
+  dateLabel: string;
+  readCount: string;
+  commentCount: string;
+  thumbnailSrc: string;
+  href: string;
+};
 
 export const tabs: Array<{
   key: TabKey;
   label: string;
-  iconSrc: string;
 }> = [
-  { key: "trending", label: "Trending", iconSrc: "/TrendingUp.svg" },
-  { key: "latest", label: "Latest", iconSrc: "/BookOpen.svg" },
-  { key: "following", label: "Following", iconSrc: "/Users.svg" },
+  { key: "home", label: "Home" },
+  { key: "following", label: "Following" },
 ];
+
+export const feedPosts: FeedPost[] = [
+  {
+    id: "operational-notes",
+    author: "Mina Park",
+    publication: "OpenLog Engineering",
+    title: "Operational Notes That Survive the Sprint",
+    description:
+      "A practical way to turn short-lived implementation details into durable context for the next person reading the system.",
+    dateLabel: "May 2",
+    readCount: "1.8K",
+    commentCount: "24",
+    thumbnailSrc: "/feed/operational-notes.svg",
+    href: "/@minapark/posts/operational-notes",
+  },
+  {
+    id: "review-cadence",
+    author: "Jinwoo Lee",
+    publication: "Product Systems",
+    title: "The Review Cadence That Keeps Product Debt Visible",
+    description:
+      "Most teams only notice product debt when it blocks release. A lightweight weekly ritual makes the tradeoffs visible earlier.",
+    dateLabel: "Apr 29",
+    readCount: "892",
+    commentCount: "11",
+    thumbnailSrc: "/feed/review-cadence.svg",
+    href: "/@jinwoolee/posts/review-cadence",
+  },
+  {
+    id: "knowledge-graph",
+    author: "Hannah Kim",
+    title: "Designing a Knowledge Graph People Actually Use",
+    description:
+      "The useful graph is not the densest one. It is the one that connects decisions, owners, and follow-up work without ceremony.",
+    dateLabel: "Apr 24",
+    readCount: "3.4K",
+    commentCount: "37",
+    thumbnailSrc: "/feed/knowledge-graph.svg",
+    href: "/@hannahkim/posts/knowledge-graph",
+  },
+  {
+    id: "quiet-interfaces",
+    author: "Alex Cho",
+    publication: "Interface Notes",
+    title: "Quiet Interfaces for Repeated Work",
+    description:
+      "A look at dense, predictable screens that respect operators by staying out of the way after the first week.",
+    dateLabel: "Apr 18",
+    readCount: "756",
+    commentCount: "8",
+    thumbnailSrc: "/feed/quiet-interfaces.svg",
+    href: "/@alexcho/posts/quiet-interfaces",
+  },
+];
+
+export const followingPosts: FeedPost[] = feedPosts.slice(1, 4);
 
 export const recommendedTopics = [
   "React",
@@ -29,13 +96,13 @@ export const topContributors = [
     avatar: assets.avatarA,
   },
   {
-    name: "Dan Abramov",
-    summary: "Merged 42 PRs this week",
+    name: "Sarah Drasner",
+    summary: "Published 8 architecture notes",
     avatar: assets.avatarB,
   },
   {
-    name: "Dan Abramov",
-    summary: "Merged 42 PRs this week",
+    name: "Kent C. Dodds",
+    summary: "Reviewed 15 implementation logs",
     avatar: assets.avatarA,
   },
 ] as const;

--- a/frontend/src/01_widgets/home-feed/ui/data.ts
+++ b/frontend/src/01_widgets/home-feed/ui/data.ts
@@ -1,6 +1,6 @@
 import { assets } from "@/shared/config/assets";
 
-export type TabKey = "home" | "following";
+export type TabKey = "home" | "following" | "liked";
 
 export type FeedPost = {
   id: string;
@@ -21,6 +21,7 @@ export const tabs: Array<{
 }> = [
   { key: "home", label: "Home" },
   { key: "following", label: "Following" },
+  { key: "liked", label: "Liked" },
 ];
 
 export const feedPosts: FeedPost[] = [
@@ -78,6 +79,8 @@ export const feedPosts: FeedPost[] = [
 ];
 
 export const followingPosts: FeedPost[] = feedPosts.slice(1, 4);
+
+export const likedPosts: FeedPost[] = [feedPosts[0], feedPosts[2]];
 
 export const recommendedTopics = [
   "React",

--- a/frontend/src/01_widgets/home-feed/ui/data.ts
+++ b/frontend/src/01_widgets/home-feed/ui/data.ts
@@ -4,13 +4,13 @@ export type TabKey = "home" | "following" | "liked";
 
 export type FeedPost = {
   id: string;
-  author: string;
-  publication?: string;
+  nickname: string;
+  profileImageSrc: string;
   title: string;
   description: string;
   dateLabel: string;
-  readCount: string;
   commentCount: string;
+  likeCount: string;
   thumbnailSrc: string;
   href: string;
 };
@@ -27,52 +27,53 @@ export const tabs: Array<{
 export const feedPosts: FeedPost[] = [
   {
     id: "operational-notes",
-    author: "Mina Park",
-    publication: "OpenLog Engineering",
+    nickname: "Mina Park",
+    profileImageSrc: assets.avatarA,
     title: "Operational Notes That Survive the Sprint",
     description:
       "A practical way to turn short-lived implementation details into durable context for the next person reading the system.",
     dateLabel: "May 2",
-    readCount: "1.8K",
     commentCount: "24",
+    likeCount: "1.8K",
     thumbnailSrc: "/feed/operational-notes.svg",
     href: "/@minapark/posts/operational-notes",
   },
   {
     id: "review-cadence",
-    author: "Jinwoo Lee",
-    publication: "Product Systems",
+    nickname: "Jinwoo Lee",
+    profileImageSrc: assets.avatarB,
     title: "The Review Cadence That Keeps Product Debt Visible",
     description:
       "Most teams only notice product debt when it blocks release. A lightweight weekly ritual makes the tradeoffs visible earlier.",
     dateLabel: "Apr 29",
-    readCount: "892",
     commentCount: "11",
+    likeCount: "892",
     thumbnailSrc: "/feed/review-cadence.svg",
     href: "/@jinwoolee/posts/review-cadence",
   },
   {
     id: "knowledge-graph",
-    author: "Hannah Kim",
+    nickname: "Hannah Kim",
+    profileImageSrc: assets.defaultAvatar,
     title: "Designing a Knowledge Graph People Actually Use",
     description:
       "The useful graph is not the densest one. It is the one that connects decisions, owners, and follow-up work without ceremony.",
     dateLabel: "Apr 24",
-    readCount: "3.4K",
     commentCount: "37",
+    likeCount: "3.4K",
     thumbnailSrc: "/feed/knowledge-graph.svg",
     href: "/@hannahkim/posts/knowledge-graph",
   },
   {
     id: "quiet-interfaces",
-    author: "Alex Cho",
-    publication: "Interface Notes",
+    nickname: "Alex Cho",
+    profileImageSrc: assets.avatarA,
     title: "Quiet Interfaces for Repeated Work",
     description:
       "A look at dense, predictable screens that respect operators by staying out of the way after the first week.",
     dateLabel: "Apr 18",
-    readCount: "756",
     commentCount: "8",
+    likeCount: "756",
     thumbnailSrc: "/feed/quiet-interfaces.svg",
     href: "/@alexcho/posts/quiet-interfaces",
   },

--- a/frontend/src/01_widgets/profile/ui/AuthoredPostsSection.tsx
+++ b/frontend/src/01_widgets/profile/ui/AuthoredPostsSection.tsx
@@ -419,7 +419,8 @@ function SecondBrainGraph({
     }
 
     const moved =
-      Math.abs(point.x - drag.startX) > 2 || Math.abs(point.y - drag.startY) > 2;
+      Math.abs(point.x - drag.startX) > 2 ||
+      Math.abs(point.y - drag.startY) > 2;
     drag.moved = drag.moved || moved;
     lastDragMovedRef.current = drag.moved;
     moveDraggedNode(drag.slug, point.x, point.y, false);
@@ -513,99 +514,92 @@ function SecondBrainGraph({
           onPointerUp={handlePointerUp}
           onPointerCancel={handlePointerUp}
         >
-        <g transform={`translate(${transform.x} ${transform.y}) scale(${transform.scale})`}>
-          {graph.edges.map((edge, index) => {
-            const source = nodeStatesBySlug.get(edge.sourceSlug);
-            const target = nodeStatesBySlug.get(edge.targetSlug);
-            if (!source || !target) {
-              return null;
-            }
+          <g
+            transform={`translate(${transform.x} ${transform.y}) scale(${transform.scale})`}
+          >
+            {graph.edges.map((edge, index) => {
+              const source = nodeStatesBySlug.get(edge.sourceSlug);
+              const target = nodeStatesBySlug.get(edge.targetSlug);
+              if (!source || !target) {
+                return null;
+              }
 
-            const active =
-              !activeSlug ||
-              edge.sourceSlug === activeSlug ||
-              edge.targetSlug === activeSlug;
+              const active =
+                !activeSlug ||
+                edge.sourceSlug === activeSlug ||
+                edge.targetSlug === activeSlug;
 
-            return (
-              <line
-                key={`${edge.sourceSlug}-${edge.targetSlug}-${edge.label}-${index}`}
-                x1={source.x}
-                y1={source.y}
-                x2={target.x}
-                y2={target.y}
-                className="transition"
-                stroke={active ? "#52525b" : "#d4d4d8"}
-                strokeWidth={active ? 0.85 : 0.5}
-                strokeLinecap="round"
-                opacity={active ? 0.48 : 0.34}
-              />
-            );
-          })}
+              return (
+                <line
+                  key={`${edge.sourceSlug}-${edge.targetSlug}-${edge.label}-${index}`}
+                  x1={source.x}
+                  y1={source.y}
+                  x2={target.x}
+                  y2={target.y}
+                  className="transition"
+                  stroke={active ? "#52525b" : "#d4d4d8"}
+                  strokeWidth={active ? 0.85 : 0.5}
+                  strokeLinecap="round"
+                  opacity={active ? 0.48 : 0.34}
+                />
+              );
+            })}
 
-          {nodeStates.map((node) => {
-            const active =
-              !activeSlug ||
-              activeSlug === node.slug ||
-              connectedSlugs?.has(node.slug);
-            const href = buildPublicPostPath(username, node.slug);
+            {nodeStates.map((node) => {
+              const active =
+                !activeSlug ||
+                activeSlug === node.slug ||
+                connectedSlugs?.has(node.slug);
+              const href = buildPublicPostPath(username, node.slug);
 
-            return (
-              <g
-                key={node.slug}
-                role="link"
-                tabIndex={0}
-                aria-label={`Open ${node.title}`}
-                onPointerDown={(event) =>
-                  handleNodePointerDown(event, node.slug)
-                }
-                onPointerMove={handleNodePointerMove}
-                onPointerUp={handleNodePointerUp}
-                onPointerCancel={handleNodePointerUp}
-                onClick={(event) => handleNodeClick(event, href)}
-                onKeyDown={(event) => handleNodeKeyDown(event, href)}
-                onMouseEnter={() => setActiveSlug(node.slug)}
-                onMouseLeave={() => setActiveSlug(null)}
-                onFocus={() => setActiveSlug(node.slug)}
-                onBlur={() => setActiveSlug(null)}
-                className="cursor-pointer outline-none"
-              >
-                <g className="transition">
-                  <circle
-                    cx={node.x}
-                    cy={node.y}
-                    r={18}
-                    fill="transparent"
-                  />
-                  <circle
-                    cx={node.x}
-                    cy={node.y}
-                    r={activeSlug === node.slug ? 7.5 : 5.6}
-                    fill={activeSlug === node.slug ? "#18181b" : "#a1a1aa"}
-                    opacity={active ? 0.96 : 0.56}
-                    className="transition"
-                  />
-                  {showLabels ? (
-                    <text
-                      x={node.x}
-                      y={node.y + 20}
-                      textAnchor="middle"
-                      paintOrder="stroke"
-                      stroke="#ffffff"
-                      strokeWidth={4}
-                      strokeLinejoin="round"
-                      className={cn(
-                        "pointer-events-none text-[10px] font-medium transition",
-                        active ? "fill-zinc-800" : "fill-zinc-500",
-                      )}
-                    >
-                      {truncateNodeTitle(node.title)}
-                    </text>
-                  ) : null}
+              return (
+                <g
+                  key={node.slug}
+                  role="link"
+                  tabIndex={0}
+                  aria-label={`Open ${node.title}`}
+                  onPointerDown={(event) =>
+                    handleNodePointerDown(event, node.slug)
+                  }
+                  onPointerMove={handleNodePointerMove}
+                  onPointerUp={handleNodePointerUp}
+                  onPointerCancel={handleNodePointerUp}
+                  onClick={(event) => handleNodeClick(event, href)}
+                  onKeyDown={(event) => handleNodeKeyDown(event, href)}
+                  onMouseEnter={() => setActiveSlug(node.slug)}
+                  onMouseLeave={() => setActiveSlug(null)}
+                  onFocus={() => setActiveSlug(node.slug)}
+                  onBlur={() => setActiveSlug(null)}
+                  className="cursor-pointer outline-none"
+                >
+                  <g className="transition">
+                    <circle cx={node.x} cy={node.y} r={18} fill="transparent" />
+                    <circle
+                      cx={node.x}
+                      cy={node.y}
+                      r={activeSlug === node.slug ? 7.5 : 5.6}
+                      fill={activeSlug === node.slug ? "#18181b" : "#a1a1aa"}
+                      opacity={active ? 0.96 : 0.56}
+                      className="transition"
+                    />
+                    {showLabels ? (
+                      <text
+                        x={node.x}
+                        y={node.y + 20}
+                        textAnchor="middle"
+                        className={cn(
+                          "pointer-events-none text-[10px] font-medium transition",
+                          active ? "fill-zinc-800" : "fill-zinc-500",
+                        )}
+                      >
+                        {truncateNodeTitle(node.title)}
+                      </text>
+                    ) : null}
+                  </g>
                 </g>
-              </g>
-            );
-          })}
-        </g>
+              );
+            })}
+          </g>
         </svg>
       </div>
     </div>

--- a/frontend/src/01_widgets/write/ui/WriteView.tsx
+++ b/frontend/src/01_widgets/write/ui/WriteView.tsx
@@ -80,7 +80,7 @@ export function WriteView({
   authoredPosts = [],
   initialWikiLinks = [],
   draftStorageKey = DRAFT_STORAGE_KEY,
-  backHref = "/?tab=trending",
+  backHref = "/",
   backLabel = "Back to feed",
   submitLabel = "Publish",
   pendingSubmitLabel = "Publishing...",
@@ -138,7 +138,10 @@ export function WriteView({
   const deferredTopics = useDeferredValue(topics);
   const deferredBody = useDeferredValue(body);
   const activeWikiLinks = getActiveWikiLinks(body, wikiLinks);
-  const wikiCandidates = getWikiCandidates(authoredPosts, wikiMenu?.query ?? "");
+  const wikiCandidates = getWikiCandidates(
+    authoredPosts,
+    wikiMenu?.query ?? "",
+  );
   const activeWikiCandidateIndex =
     wikiCandidates.length === 0
       ? 0
@@ -181,7 +184,7 @@ export function WriteView({
     }
 
     const updatedAt = new Date().toISOString();
-      window.localStorage.setItem(
+    window.localStorage.setItem(
       draftStorageKey,
       JSON.stringify({
         title,
@@ -367,7 +370,8 @@ export function WriteView({
     const menuHeight = 244;
     const menuWidth = 320;
     const textareaRect = textarea.getBoundingClientRect();
-    const spaceBelow = window.innerHeight - (textareaRect.top + caret.top + caret.height);
+    const spaceBelow =
+      window.innerHeight - (textareaRect.top + caret.top + caret.height);
     const placement: WikiMenuPlacement =
       spaceBelow < menuHeight + 24 && caret.top > menuHeight ? "top" : "bottom";
 
@@ -726,7 +730,10 @@ export function WriteView({
                       name="content"
                       value={body}
                       onChange={(event) =>
-                        handleBodyChange(event.target.value, event.currentTarget)
+                        handleBodyChange(
+                          event.target.value,
+                          event.currentTarget,
+                        )
                       }
                       onClick={(event) => syncWikiMenu(event.currentTarget)}
                       onKeyDown={handleEditorKeyDown}

--- a/frontend/src/03_entities/post/api/getLikedPosts.ts
+++ b/frontend/src/03_entities/post/api/getLikedPosts.ts
@@ -1,0 +1,24 @@
+import { headers } from "next/headers";
+import { API_CONFIG } from "@/shared/api";
+import { apiClient } from "@/shared/api/apiClient";
+import type { RecentPostCursorPage } from "./getRecentPosts";
+
+export async function getLikedPosts(cursor?: string | null, size = 10) {
+  const headerStore = await headers();
+  const params = new URLSearchParams({
+    size: String(size),
+  });
+  if (cursor) {
+    params.set("cursor", cursor);
+  }
+
+  return apiClient<RecentPostCursorPage>(
+    `${API_CONFIG.baseURL}/users/me/liked-posts?${params}`,
+    {
+      cache: "no-store",
+      headers: {
+        cookie: headerStore.get("cookie") ?? "",
+      },
+    },
+  );
+}

--- a/frontend/src/03_entities/post/api/getRecentPosts.ts
+++ b/frontend/src/03_entities/post/api/getRecentPosts.ts
@@ -1,0 +1,38 @@
+import { API_CONFIG } from "@/shared/api";
+import { apiClient } from "@/shared/api/apiClient";
+
+export type RecentPostSummary = {
+  id: number;
+  slug: string;
+  title: string;
+  description: string;
+  publishedAtLabel: string;
+  authorUsername: string;
+  authorName: string;
+  authorAvatarSrc: string | null;
+  likes: number;
+  comments: number;
+};
+
+export type RecentPostCursorPage = {
+  posts: RecentPostSummary[];
+  size: number;
+  nextCursor: string | null;
+  hasNext: boolean;
+};
+
+export function getRecentPosts(cursor?: string | null, size = 10) {
+  const params = new URLSearchParams({
+    size: String(size),
+  });
+  if (cursor) {
+    params.set("cursor", cursor);
+  }
+
+  return apiClient<RecentPostCursorPage>(
+    `${API_CONFIG.baseURL}/posts?${params}`,
+    {
+      cache: "no-store",
+    },
+  );
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #

---

## 1. PR 유형
- [x] 🐛 버그 수정 (Bug Fix)
- [x] ✨ 새로운 기능 (New Feature)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 업데이트 (Documentation)
- [ ] ⚙️ 설정/빌드 변경 (Chore)

---

## 2. 작업 배경 및 목적
- **기존 상태:** 메인 페이지는 정적 목 데이터 기반 피드와 기본 헤더/탭 UI만 제공했다. 백엔드의 `GET /posts`는 최신 포스트 목록을 반환하지 않았고, 사용자가 좋아요한 포스트 목록을 조회하는 인증 API도 없었다.
- **문제점:** 사용자는 실제 작성된 최신 포스트를 메인 피드에서 이어서 탐색할 수 없었다. `Liked` 탭도 실제 사용자 좋아요 데이터와 연결되지 않았고, 스크롤 경계에서 사이드바와 헤더가 서로 다른 스크롤 기준으로 렌더링되어 사이드바가 헤더 영역을 침범할 수 있었다.
- **해결 목표:** 최신 포스트와 사용자가 좋아요한 포스트를 각각 10개 단위 커서 페이지로 조회한다. 프론트엔드는 홈/좋아요 탭에서 초기 데이터를 서버 렌더링하고, 스크롤 하단 진입 시 같은 커서로 다음 페이지를 요청한다. 사이드바는 헤더 아래 고정 위치를 유지하고 모바일 드로어가 열린 동안 문서 overscroll을 차단한다.

---

## 3. 상세 변경 내역 및 동작 흐름

### A. 최신 포스트 커서 페이지 API 추가
- **진입점 및 초기 조건:** 클라이언트가 `GET /posts?size=10` 또는 `GET /posts?size=10&cursor={nextCursor}`를 호출한다. 첫 요청은 `cursor`가 없고, 후속 요청은 이전 응답의 `nextCursor`를 전달한다.
- **단계별 제어 흐름:**
  1. `PostController.getRecentPosts()`가 `cursor`, `size`를 명시적으로 받아 `PostService.getRecentPosts(cursor, size)`를 호출한다.
  2. 서비스는 `size`를 1~10 범위로 보정하고, `cursor`가 없으면 `createdAt desc, id desc` 기준으로 `size + 1`개를 조회한다.
  3. `cursor`가 있으면 `DateTimeIdCursorCodec.decode()`로 `createdAt`, `id`를 복원하고, 해당 기준보다 뒤에 있는 포스트만 조회한다.
  4. 조회 결과가 `size`보다 많으면 `hasNext=true`로 판단하고, 반환할 마지막 포스트의 `createdAt`, `id`로 `nextCursor`를 생성한다.
- **데이터 상태 변이:** DB 상태는 변경하지 않는다. 응답 DTO에 포스트 목록, 보정된 `size`, `nextCursor`, `hasNext`가 포함된다.
- **최종 반환 및 종료 상태:** 클라이언트는 최신순 포스트 10개와 다음 페이지 조회에 필요한 URL-safe Base64 커서를 받는다.

### B. 좋아요한 포스트 커서 페이지 API 추가
- **진입점 및 초기 조건:** 로그인 사용자가 `GET /users/me/liked-posts?size=10` 또는 `GET /users/me/liked-posts?size=10&cursor={nextCursor}`를 호출한다. 요청에는 인증 쿠키가 포함되어야 한다.
- **단계별 제어 흐름:**
  1. `UserController.getLikedPosts()`가 `CurrentUserResolver`로 현재 사용자를 확인한다.
  2. `UserService.getLikedPosts(userId, cursor, size)`가 `post_likes.created_at desc, post_likes.id desc` 기준으로 좋아요 목록을 조회한다.
  3. 첫 페이지는 사용자 id만으로 조회하고, 후속 페이지는 `likedAt|postLikeId` 커서를 복원해 해당 커서 이후의 좋아요 행만 조회한다.
  4. 각 `PostLike`의 `post`, `post.author`를 fetch join으로 가져오고, 포스트별 좋아요/댓글 수를 bulk count 쿼리로 보강한다.
- **데이터 상태 변이:** DB 상태는 변경하지 않는다. 커서는 좋아요 행의 생성 시각과 id를 기준으로 생성되므로 사용자가 좋아요한 순서를 안정적으로 유지한다.
- **최종 반환 및 종료 상태:** 로그인 사용자는 본인이 좋아요한 포스트 목록을 10개 단위로 이어서 받을 수 있다. 인증 실패 시 기존 전역 예외 처리에 따라 401 응답이 반환된다.

### C. 공용 커서 codec 분리
- **진입점 및 초기 조건:** 최신 포스트와 좋아요 포스트가 모두 `LocalDateTime + id` 형태의 커서를 사용한다.
- **단계별 제어 흐름:**
  1. `DateTimeIdCursorCodec.encode(createdAt, id)`가 `createdAt|id` 원문을 URL-safe Base64 without padding 형식으로 인코딩한다.
  2. `DateTimeIdCursorCodec.decode(cursor)`가 Base64 문자열을 복원하고 `|` 구분자, 날짜 파싱, id 파싱을 검증한다.
  3. 잘못된 커서는 `BadRequestException("유효하지 않은 커서입니다.")`를 발생시킨다.
- **데이터 상태 변이:** 서비스별 중복 encode/decode 함수와 cursor data class를 제거하고 공통 커서 타입을 사용한다.
- **최종 반환 및 종료 상태:** 최신 포스트와 좋아요 포스트 페이지네이션이 같은 커서 파싱 규칙을 공유한다.

### D. 메인 피드 UI 및 탭 데이터 연결
- **진입점 및 초기 조건:** 사용자가 `/`에 접근하고, 쿼리 파라미터 `tab` 값이 없거나 `home`, `following`, `liked` 중 하나이다.
- **단계별 제어 흐름:**
  1. `app/page.tsx`가 `tab` 값을 정규화해 `HomeFeed`에 전달한다.
  2. `HomeFeed`는 로그인 사용자 상태를 확인하고, 홈 탭이면 최신 포스트 첫 페이지를 서버에서 조회한다.
  3. `Liked` 탭이고 로그인 상태이면 `getLikedPosts(null, 10)`으로 좋아요한 포스트 첫 페이지를 조회한다.
  4. `HomeFeedShell`은 탭별 초기 데이터, `nextCursor`, `hasNext`를 상태로 보관한다.
  5. `IntersectionObserver`가 하단 sentinel 진입을 감지하면 현재 탭에 맞는 Next 프록시 API(`/api/posts`, `/api/users/me/liked-posts`)를 호출하고 응답 포스트를 append한다.
- **데이터 상태 변이:** 클라이언트 상태에는 탭별 포스트 배열과 다음 커서가 누적된다. 서버 데이터는 변경하지 않는다.
- **최종 반환 및 종료 상태:** 홈 탭은 최신 포스트를, 좋아요 탭은 로그인 사용자의 좋아요 포스트를 실제 API 기반으로 무한 스크롤한다.

### E. 홈 레이아웃, 헤더, 사이드바 동작 보정
- **진입점 및 초기 조건:** 사용자가 메인 페이지에서 사이드바를 열거나 스크롤 경계에서 위/아래로 당긴다.
- **단계별 제어 흐름:**
  1. `Header`는 사이드바 토글 버튼과 로그인 사용자 액션을 포함한다.
  2. `HomeFeedShell`은 뷰포트 폭이 1024px 이상이면 사이드바를 기본 열림 상태로 동기화한다.
  3. 모바일에서 사이드바가 열린 동안 `body.style.overflow = "hidden"`과 `overscrollBehaviorY = "none"`을 적용한다.
  4. 전역 `html, body`에도 `overscroll-behavior-y: none`을 적용해 스크롤 경계 rubber-band가 고정 레이어를 밀지 않게 한다.
- **데이터 상태 변이:** UI 상태는 사이드바 열림 여부와 로딩 상태만 변경한다.
- **최종 반환 및 종료 상태:** 사이드바는 헤더 아래 `top-16` 위치를 유지하고, 모바일 드로어 상태에서는 문서 스크롤이 잠긴다.

---

## 4. 스크린샷 (선택)
- 없음

## 5. 테스트 및 검증 방법
- **테스트 환경:** macOS 로컬 환경, Spring Boot backend, Next.js frontend, Playwright Chromium
- **입력 시나리오:**
  1. `GET /posts?size=10` 첫 페이지 요청
  2. `GET /posts?size=10&cursor={nextCursor}` 후속 페이지 요청
  3. 로그인 쿠키 전달 상태에서 `GET /users/me/liked-posts?size=10` 요청
  4. `Liked` 탭 진입 후 하단 sentinel 진입
  5. 모바일/데스크톱에서 사이드바 열린 상태로 최상단 위쪽 wheel, 최하단 아래쪽 wheel 입력
- **출력 검증:**
  - `./gradlew :backend:compileKotlin`
  - `./gradlew :backend:test`
  - `npx tsc --noEmit`
  - `npm run lint`
  - `npm run build`
  - Playwright Chromium에서 모바일/데스크톱 사이드바 좌표 확인
  - frontend lint는 통과했지만 기존 파일 `frontend/src/01_widgets/onboarding/ui/OnboardingView.tsx`의 unused `Image` warning은 남아 있다.

---

## 6. 리뷰어 참고 사항 (선택)
- **특이 구현 사항:** 커서는 암호화가 아니라 URL-safe Base64 인코딩이다. 원문은 `createdAt|id`이며, 최신 포스트는 `posts.created_at/id`, 좋아요 포스트는 `post_likes.created_at/id`를 기준으로 한다.
- **파급 효과:** `Liked` 탭은 로그인 사용자 전용 API를 사용한다. 비로그인 상태에서는 초기 좋아요 목록을 조회하지 않고 빈 상태 문구를 표시한다.

---

## 7. 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일 가이드를 준수합니다.
- [x] 변경 사항에 대한 테스트 코드를 작성하거나 통과했습니다.
- [ ] 관련된 문서(README, API 명세 등)를 업데이트했습니다.
