### PR TITLE
[Fix] 데모 이미지 제거

### DIFF
--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostService.kt
@@ -67,6 +67,7 @@ class PostService(
                     authorUsername = requireNotNull(post.author.username),
                     authorName = resolveAuthorName(post),
                     authorAvatarSrc = post.author.profileImageUrl,
+                    thumbnailSrc = extractFirstMarkdownImageSrc(post.content),
                     likes = likeCounts[postId]?.toInt() ?: 0,
                     comments = commentCounts[postId]?.toInt() ?: 0,
                 )

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostViewFormatters.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/PostViewFormatters.kt
@@ -7,6 +7,19 @@ private val PUBLISHED_AT_FORMATTER = DateTimeFormatter.ofPattern("yyyy. M. d.")
 
 fun formatPublishedAtLabel(post: Post): String = post.createdAt.format(PUBLISHED_AT_FORMATTER)
 
+fun extractFirstMarkdownImageSrc(content: String): String? {
+    val imageSrc = MARKDOWN_IMAGE_PATTERN.find(content)
+        ?.groupValues
+        ?.getOrNull(1)
+        ?.trim()
+
+    return imageSrc?.takeIf {
+        it.isNotEmpty() &&
+            !it.startsWith("uploading://") &&
+            !it.startsWith("upload-failed://")
+    }
+}
+
 fun resolveAuthorName(post: Post): String {
     val author = post.author
     return when {
@@ -16,3 +29,5 @@ fun resolveAuthorName(post: Post): String {
         else -> "OpenLog member"
     }
 }
+
+private val MARKDOWN_IMAGE_PATTERN = Regex("""!\[[^\]]*\]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)""")

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/dto/RecentPostResponse.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/dto/RecentPostResponse.kt
@@ -9,6 +9,7 @@ data class RecentPostResponse(
     val authorUsername: String,
     val authorName: String,
     val authorAvatarSrc: String?,
+    val thumbnailSrc: String?,
     val likes: Int,
     val comments: Int,
 )

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserService.kt
@@ -110,6 +110,7 @@ class UserService(
                 title = post.title,
                 description = post.description,
                 publishedAtLabel = formatPublishedAtLabel(post),
+                thumbnailSrc = extractFirstMarkdownImageSrc(post.content),
             )
         }
     }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserService.kt
@@ -10,6 +10,7 @@ import io.github.kitae9999.openlog.post.dto.PostDetailResponse
 import io.github.kitae9999.openlog.post.dto.RecentPostCursorResponse
 import io.github.kitae9999.openlog.post.dto.RecentPostResponse
 import io.github.kitae9999.openlog.post.dto.PostWikiLinkResponse
+import io.github.kitae9999.openlog.post.extractFirstMarkdownImageSrc
 import io.github.kitae9999.openlog.post.formatPublishedAtLabel
 import io.github.kitae9999.openlog.post.repository.PostLinkRepository
 import io.github.kitae9999.openlog.post.repository.PostRepository
@@ -73,6 +74,7 @@ class UserService(
                     authorUsername = requireNotNull(post.author.username),
                     authorName = resolveAuthorName(post),
                     authorAvatarSrc = post.author.profileImageUrl,
+                    thumbnailSrc = extractFirstMarkdownImageSrc(post.content),
                     likes = likeCounts[postId]?.toInt() ?: 0,
                     comments = commentCounts[postId]?.toInt() ?: 0,
                 )

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/dto/PublicUserPostSummaryResponse.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/dto/PublicUserPostSummaryResponse.kt
@@ -5,4 +5,5 @@ data class PublicUserPostSummaryResponse(
     val title: String,
     val description: String,
     val publishedAtLabel: String,
+    val thumbnailSrc: String?,
 )

--- a/backend/src/test/kotlin/io/github/kitae9999/openlog/post/PostServiceTest.kt
+++ b/backend/src/test/kotlin/io/github/kitae9999/openlog/post/PostServiceTest.kt
@@ -115,7 +115,7 @@ class PostServiceTest {
             slug = "hello-openlog",
             title = "Hello OpenLog",
             description = "A short intro",
-            content = "Content",
+            content = "Intro\n\n![Cover](https://example.com/cover.webp)\n\nContent",
         )
         given(postRepository.findAllByOrderByCreatedAtDescIdDesc(PageRequest.of(0, 11)))
             .willReturn(listOf(post))
@@ -143,6 +143,7 @@ class PostServiceTest {
         assertThat(summary.authorUsername).isEqualTo("alice")
         assertThat(summary.authorName).isEqualTo("Alice")
         assertThat(summary.authorAvatarSrc).isEqualTo("https://example.com/alice.png")
+        assertThat(summary.thumbnailSrc).isEqualTo("https://example.com/cover.webp")
         assertThat(summary.likes).isEqualTo(3)
         assertThat(summary.comments).isEqualTo(2)
     }

--- a/frontend/app/[username]/posts/[postSlug]/page.tsx
+++ b/frontend/app/[username]/posts/[postSlug]/page.tsx
@@ -81,7 +81,6 @@ export default async function PublicPostPage({
               publishedAtLabel: detail.publishedAtLabel,
               versionLabel: formatPostVersionLabel(detail.version),
               tags: detail.topics,
-              coverSrc: assets.postCover,
               likes: detail.likes,
               liked: detail.liked,
               comments: commentItems.length,

--- a/frontend/app/[username]/posts/[postSlug]/suggestions/[suggestionNumber]/page.tsx
+++ b/frontend/app/[username]/posts/[postSlug]/suggestions/[suggestionNumber]/page.tsx
@@ -168,7 +168,6 @@ function toPost(detail: ApiPostDetail): Post {
     publishedAtLabel: detail.publishedAtLabel,
     versionLabel: formatPostVersionLabel(detail.version),
     tags: detail.topics,
-    coverSrc: assets.postCover,
     likes: detail.likes,
     liked: detail.liked,
     comments: detail.comments,

--- a/frontend/app/[username]/posts/[postSlug]/suggestions/page.tsx
+++ b/frontend/app/[username]/posts/[postSlug]/suggestions/page.tsx
@@ -88,7 +88,6 @@ export default async function PublicPostSuggestsPage({
               publishedAtLabel: detail.publishedAtLabel,
               versionLabel: formatPostVersionLabel(detail.version),
               tags: detail.topics,
-              coverSrc: assets.postCover,
               likes: detail.likes,
               liked: detail.liked,
               comments: detail.comments,

--- a/frontend/src/01_widgets/home-feed/ui/HomeFeedShell.tsx
+++ b/frontend/src/01_widgets/home-feed/ui/HomeFeedShell.tsx
@@ -346,11 +346,16 @@ function HomeSidebar({
 }
 
 function ArticleCard({ post }: { post: FeedPost }) {
+  const thumbnailSrc = post.thumbnailSrc;
+
   return (
     <article className="py-8">
       <Link
         href={post.href}
-        className="group grid gap-5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20 sm:grid-cols-[minmax(0,1fr)_184px] sm:items-center"
+        className={cn(
+          "group grid gap-5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20",
+          thumbnailSrc ? "sm:grid-cols-[minmax(0,1fr)_184px] sm:items-center" : "",
+        )}
       >
         <div className="min-w-0">
           <div className="flex items-center gap-2 text-[13px] text-zinc-600">
@@ -373,15 +378,17 @@ function ArticleCard({ post }: { post: FeedPost }) {
           </p>
         </div>
 
-        <div className="relative h-[126px] w-full overflow-hidden rounded-md border border-zinc-200 bg-zinc-100 sm:h-[118px]">
-          <Image
-            src={post.thumbnailSrc}
-            alt=""
-            fill
-            sizes="(min-width: 640px) 184px, 100vw"
-            className="object-cover transition duration-300 group-hover:scale-[1.03]"
-          />
-        </div>
+        {thumbnailSrc ? (
+          <div className="relative h-[126px] w-full overflow-hidden rounded-md border border-zinc-200 bg-zinc-100 sm:h-[118px]">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={thumbnailSrc}
+              alt=""
+              loading="lazy"
+              className="size-full object-cover transition duration-300 group-hover:scale-[1.03]"
+            />
+          </div>
+        ) : null}
       </Link>
 
       <div className="mt-5 flex flex-wrap items-center gap-3 text-[13px] text-zinc-500">
@@ -407,13 +414,6 @@ function getPostsForTab(tab: TabKey) {
   return feedPosts;
 }
 
-const FEED_THUMBNAILS = [
-  "/feed/operational-notes.svg",
-  "/feed/review-cadence.svg",
-  "/feed/knowledge-graph.svg",
-  "/feed/quiet-interfaces.svg",
-] as const;
-
 function toFeedPost(post: RecentPostSummary): FeedPost {
   return {
     id: String(post.id),
@@ -424,7 +424,7 @@ function toFeedPost(post: RecentPostSummary): FeedPost {
     dateLabel: post.publishedAtLabel,
     commentCount: formatCompactCount(post.comments),
     likeCount: formatCompactCount(post.likes),
-    thumbnailSrc: FEED_THUMBNAILS[post.id % FEED_THUMBNAILS.length],
+    thumbnailSrc: post.thumbnailSrc,
     href: buildPublicPostPath(post.authorUsername, post.slug),
   };
 }

--- a/frontend/src/01_widgets/home-feed/ui/data.ts
+++ b/frontend/src/01_widgets/home-feed/ui/data.ts
@@ -11,7 +11,7 @@ export type FeedPost = {
   dateLabel: string;
   commentCount: string;
   likeCount: string;
-  thumbnailSrc: string;
+  thumbnailSrc?: string | null;
   href: string;
 };
 

--- a/frontend/src/01_widgets/post/ui/PostArticle.tsx
+++ b/frontend/src/01_widgets/post/ui/PostArticle.tsx
@@ -178,19 +178,6 @@ export function PostArticle({
             ) : null}
           </header>
 
-          <div className="mt-7 overflow-hidden rounded-2xl border border-zinc-200 bg-zinc-50 shadow-sm">
-            <div className="relative aspect-[16/9] w-full">
-              <Image
-                src={post.coverSrc}
-                alt="Post cover"
-                fill
-                priority
-                sizes="(min-width: 1024px) 768px, 100vw"
-                className="object-cover"
-              />
-            </div>
-          </div>
-
           {children}
 
           <div className="mt-10 flex justify-center lg:hidden">

--- a/frontend/src/01_widgets/profile/ui/AuthoredPostsSection.tsx
+++ b/frontend/src/01_widgets/profile/ui/AuthoredPostsSection.tsx
@@ -155,11 +155,14 @@ function AuthoredPostList({
 
   return (
     <div>
-      {posts.map((post, index) => (
+      {posts.map((post) => (
         <Link
           key={post.slug}
           href={buildPublicPostPath(username, post.slug)}
-          className="group grid grid-cols-[minmax(0,1fr)_64px] items-start gap-4 rounded-xl border-b border-zinc-200/80 px-2 py-4 transition hover:bg-white/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/10"
+          className={cn(
+            "group grid items-start gap-4 rounded-xl border-b border-zinc-200/80 px-2 py-4 transition hover:bg-white/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/10",
+            post.thumbnailSrc ? "grid-cols-[minmax(0,1fr)_64px]" : "",
+          )}
         >
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2 text-xs text-zinc-500">
@@ -186,15 +189,17 @@ function AuthoredPostList({
             </div>
           </div>
 
-          <div className="relative size-16 overflow-hidden rounded-[4px] bg-zinc-200">
-            <Image
-              src={index % 2 === 0 ? assets.featuredCover : assets.postCover}
-              alt={`${post.title} thumbnail`}
-              fill
-              sizes="64px"
-              className="object-cover transition duration-300 group-hover:scale-[1.03]"
-            />
-          </div>
+          {post.thumbnailSrc ? (
+            <div className="relative size-16 overflow-hidden rounded-[4px] bg-zinc-200">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={post.thumbnailSrc}
+                alt={`${post.title} thumbnail`}
+                loading="lazy"
+                className="size-full object-cover transition duration-300 group-hover:scale-[1.03]"
+              />
+            </div>
+          ) : null}
         </Link>
       ))}
     </div>

--- a/frontend/src/03_entities/post/api/getRecentPosts.ts
+++ b/frontend/src/03_entities/post/api/getRecentPosts.ts
@@ -10,6 +10,7 @@ export type RecentPostSummary = {
   authorUsername: string;
   authorName: string;
   authorAvatarSrc: string | null;
+  thumbnailSrc: string | null;
   likes: number;
   comments: number;
 };

--- a/frontend/src/03_entities/post/model/postData.tsx
+++ b/frontend/src/03_entities/post/model/postData.tsx
@@ -16,7 +16,6 @@ export type Post = {
   versionLabel?: string;
   readTimeLabel?: string;
   tags: string[];
-  coverSrc: string;
   likes: number;
   liked?: boolean;
   comments: number;
@@ -121,7 +120,6 @@ const postEntries: Record<string, Record<string, PostEntry>> = {
         publishedAtLabel: "2026. 2. 25.",
         readTimeLabel: "5 min read",
         tags: ["CSS", "Tooling"],
-        coverSrc: assets.postCover,
         likes: 890,
         comments: 12,
       },
@@ -235,7 +233,6 @@ const postEntries: Record<string, Record<string, PostEntry>> = {
         publishedAtLabel: "2026. 2. 28.",
         readTimeLabel: "8 min read",
         tags: ["React", "Web Development", "Performance"],
-        coverSrc: assets.featuredCover,
         likes: 1240,
         comments: 24,
       },

--- a/frontend/src/03_entities/user/api/getPublicUserPosts.ts
+++ b/frontend/src/03_entities/user/api/getPublicUserPosts.ts
@@ -7,6 +7,7 @@ export type PublicUserPostSummary = {
   title: string;
   description: string;
   publishedAtLabel: string;
+  thumbnailSrc: string | null;
 };
 
 export async function getPublicUserPosts(username: string) {


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #

---

## 1. PR 유형
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ✨ 새로운 기능 (New Feature)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 업데이트 (Documentation)
- [ ] ⚙️ 설정/빌드 변경 (Chore)

---

## 2. 변경 배경 및 목표
- **변경 전 상태:** 메인 피드와 프로필 authored posts 목록은 포스트 본문에 이미지가 없어도 데모 썸네일을 강제로 표시했다. 포스트 상세 화면도 모든 글 상단에 `assets.postCover` 기본 커버 이미지를 항상 렌더링했다.
- **문제/필요성:** 이미지가 없는 글에도 임의 이미지가 노출되어 실제 포스트 내용과 카드/상세 화면이 다르게 보였다. 특히 본문 이미지가 없는 글이 이미지가 있는 글처럼 보이는 문제가 있었다.
- **이번 PR의 목표:** 포스트 본문에 실제 마크다운 이미지가 있을 때만 카드 썸네일을 표시하고, 포스트 상세 상단의 기본 커버 이미지는 제거한다.

---

## 3. 주요 구현 내용 및 동작 방식

### A. 본문 첫 이미지 기반 썸네일 응답 추가
- **관련 위치/대상:** `PostViewFormatters`, `PostService`, `UserService`, `RecentPostResponse`, `PublicUserPostSummaryResponse`
- **변경 전 상황:** 최근 글 목록과 프로필 글 목록 API 응답에는 본문 이미지 여부를 판단할 수 있는 필드가 없었다. 프론트는 응답 데이터 대신 고정 데모 이미지 목록을 사용했다.
- **변경한 내용:** 포스트 본문에서 첫 번째 마크다운 이미지 URL을 추출하는 `extractFirstMarkdownImageSrc`를 추가하고, 최근 글/좋아요 글/프로필 글 목록 응답에 `thumbnailSrc`를 포함했다. 업로드 진행 중이거나 실패한 임시 URL은 썸네일로 사용하지 않도록 제외했다.
- **변경 후 동작:** API 응답의 `thumbnailSrc`는 본문에 사용 가능한 이미지가 있을 때만 값이 채워지고, 이미지가 없으면 `null`로 내려간다.
- **바뀌는 데이터/상태:** `RecentPostResponse.thumbnailSrc`, `PublicUserPostSummaryResponse.thumbnailSrc` 응답 필드가 추가된다.
- **영향 범위:** 메인 피드, liked posts 피드, 프로필 authored posts 목록의 썸네일 표시 조건에 영향을 준다.

### B. 피드와 프로필 글 목록의 기본 썸네일 제거
- **관련 위치/대상:** `HomeFeedShell`, `AuthoredPostsSection`, 관련 프론트 API 타입
- **변경 전 상황:** 메인 피드는 포스트 ID를 기준으로 `/feed/*.svg` 데모 이미지를 순환 사용했고, 프로필 authored posts는 `assets.featuredCover`와 `assets.postCover`를 번갈아 사용했다.
- **변경한 내용:** API에서 받은 `thumbnailSrc`가 있을 때만 썸네일 영역을 렌더링하도록 변경했다. 값이 없으면 카드 레이아웃도 텍스트 단일 영역으로 표시되도록 grid column 조건을 분리했다.
- **변경 후 동작:** 본문 이미지가 없는 포스트는 메인 피드와 authored posts 목록에서 썸네일 없이 표시된다. 본문 이미지가 있는 포스트만 해당 이미지를 썸네일로 표시한다.
- **바뀌는 데이터/상태:** `FeedPost.thumbnailSrc`, `PublicUserPostSummary.thumbnailSrc`가 nullable 값으로 처리된다.
- **영향 범위:** 메인 피드 카드, liked posts 카드, 프로필 authored posts 리스트 UI.

### C. 포스트 상세 상단 기본 커버 제거
- **관련 위치/대상:** `PostArticle`, 포스트 상세/제안 화면의 `Post` 모델 사용부
- **변경 전 상황:** 포스트 상세 본문 위에 기본 커버 이미지가 항상 렌더링되었고, 상세/제안 페이지에서 `coverSrc: assets.postCover`를 주입했다.
- **변경한 내용:** `PostArticle`의 상단 커버 렌더링 블록을 삭제하고, `Post` 모델 및 상세/제안 페이지에서 더 이상 `coverSrc`를 전달하지 않도록 정리했다.
- **변경 후 동작:** 포스트 상세 화면은 제목, 설명, 태그 다음에 바로 본문을 보여준다. 본문 내부 이미지는 마크다운 렌더러가 기존 방식대로 표시한다.
- **영향 범위:** 포스트 상세 화면, 제안 목록/상세 화면에서 공유하는 포스트 모델 타입.

---

## 4. 스크린샷 (선택)
- 없음

## 5. 테스트 및 검증 방법
- **검증 환경:** 로컬 개발 환경, `develop` 브랜치 워킹트리
- **검증한 시나리오:** 백엔드 응답 DTO 컴파일 및 서비스 테스트, 프론트 린트, Next.js 프로덕션 빌드
- **확인한 결과:**
  - `./gradlew :backend:test` 성공
  - `npm run lint` 성공. 기존 `OnboardingView.tsx`의 미사용 `Image` import 경고 1건은 이번 변경과 무관하게 남아 있음
  - `npm run build` 성공
- **확인하지 못한 부분:** 실제 브라우저에서 이미지 유무별 시각 회귀는 자동화하지 않았다.

---

## 6. 리뷰어 참고 사항 (선택)
- **리뷰할 때 봐야 할 점:** 썸네일 렌더링은 마크다운 본문 이미지와 같은 방식으로 외부/백엔드 미디어 URL을 받을 수 있어 `next/image` 대신 일반 `img`를 사용했다.
- **영향 범위:** 목록 API 응답 필드가 추가되므로 프론트 외부에서 해당 API를 직접 소비하는 클라이언트가 있다면 nullable 필드 추가를 확인해야 한다.

---

## 7. 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일 가이드를 준수합니다.
- [x] 변경 사항에 대한 테스트 코드를 작성하거나 통과했습니다.
- [ ] 관련된 문서(README, API 명세 등)를 업데이트했습니다.
