### PR TITLE
[Feat] 마크다운 옵시디언 문법 추가

### DIFF
--- a/frontend/src/04_shared/ui/markdown/MarkdownContent.tsx
+++ b/frontend/src/04_shared/ui/markdown/MarkdownContent.tsx
@@ -4,12 +4,35 @@ import { highlightCodeBlock } from "@/shared/lib/markdown/highlightCode";
 import { MarkdownCodeBlock } from "./MarkdownCodeBlock";
 
 type MarkdownBlock =
-  | { type: "heading"; level: 1 | 2 | 3; text: string }
+  | { type: "heading"; level: HeadingLevel; text: string }
   | { type: "paragraph"; lines: string[] }
   | { type: "quote"; lines: string[] }
   | { type: "unordered-list"; items: string[] }
   | { type: "ordered-list"; items: string[] }
   | { type: "code"; language: string; code: string };
+
+type HeadingLevel = 1 | 2 | 3 | 4 | 5;
+type HeadingTag = `h${HeadingLevel}`;
+
+const headingClassNamesByVariant: Record<
+  "default" | "compact",
+  Record<HeadingLevel, string>
+> = {
+  default: {
+    1: "text-[32px]",
+    2: "text-[28px]",
+    3: "text-[24px]",
+    4: "text-[20px]",
+    5: "text-[16px]",
+  },
+  compact: {
+    1: "text-[24px]",
+    2: "text-[22px]",
+    3: "text-[20px]",
+    4: "text-[18px]",
+    5: "text-[16px]",
+  },
+};
 
 export function MarkdownContent({
   markdown,
@@ -44,29 +67,18 @@ export function MarkdownContent({
 
         switch (block.type) {
           case "heading": {
-            const className =
-              variant === "default"
-                ? block.level === 1
-                  ? "text-[32px]"
-                  : block.level === 2
-                    ? "text-[26px]"
-                    : "text-[20px]"
-                : block.level === 1
-                  ? "text-[24px]"
-                  : block.level === 2
-                    ? "text-[20px]"
-                    : "text-[18px]";
+            const HeadingTag = `h${block.level}` as HeadingTag;
 
             return (
-              <h3
+              <HeadingTag
                 key={key}
                 className={cn(
-                  "[font-family:Georgia,serif] font-bold leading-tight tracking-[-0.03em] text-zinc-950",
-                  className,
+                  "[font-family:Georgia,serif] font-bold leading-tight text-zinc-950",
+                  headingClassNamesByVariant[variant][block.level],
                 )}
               >
                 {renderInlineContent(block.text, key, wikiLinksByLabel)}
-              </h3>
+              </HeadingTag>
             );
           }
           case "paragraph":
@@ -181,11 +193,11 @@ function parseMarkdown(markdown: string): MarkdownBlock[] {
       continue;
     }
 
-    const headingMatch = line.match(/^(#{1,3})\s+(.+)$/);
+    const headingMatch = line.match(/^(#{1,5})\s+(.+)$/);
     if (headingMatch) {
       blocks.push({
         type: "heading",
-        level: headingMatch[1].length as 1 | 2 | 3,
+        level: headingMatch[1].length as HeadingLevel,
         text: headingMatch[2],
       });
       index += 1;
@@ -208,7 +220,7 @@ function parseMarkdown(markdown: string): MarkdownBlock[] {
       const items: string[] = [];
 
       while (index < lines.length && isUnorderedListLine(lines[index])) {
-        items.push(lines[index].replace(/^[-*]\s+/, ""));
+        items.push(lines[index].replace(/^[-*+]\s+/, ""));
         index += 1;
       }
 
@@ -371,7 +383,7 @@ function renderInlineLines(
 function isStructuredMarkdownLine(line: string) {
   return (
     line.startsWith("```") ||
-    /^#{1,3}\s+/.test(line) ||
+    /^#{1,5}\s+/.test(line) ||
     line.startsWith(">") ||
     isUnorderedListLine(line) ||
     isOrderedListLine(line)
@@ -379,7 +391,7 @@ function isStructuredMarkdownLine(line: string) {
 }
 
 function isUnorderedListLine(line: string) {
-  return /^[-*]\s+/.test(line);
+  return /^[-*+]\s+/.test(line);
 }
 
 function isOrderedListLine(line: string) {


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #

---

## 1. PR 유형
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ✨ 새로운 기능 (New Feature)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 업데이트 (Documentation)
- [ ] ⚙️ 설정/빌드 변경 (Chore)

---

## 2. 작업 배경 및 목적
- **기존 상태:** 마크다운 렌더러는 제목 문법을 `#`부터 `###`까지만 파싱했고, 순서 없는 목록은 `- `와 `* ` 접두어만 인식했다.
- **문제점:** 사용자가 `####`, `#####` 제목을 작성해도 제목 블록으로 렌더링되지 않았다. 표준 마크다운 불릿 문법 중 하나인 `+ `도 목록으로 처리되지 않았다.
- **해결 목표:** 제목 문법을 5단계까지 지원하고, `+ ` 접두어도 기존 unordered list와 동일하게 렌더링한다.

---

## 3. 상세 변경 내역 및 동작 흐름

### A. 제목 마크다운 5단계 지원
- **진입점 및 초기 조건:** `MarkdownContent`가 작성 글, 댓글, 제안 본문의 마크다운 문자열을 렌더링한다.
- **단계별 제어 흐름:**
  1. `parseMarkdown()`이 제목 정규식을 `#{1,5}`까지 허용한다.
  2. 파싱된 `#` 개수를 `HeadingLevel` 타입으로 저장한다.
  3. 렌더링 시 `h1`부터 `h5`까지 동적 태그를 선택하고, variant별 제목 크기 테이블에서 className을 조회한다.
- **데이터 상태 변이:** 마크다운 원문은 변경하지 않고, 파싱된 heading block의 `level` 범위만 1~5로 확장한다.
- **최종 반환 및 종료 상태:** `####`, `#####` 문법도 제목 요소로 렌더링되며, 레벨이 커질수록 일정 간격으로 글자 크기가 줄어든다.

### B. `+ ` 불릿 문법 지원
- **진입점 및 초기 조건:** 한 줄이 순서 없는 목록 후보로 들어온다.
- **단계별 제어 흐름:**
  1. `isUnorderedListLine()`이 `- `, `* `, `+ ` 접두어를 모두 검사한다.
  2. unordered list block 생성 시 같은 정규식으로 접두어를 제거한다.
  3. paragraph 병합 중단 조건인 `isStructuredMarkdownLine()`도 확장된 불릿 판별 결과를 사용한다.
- **데이터 상태 변이:** 목록 item 문자열에는 접두어가 제거된 본문만 저장된다.
- **최종 반환 및 종료 상태:** `+ item` 입력은 기존 `- item`과 동일한 `<ul><li>item</li></ul>` 구조로 렌더링된다.

---

## 4. 스크린샷 (선택)
- 없음

## 5. 테스트 및 검증 방법
- **테스트 환경:** macOS 로컬 환경, Next.js frontend
- **입력 시나리오:**
  1. `#### Heading`, `##### Heading` 제목 문법을 포함한 마크다운 렌더링
  2. `+ item` 불릿 문법을 포함한 마크다운 렌더링
- **출력 검증:**
  - `npm run lint`
  - `npm run build`
  - lint는 통과했으며 기존 `frontend/src/01_widgets/onboarding/ui/OnboardingView.tsx`의 unused `Image` warning은 남아 있다.

---

## 7. 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일 가이드를 준수합니다.
- [x] 변경 사항에 대한 테스트 코드를 작성하거나 통과했습니다.
- [ ] 관련된 문서(README, API 명세 등)를 업데이트했습니다.
