### PR TITLE
[Fix] 포스트 링크 팝업 버그 수정

### DIFF
--- a/frontend/src/01_widgets/write/ui/WriteView.tsx
+++ b/frontend/src/01_widgets/write/ui/WriteView.tsx
@@ -370,10 +370,19 @@ export function WriteView({
     const menuHeight = 244;
     const menuWidth = 320;
     const textareaRect = textarea.getBoundingClientRect();
-    const spaceBelow =
-      window.innerHeight - (textareaRect.top + caret.top + caret.height);
+    const visibleTextareaTop = Math.max(0, textareaRect.top);
+    const visibleTextareaBottom = Math.min(
+      window.innerHeight,
+      textareaRect.bottom,
+    );
+    const caretViewportTop = textareaRect.top + caret.top;
+    const caretViewportBottom = caretViewportTop + caret.height;
+    const spaceAbove = Math.max(0, caretViewportTop - visibleTextareaTop);
+    const spaceBelow = Math.max(0, visibleTextareaBottom - caretViewportBottom);
     const placement: WikiMenuPlacement =
-      spaceBelow < menuHeight + 24 && caret.top > menuHeight ? "top" : "bottom";
+      spaceBelow < menuHeight + 24 && spaceAbove > spaceBelow
+        ? "top"
+        : "bottom";
 
     setWikiMenu({
       query: trigger.query,
@@ -738,6 +747,7 @@ export function WriteView({
                       onClick={(event) => syncWikiMenu(event.currentTarget)}
                       onKeyDown={handleEditorKeyDown}
                       onKeyUp={handleEditorKeyUp}
+                      onScroll={(event) => syncWikiMenu(event.currentTarget)}
                       onSelect={(event) => syncWikiMenu(event.currentTarget)}
                       placeholder="Share your ideas, code, and insights…"
                       className="min-h-[520px] w-full resize-none px-6 py-6 text-[16px] leading-8 tracking-normal text-zinc-900 outline-none placeholder:text-zinc-400"


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #

---

## 1. PR 유형
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ✨ 새로운 기능 (New Feature)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 업데이트 (Documentation)
- [ ] ⚙️ 설정/빌드 변경 (Chore)

---

## 2. 작업 배경 및 목적
- **기존 상태:** 글 작성 에디터의 postlink 후보 팝업은 caret 위치와 브라우저 viewport 하단 여유 공간을 기준으로 위/아래 배치를 결정했다.
- **문제점:** textarea 내부 스크롤이 발생한 뒤에는 caret이 에디터 하단에 있어도 팝업이 아래로 펼쳐질 수 있었다.
- **해결 목표:** textarea의 실제 가시 영역을 기준으로 남은 공간을 계산해, 에디터 하단에서는 팝업이 위로 펼쳐지도록 한다.

---

## 3. 상세 변경 내역 및 동작 흐름

### A. postlink 팝업 배치 계산 보정
- **진입점 및 초기 조건:** 사용자가 글 작성 textarea에서 `[[`를 입력해 postlink 후보 메뉴가 열리는 시점.
- **단계별 제어 흐름:**
  1. caret의 textarea 내부 좌표를 계산한다.
  2. textarea의 viewport 내 가시 상단/하단과 caret의 viewport 좌표를 계산한다.
  3. caret 위/아래 남은 공간을 비교해 아래 공간이 부족하면 `top` 배치를 선택한다.
- **데이터 상태 변이:** `wikiMenu.placement`, `wikiMenu.top`, `wikiMenu.left` 상태가 보정된 좌표로 갱신된다.
- **최종 반환 및 종료 상태:** textarea 내부 스크롤 이후에도 에디터 하단에서는 후보 팝업이 위쪽으로 표시된다.

### B. textarea 스크롤 중 메뉴 위치 재동기화
- **진입점 및 초기 조건:** postlink 메뉴가 열린 상태에서 textarea 내부 스크롤이 발생하는 시점.
- **단계별 제어 흐름:**
  1. textarea `onScroll` 이벤트에서 `syncWikiMenu`를 호출한다.
  2. 현재 caret과 스크롤 위치 기준으로 메뉴 좌표를 다시 계산한다.
- **데이터 상태 변이:** 스크롤 이후 `wikiMenu` 위치 상태가 최신 textarea 스크롤 위치에 맞춰 갱신된다.
- **최종 반환 및 종료 상태:** 메뉴가 열린 상태로 스크롤해도 팝업 위치가 이전 좌표에 고정되지 않는다.

---

## 4. 테스트 및 검증 방법
- **테스트 환경:** frontend 로컬 Next 서버(`localhost:3030`), mock API(`localhost:8080`), Playwright Chromium.
- **입력 시나리오:** `/write`에서 상단에 `[[` 입력 후, 긴 본문으로 textarea 내부 스크롤을 만든 뒤 하단에서 다시 `[[`를 입력했다.
- **출력 검증:** 상단 입력은 `data-placement="bottom"`, 내부 스크롤 후 하단 입력은 `data-placement="top"`으로 확인했다.
- **정적 검증:** `npm run lint` 통과. 기존 `OnboardingView.tsx` 미사용 import warning 1건은 이번 변경과 무관하다.

---

## 5. 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일 가이드를 준수합니다.
- [x] 변경 사항에 대한 테스트 코드를 작성하거나 통과했습니다.
- [ ] 관련된 문서(README, API 명세 등)를 업데이트했습니다.
