### PR TITLE
[Feat] OpenLog CLI 및 MCP

### DIFF
--- a/.github/workflows/openlog-cli-publish.yml
+++ b/.github/workflows/openlog-cli-publish.yml
@@ -1,0 +1,112 @@
+name: OpenLog CLI CI/CD
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - "packages/openlog-cli/**"
+      - ".github/workflows/openlog-cli-publish.yml"
+  push:
+    branches:
+      - develop
+    paths:
+      - "packages/openlog-cli/**"
+      - ".github/workflows/openlog-cli-publish.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: openlog-cli-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/openlog-cli
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: packages/openlog-cli/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify package contents
+        run: npm pack --dry-run
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: verify
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: packages/openlog-cli
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify package contents
+        run: npm pack --dry-run
+
+      - name: Read package metadata
+        id: package
+        run: |
+          node - <<'NODE' >> "$GITHUB_OUTPUT"
+          const packageJson = require('./package.json')
+          console.log(`name=${packageJson.name}`)
+          console.log(`version=${packageJson.version}`)
+          NODE
+
+      - name: Check version is unpublished
+        run: |
+          set +e
+          npm view "${{ steps.package.outputs.name }}@${{ steps.package.outputs.version }}" version --json >/tmp/openlog-cli-version.json 2>/tmp/openlog-cli-view-error.log
+          status=$?
+          set -e
+
+          if [ "$status" -eq 0 ]; then
+            echo "::error::${{ steps.package.outputs.name }}@${{ steps.package.outputs.version }} is already published. Bump packages/openlog-cli/package.json before publishing."
+            exit 1
+          fi
+
+          if ! grep -q "E404" /tmp/openlog-cli-view-error.log; then
+            cat /tmp/openlog-cli-view-error.log
+            exit "$status"
+          fi
+
+      - name: Publish to npm
+        run: npm publish --access public

--- a/README.md
+++ b/README.md
@@ -66,6 +66,82 @@ OpenLog는 이런 사용자에게 잘 맞습니다.
 - 자신의 기여를 포트폴리오처럼 남기고 싶은 기여자
 - 문서와 블로그의 장점을 함께 가진 플랫폼을 원하는 팀과 커뮤니티
 
+## CLI and MCP
+
+OpenLog는 공식 CLI와 MCP server를 npm 패키지로 제공합니다.
+
+CLI는 웹에서 승인한 로그인 결과를 로컬에 저장하고, MCP server는 Codex나 Claude Code 같은 MCP client가 로그인한 OpenLog 계정의 데이터를 조회하거나 글을 발행할 수 있게 합니다.
+
+### CLI 사용
+
+```bash
+npx -y @kitae9999/openlog-cli login
+npx -y @kitae9999/openlog-cli whoami
+npx -y @kitae9999/openlog-cli mcp
+```
+
+- `openlog login`: device login을 시작하고 브라우저에서 OpenLog 승인 화면을 엽니다.
+- `openlog whoami`: 현재 저장된 로그인 계정을 확인합니다.
+- `openlog logout`: 로컬에 저장된 OpenLog 인증 정보를 삭제합니다.
+- `openlog mcp`: stdio 기반 OpenLog MCP server를 실행합니다.
+
+전역 설치 후에는 `openlog` 명령을 직접 사용할 수 있습니다.
+
+```bash
+npm install -g @kitae9999/openlog-cli
+openlog login
+openlog mcp
+```
+
+### MCP client 설정
+
+MCP client에는 다음처럼 등록할 수 있습니다.
+
+```json
+{
+  "mcpServers": {
+    "openlog": {
+      "command": "npx",
+      "args": ["-y", "@kitae9999/openlog-cli", "mcp"]
+    }
+  }
+}
+```
+
+CLI에서 지원하는 자동 등록 명령도 제공합니다.
+
+```bash
+openlog mcp install codex
+openlog mcp install claude-code
+```
+
+### MCP tools
+
+- `get_auth_status`: 로컬 CLI 로그인 상태 확인
+- `get_me`: 현재 로그인 사용자 조회
+- `list_my_notifications`: 내 알림 목록 조회
+- `list_my_posts`: 내가 작성한 글 목록 조회
+- `list_my_liked_posts`: 내가 좋아요한 글 목록 조회
+- `get_post_detail`: 특정 글 상세 조회
+- `upload_post_image`: 로컬 이미지를 WebP로 변환해 OpenLog 글 본문 이미지로 업로드
+- `publish_post`: 로그인 계정으로 새 글 발행
+
+`publish_post`는 기본적으로 preview만 반환하며, 실제 발행은 `confirm: true` 또는 명시적인 `skipConfirmation: true`가 있을 때만 수행합니다.
+
+### 로컬 개발 환경 연결
+
+운영 API 대신 로컬 서버를 사용할 때는 환경 변수를 지정합니다.
+
+```bash
+OPENLOG_API_BASE_URL=http://localhost:8080/api \
+OPENLOG_WEB_BASE_URL=http://localhost:3030 \
+npx -y @kitae9999/openlog-cli mcp
+```
+
+- `OPENLOG_API_BASE_URL`: CLI/MCP가 호출할 OpenLog API base URL
+- `OPENLOG_WEB_BASE_URL`: `publish_post` 응답에 포함할 웹 URL base
+- `OPENLOG_AUTH_FILE`: 기본 `~/.openlog/auth.json` 대신 사용할 인증 파일 경로
+
 ## Vision
 
 OpenLog의 목표는 “좋은 글이 쌓이는 서비스”를 넘어서,  

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthController.kt
@@ -1,6 +1,10 @@
 package io.github.kitae9999.openlog.auth
 
 import io.github.kitae9999.openlog.auth.dto.CompleteOnboardingRequest
+import io.github.kitae9999.openlog.auth.dto.DeviceApproveRequest
+import io.github.kitae9999.openlog.auth.dto.DeviceStartResponse
+import io.github.kitae9999.openlog.auth.dto.DeviceTokenRequest
+import io.github.kitae9999.openlog.auth.dto.DeviceTokenResponse
 import io.github.kitae9999.openlog.auth.dto.MeResponse
 import io.github.kitae9999.openlog.auth.exception.OAuthAuthenticationException
 import io.github.kitae9999.openlog.user.entity.User
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder
 import java.net.URI
 import java.time.Duration
 
@@ -26,6 +31,7 @@ import java.time.Duration
 @RequestMapping("auth")
 class AuthController(
     private val authService: AuthService,
+    private val deviceAuthService: DeviceAuthService,
     private val currentUserResolver: CurrentUserResolver,
     private val jwtTokenService: JwtTokenService,
     private val accessTokenCookieFactory: AccessTokenCookieFactory,
@@ -72,10 +78,34 @@ class AuthController(
         return onboardedUser.toMeResponse()
     }
 
+    @PostMapping("device/start")
+    fun startDeviceLogin(): DeviceStartResponse {
+        return deviceAuthService.start()
+    }
+
+    @PostMapping("device/approve")
+    fun approveDeviceLogin(
+        request: HttpServletRequest,
+        @RequestBody deviceApproveRequest: DeviceApproveRequest,
+    ): ResponseEntity<Void> {
+        val currentUser = currentUserResolver.resolveCurrentUser(request)
+        deviceAuthService.approve(deviceApproveRequest.userCode, currentUser)
+
+        return ResponseEntity.noContent().build()
+    }
+
+    @PostMapping("device/token")
+    fun getDeviceToken(
+        @RequestBody deviceTokenRequest: DeviceTokenRequest,
+    ): DeviceTokenResponse {
+        return deviceAuthService.token(deviceTokenRequest.deviceCode)
+    }
+
     @GetMapping("google")
     fun redirectToGoogleOAuth(
+        @RequestParam(required = false) returnTo: String?,
     ): ResponseEntity<Void>{
-        val authRequest = authService.createGoogleAuthRequest()
+        val authRequest = authService.createGoogleAuthRequest(returnTo)
 
         val flowCookie = ResponseCookie.from("oauth_flow_id",authRequest.flowId)
             .httpOnly(true)
@@ -91,13 +121,34 @@ class AuthController(
             .build()
     }
 
+    @GetMapping("github")
+    fun redirectToGithubOAuth(
+        request: HttpServletRequest,
+        @RequestParam(required = false) returnTo: String?,
+    ): ResponseEntity<Void> {
+        normalizeFrontendReturnTo(returnTo)?.let {
+            request.session.setAttribute(GITHUB_RETURN_TO_SESSION_ATTRIBUTE, it)
+        }
+
+        return ResponseEntity.status(HttpStatus.FOUND)
+            .location(
+                URI.create(
+                    ServletUriComponentsBuilder.fromCurrentContextPath()
+                        .path("/oauth2/authorization/github")
+                        .build()
+                        .toUriString()
+                )
+            )
+            .build()
+    }
+
     @GetMapping("google/callback")
     fun hangleGoogleCallback(
         @RequestParam code: String,
         @RequestParam state: String,
         @CookieValue("oauth_flow_id") flowId: String
     ): ResponseEntity<Void> {
-        authService.validateGoogleState(flowId, state)
+        val oauthState = authService.consumeGoogleState(flowId, state)
 
         val deleteCookie = ResponseCookie.from("oauth_flow_id", "")
             .httpOnly(true)
@@ -127,15 +178,7 @@ class AuthController(
 
         return ResponseEntity.status(HttpStatus.FOUND)
             .header(HttpHeaders.SET_COOKIE, deleteCookie.toString(), authCookie.toString())
-            .location(
-                URI.create(
-                    if (currentUser.isOnboardingComplete()) {
-                        frontendHomeUrl
-                    } else {
-                        URI.create(frontendHomeUrl).resolve("/onboarding").toString()
-                    },
-                )
-            )
+            .location(URI.create(resolvePostLoginRedirect(currentUser, oauthState.returnTo)))
             .build()
     }
 
@@ -151,6 +194,35 @@ class AuthController(
         )
     }
 
+    private fun resolvePostLoginRedirect(user: User, returnTo: String?): String {
+        val frontendHome = URI.create(frontendHomeUrl)
 
+        if (!user.isOnboardingComplete()) {
+            return frontendHome.resolve("/onboarding").toString()
+        }
 
+        return normalizeFrontendReturnTo(returnTo)
+            ?.let { frontendHome.resolve(it).toString() }
+            ?: frontendHome.toString()
+    }
+
+    private fun normalizeFrontendReturnTo(returnTo: String?): String? {
+        val trimmedReturnTo = returnTo?.trim()?.takeIf { it.isNotBlank() }
+            ?: return null
+
+        return if (
+            trimmedReturnTo.startsWith("/") &&
+            !trimmedReturnTo.startsWith("//") &&
+            !trimmedReturnTo.contains("\r") &&
+            !trimmedReturnTo.contains("\n")
+        ) {
+            trimmedReturnTo
+        } else {
+            null
+        }
+    }
+
+    private companion object {
+        const val GITHUB_RETURN_TO_SESSION_ATTRIBUTE = "oauth_return_to"
+    }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/AuthService.kt
@@ -43,11 +43,17 @@ class AuthService(
     companion object {
         private  val OAUTH_STATE_TTL: Duration = Duration.ofMinutes(5)
         private const val GOOGLE_STATE_KEY_PREFIX = "oauth:google:state"
+        private const val GOOGLE_STATE_VALUE_SEPARATOR = "\n"
     }
 
     data class GoogleAuthRequest(
         val flowId: String,
         val authUrl: String,
+    )
+
+    data class GoogleOAuthState(
+        val state: String,
+        val returnTo: String?,
     )
 
     data class GoogleUserInfoResponse(
@@ -123,13 +129,14 @@ class AuthService(
     /**
      * auth 이벤트 발생 시 state 발행 및 레디스 저장
      */
-    fun createGoogleAuthRequest(): GoogleAuthRequest {
+    fun createGoogleAuthRequest(returnTo: String? = null): GoogleAuthRequest {
         val flowId = UUID.randomUUID().toString()
         val state = UUID.randomUUID().toString()
+        val normalizedReturnTo = normalizeFrontendReturnTo(returnTo)
 
         redisTemplate.opsForValue().set(
             buildStateKey(flowId),
-            state,
+            listOf(state, normalizedReturnTo.orEmpty()).joinToString(GOOGLE_STATE_VALUE_SEPARATOR),
             OAUTH_STATE_TTL
         )
 
@@ -141,15 +148,22 @@ class AuthService(
     }
 
 
-    fun validateGoogleState(flowId: String?, state: String){
+    fun validateGoogleState(flowId: String?, state: String) {
+        consumeGoogleState(flowId, state)
+    }
+
+    fun consumeGoogleState(flowId: String?, state: String): GoogleOAuthState {
         if (flowId.isNullOrBlank()){
             throw InvalidOAuthStateException()
         }
 
-        val savedState = redisTemplate.opsForValue().getAndDelete(buildStateKey(flowId))
-        if (savedState == null || savedState != state ){
+        val savedValue = redisTemplate.opsForValue().getAndDelete(buildStateKey(flowId))
+        val savedOAuthState = savedValue?.toGoogleOAuthState()
+        if (savedOAuthState == null || savedOAuthState.state != state ){
             throw InvalidOAuthStateException()
         }
+
+        return savedOAuthState
     }
 
     @Transactional
@@ -236,4 +250,29 @@ class AuthService(
 
     private fun buildStateKey(flowId: String): String =
         "$GOOGLE_STATE_KEY_PREFIX$flowId"
+
+    private fun String.toGoogleOAuthState(): GoogleOAuthState {
+        val parts = split(GOOGLE_STATE_VALUE_SEPARATOR, limit = 2)
+
+        return GoogleOAuthState(
+            state = parts[0],
+            returnTo = parts.getOrNull(1)?.takeIf { it.isNotBlank() },
+        )
+    }
+
+    private fun normalizeFrontendReturnTo(returnTo: String?): String? {
+        val trimmedReturnTo = returnTo?.trim()?.takeIf { it.isNotBlank() }
+            ?: return null
+
+        return if (
+            trimmedReturnTo.startsWith("/") &&
+            !trimmedReturnTo.startsWith("//") &&
+            !trimmedReturnTo.contains("\r") &&
+            !trimmedReturnTo.contains("\n")
+        ) {
+            trimmedReturnTo
+        } else {
+            null
+        }
+    }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/DeviceAuthService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/DeviceAuthService.kt
@@ -1,0 +1,138 @@
+package io.github.kitae9999.openlog.auth
+
+import io.github.kitae9999.openlog.auth.dto.DeviceStartResponse
+import io.github.kitae9999.openlog.auth.dto.DeviceTokenResponse
+import io.github.kitae9999.openlog.auth.dto.DeviceTokenStatus
+import io.github.kitae9999.openlog.common.exception.BadRequestException
+import io.github.kitae9999.openlog.user.entity.User
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Service
+import org.springframework.web.util.UriComponentsBuilder
+import java.security.SecureRandom
+import java.time.Duration
+import java.util.Locale
+import java.util.UUID
+
+@Service
+class DeviceAuthService(
+    private val redisTemplate: StringRedisTemplate,
+    private val jwtTokenService: JwtTokenService,
+    @Value("\${app.frontend-home-url:http://localhost:3030}")
+    private val frontendHomeUrl: String,
+) {
+    fun start(): DeviceStartResponse {
+        val deviceCode = UUID.randomUUID().toString()
+        val userCode = generateUserCode()
+        val verificationUri = UriComponentsBuilder
+            .fromUriString(frontendHomeUrl)
+            .path("/cli-login")
+            .build()
+            .toUriString()
+        val verificationUriComplete = UriComponentsBuilder
+            .fromUriString(verificationUri)
+            .queryParam("code", userCode)
+            .build()
+            .toUriString()
+
+        redisTemplate.opsForValue().set(
+            deviceKey(deviceCode),
+            PENDING_VALUE,
+            DEVICE_CODE_TTL,
+        )
+        redisTemplate.opsForValue().set(
+            userKey(userCode),
+            deviceCode,
+            DEVICE_CODE_TTL,
+        )
+
+        return DeviceStartResponse(
+            deviceCode = deviceCode,
+            userCode = userCode,
+            verificationUri = verificationUri,
+            verificationUriComplete = verificationUriComplete,
+            expiresIn = DEVICE_CODE_TTL.toSeconds().toInt(),
+            interval = POLLING_INTERVAL_SECONDS,
+        )
+    }
+
+    fun approve(userCode: String, currentUser: User) {
+        val normalizedUserCode = normalizeUserCode(userCode)
+        val deviceCode = redisTemplate.opsForValue().get(userKey(normalizedUserCode))
+            ?: throw BadRequestException("만료되었거나 잘못된 CLI 로그인 코드입니다.")
+        val key = deviceKey(deviceCode)
+        val currentValue = redisTemplate.opsForValue().get(key)
+            ?: throw BadRequestException("만료되었거나 잘못된 CLI 로그인 코드입니다.")
+
+        if (currentValue != PENDING_VALUE) {
+            throw BadRequestException("이미 승인된 CLI 로그인 코드입니다.")
+        }
+
+        val remainingSeconds = redisTemplate.getExpire(key)
+        if (remainingSeconds <= 0) {
+            throw BadRequestException("만료되었거나 잘못된 CLI 로그인 코드입니다.")
+        }
+
+        redisTemplate.opsForValue().set(
+            key,
+            "$APPROVED_VALUE:${jwtTokenService.createAccessToken(currentUser)}",
+            Duration.ofSeconds(remainingSeconds),
+        )
+        redisTemplate.delete(userKey(normalizedUserCode))
+    }
+
+    fun token(deviceCode: String): DeviceTokenResponse {
+        val key = deviceKey(deviceCode)
+        val currentValue = redisTemplate.opsForValue().get(key)
+            ?: throw BadRequestException("만료되었거나 잘못된 device code입니다.")
+
+        if (currentValue == PENDING_VALUE) {
+            return DeviceTokenResponse(
+                status = DeviceTokenStatus.PENDING,
+                interval = POLLING_INTERVAL_SECONDS,
+            )
+        }
+
+        if (!currentValue.startsWith("$APPROVED_VALUE:")) {
+            throw BadRequestException("잘못된 device code 상태입니다.")
+        }
+
+        redisTemplate.delete(key)
+
+        return DeviceTokenResponse(
+            status = DeviceTokenStatus.APPROVED,
+            accessToken = currentValue.removePrefix("$APPROVED_VALUE:"),
+            expiresIn = jwtTokenService.accessTokenTtl().toSeconds().toInt(),
+        )
+    }
+
+    private fun generateUserCode(): String {
+        val code = (1..USER_CODE_LENGTH).map {
+            USER_CODE_ALPHABET[random.nextInt(USER_CODE_ALPHABET.length)]
+        }.joinToString("")
+
+        return "${code.substring(0, 4)}-${code.substring(4)}"
+    }
+
+    private fun normalizeUserCode(userCode: String): String =
+        userCode.trim().uppercase(Locale.US)
+
+    private fun deviceKey(deviceCode: String): String =
+        "$DEVICE_CODE_KEY_PREFIX$deviceCode"
+
+    private fun userKey(userCode: String): String =
+        "$USER_CODE_KEY_PREFIX${normalizeUserCode(userCode)}"
+
+    private companion object {
+        private val DEVICE_CODE_TTL: Duration = Duration.ofMinutes(10)
+        private const val POLLING_INTERVAL_SECONDS = 2
+        private const val DEVICE_CODE_KEY_PREFIX = "auth:device:code:"
+        private const val USER_CODE_KEY_PREFIX = "auth:device:user:"
+        private const val PENDING_VALUE = "PENDING"
+        private const val APPROVED_VALUE = "APPROVED"
+        private const val USER_CODE_LENGTH = 8
+        private const val USER_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+        private val random = SecureRandom()
+    }
+}
+

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/GithubOAuthSuccessHandler.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/GithubOAuthSuccessHandler.kt
@@ -45,15 +45,42 @@ class GithubOAuthSuccessHandler(
         )
         val issuedJwt = jwtTokenService.createAccessToken(currentUser)
         val authCookie = accessTokenCookieFactory.create(issuedJwt)
+        val returnTo = request.session.getAttribute(GITHUB_RETURN_TO_SESSION_ATTRIBUTE) as? String
+        request.session.removeAttribute(GITHUB_RETURN_TO_SESSION_ATTRIBUTE)
 
         response.addHeader(HttpHeaders.SET_COOKIE, authCookie.toString())
-        response.sendRedirect(
-            if (currentUser.isOnboardingComplete()) {
-                frontendHomeUrl
-            } else {
-                URI.create(frontendHomeUrl).resolve("/onboarding").toString()
-            },
-        )
+        response.sendRedirect(resolvePostLoginRedirect(currentUser, returnTo))
     }
 
+    private fun resolvePostLoginRedirect(user: io.github.kitae9999.openlog.user.entity.User, returnTo: String?): String {
+        val frontendHome = URI.create(frontendHomeUrl)
+
+        if (!user.isOnboardingComplete()) {
+            return frontendHome.resolve("/onboarding").toString()
+        }
+
+        return normalizeFrontendReturnTo(returnTo)
+            ?.let { frontendHome.resolve(it).toString() }
+            ?: frontendHome.toString()
+    }
+
+    private fun normalizeFrontendReturnTo(returnTo: String?): String? {
+        val trimmedReturnTo = returnTo?.trim()?.takeIf { it.isNotBlank() }
+            ?: return null
+
+        return if (
+            trimmedReturnTo.startsWith("/") &&
+            !trimmedReturnTo.startsWith("//") &&
+            !trimmedReturnTo.contains("\r") &&
+            !trimmedReturnTo.contains("\n")
+        ) {
+            trimmedReturnTo
+        } else {
+            null
+        }
+    }
+
+    private companion object {
+        const val GITHUB_RETURN_TO_SESSION_ATTRIBUTE = "oauth_return_to"
+    }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/dto/DeviceAuthDtos.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/dto/DeviceAuthDtos.kt
@@ -1,0 +1,31 @@
+package io.github.kitae9999.openlog.auth.dto
+
+data class DeviceStartResponse(
+    val deviceCode: String,
+    val userCode: String,
+    val verificationUri: String,
+    val verificationUriComplete: String,
+    val expiresIn: Int,
+    val interval: Int,
+)
+
+data class DeviceApproveRequest(
+    val userCode: String,
+)
+
+data class DeviceTokenRequest(
+    val deviceCode: String,
+)
+
+data class DeviceTokenResponse(
+    val status: DeviceTokenStatus,
+    val accessToken: String? = null,
+    val expiresIn: Int? = null,
+    val interval: Int? = null,
+)
+
+enum class DeviceTokenStatus {
+    PENDING,
+    APPROVED,
+}
+

--- a/backend/src/test/kotlin/io/github/kitae9999/openlog/auth/DeviceAuthServiceTest.kt
+++ b/backend/src/test/kotlin/io/github/kitae9999/openlog/auth/DeviceAuthServiceTest.kt
@@ -1,0 +1,114 @@
+package io.github.kitae9999.openlog.auth
+
+import io.github.kitae9999.openlog.auth.dto.DeviceTokenStatus
+import io.github.kitae9999.openlog.common.exception.BadRequestException
+import io.github.kitae9999.openlog.user.entity.User
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.BDDMockito.given
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.mockingDetails
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import java.time.Duration
+
+@ExtendWith(MockitoExtension::class)
+class DeviceAuthServiceTest {
+    @Mock
+    private lateinit var redisTemplate: StringRedisTemplate
+
+    @Mock
+    private lateinit var valueOperations: ValueOperations<String, String>
+
+    private lateinit var deviceAuthService: DeviceAuthService
+
+    private val jwtTokenService = JwtTokenService(
+        secret = "openlog-local-jwt-secret-openlog-local-jwt-secret",
+        issuer = "openlog",
+        accessTokenExpirationSeconds = 3600,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        given(redisTemplate.opsForValue()).willReturn(valueOperations)
+
+        deviceAuthService = DeviceAuthService(
+            redisTemplate = redisTemplate,
+            jwtTokenService = jwtTokenService,
+            frontendHomeUrl = "https://openlog.kr",
+        )
+    }
+
+    @Test
+    fun `start creates a device login session`() {
+        val response = deviceAuthService.start()
+
+        assertThat(response.deviceCode).isNotBlank()
+        assertThat(response.userCode).matches("[A-Z2-9]{4}-[A-Z2-9]{4}")
+        assertThat(response.verificationUri).isEqualTo("https://openlog.kr/cli-login")
+        assertThat(response.verificationUriComplete)
+            .isEqualTo("https://openlog.kr/cli-login?code=${response.userCode}")
+        assertThat(response.expiresIn).isEqualTo(600)
+        assertThat(response.interval).isEqualTo(2)
+    }
+
+    @Test
+    fun `approve stores an issued access token for the device code`() {
+        val user = User(id = 7L, username = "kitae9999", nickname = "ASH")
+
+        given(valueOperations.get("auth:device:user:ABCD-2345")).willReturn("device-code")
+        given(valueOperations.get("auth:device:code:device-code")).willReturn("PENDING")
+        given(redisTemplate.getExpire("auth:device:code:device-code")).willReturn(120L)
+
+        deviceAuthService.approve("abcd-2345", user)
+
+        val invocation = mockingDetails(valueOperations).invocations.single {
+            it.method.name == "set" && it.arguments[0] == "auth:device:code:device-code"
+        }
+        val storedValue = invocation.arguments[1] as String
+        assertThat(storedValue).startsWith("APPROVED:")
+        assertThat(storedValue.removePrefix("APPROVED:")).isNotBlank()
+        assertThat(invocation.arguments[2]).isEqualTo(Duration.ofSeconds(120))
+        verify(redisTemplate).delete("auth:device:user:ABCD-2345")
+    }
+
+    @Test
+    fun `token returns pending while approval has not completed`() {
+        given(valueOperations.get("auth:device:code:device-code")).willReturn("PENDING")
+
+        val response = deviceAuthService.token("device-code")
+
+        assertThat(response.status).isEqualTo(DeviceTokenStatus.PENDING)
+        assertThat(response.interval).isEqualTo(2)
+        assertThat(response.accessToken).isNull()
+    }
+
+    @Test
+    fun `token consumes an approved access token`() {
+        given(valueOperations.get("auth:device:code:device-code")).willReturn("APPROVED:issued-token")
+
+        val response = deviceAuthService.token("device-code")
+
+        assertThat(response.status).isEqualTo(DeviceTokenStatus.APPROVED)
+        assertThat(response.accessToken).isEqualTo("issued-token")
+        assertThat(response.expiresIn).isEqualTo(3600)
+        verify(redisTemplate).delete("auth:device:code:device-code")
+    }
+
+    @Test
+    fun `approve rejects expired or unknown user code`() {
+        given(valueOperations.get("auth:device:user:ABCD-2345")).willReturn(null)
+
+        assertThatThrownBy {
+            deviceAuthService.approve(
+                userCode = "ABCD-2345",
+                currentUser = User(id = 7L, username = "kitae9999", nickname = "ASH"),
+            )
+        }.isInstanceOf(BadRequestException::class.java)
+    }
+}

--- a/frontend/app/cli-login/CliLoginApprovalForm.tsx
+++ b/frontend/app/cli-login/CliLoginApprovalForm.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useActionState } from "react";
+import {
+  approveCliLogin,
+  type CliLoginApprovalState,
+} from "@/app/cli-login/actions";
+
+const initialState: CliLoginApprovalState = {
+  status: "idle",
+  message: null,
+};
+
+export function CliLoginApprovalForm({
+  userCode,
+  accountLabel,
+}: {
+  userCode: string;
+  accountLabel: string;
+}) {
+  const [state, formAction, isPending] = useActionState(
+    approveCliLogin,
+    initialState,
+  );
+
+  return (
+    <form action={formAction} className="mt-8 flex flex-col gap-4">
+      <input type="hidden" name="userCode" value={userCode} />
+
+      <div className="rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">
+          Account
+        </p>
+        <p className="mt-1 text-sm font-medium text-zinc-950">
+          {accountLabel}
+        </p>
+      </div>
+
+      <button
+        type="submit"
+        disabled={isPending || state.status === "success"}
+        className="inline-flex h-12 items-center justify-center rounded-xl bg-zinc-950 px-5 text-sm font-semibold text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-300"
+      >
+        {isPending
+          ? "Approving..."
+          : state.status === "success"
+            ? "Approved"
+            : "Approve CLI login"}
+      </button>
+
+      {state.message ? (
+        <p
+          role={state.status === "error" ? "alert" : "status"}
+          className={
+            state.status === "error"
+              ? "text-sm font-medium text-red-700"
+              : "text-sm font-medium text-emerald-700"
+          }
+        >
+          {state.message}
+        </p>
+      ) : null}
+    </form>
+  );
+}
+

--- a/frontend/app/cli-login/actions.ts
+++ b/frontend/app/cli-login/actions.ts
@@ -1,0 +1,61 @@
+"use server";
+
+import { headers } from "next/headers";
+import { API_CONFIG } from "@/shared/api";
+
+export type CliLoginApprovalState = {
+  status: "idle" | "success" | "error";
+  message: string | null;
+};
+
+export async function approveCliLogin(
+  _prevState: CliLoginApprovalState,
+  formData: FormData,
+): Promise<CliLoginApprovalState> {
+  const userCode = String(formData.get("userCode") ?? "").trim();
+
+  if (!userCode) {
+    return {
+      status: "error",
+      message: "승인 코드가 없습니다.",
+    };
+  }
+
+  const headerStore = await headers();
+  const response = await fetch(`${API_CONFIG.baseURL}/auth/device/approve`, {
+    method: "POST",
+    cache: "no-store",
+    headers: {
+      "content-type": "application/json",
+      cookie: headerStore.get("cookie") ?? "",
+    },
+    body: JSON.stringify({ userCode }),
+  }).catch(() => null);
+
+  if (!response) {
+    return {
+      status: "error",
+      message: "OpenLog 서버에 연결할 수 없습니다.",
+    };
+  }
+
+  if (response.status === 204) {
+    return {
+      status: "success",
+      message: "CLI 로그인이 승인되었습니다. 터미널로 돌아가세요.",
+    };
+  }
+
+  let errorBody: { message?: string } | null = null;
+  try {
+    errorBody = (await response.json()) as { message?: string };
+  } catch {
+    errorBody = null;
+  }
+
+  return {
+    status: "error",
+    message: errorBody?.message ?? "CLI 로그인 승인에 실패했습니다.",
+  };
+}
+

--- a/frontend/app/cli-login/page.tsx
+++ b/frontend/app/cli-login/page.tsx
@@ -1,0 +1,171 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { getUser } from "@/features/auth/api/getUser";
+import { API_CONFIG } from "@/shared/api";
+import { CliLoginApprovalForm } from "./CliLoginApprovalForm";
+
+export const metadata: Metadata = {
+  title: "CLI Login | OpenLog",
+  description: "Approve OpenLog CLI access.",
+};
+
+export default async function CliLoginPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ code?: string }>;
+}) {
+  const sp = await searchParams;
+  const userCode = normalizeUserCode(sp?.code);
+  const user = await getOptionalUser();
+
+  return (
+    <main className="min-h-screen bg-[#f8fafc] px-5 py-10 text-zinc-950 sm:px-8">
+      <section className="mx-auto flex min-h-[calc(100vh-5rem)] w-full max-w-[720px] flex-col justify-center">
+        <div className="border border-zinc-200 bg-white p-7 shadow-[0_24px_80px_rgba(15,23,42,0.08)] sm:p-10">
+          <div className="flex items-start justify-between gap-6">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                OpenLog CLI
+              </p>
+              <h1 className="mt-3 text-3xl font-semibold tracking-normal text-zinc-950 sm:text-4xl">
+                Authorize terminal access
+              </h1>
+            </div>
+            <div className="grid size-12 shrink-0 place-items-center bg-zinc-950 text-xl font-bold text-white [font-family:Georgia,serif]">
+              O
+            </div>
+          </div>
+
+          <div className="mt-8 border-t border-zinc-200 pt-8">
+            {!userCode ? (
+              <InvalidCodeState />
+            ) : user ? (
+              user.isOnboardingComplete ? (
+                <ApproveState
+                  userCode={userCode}
+                  accountLabel={
+                    user.username ?? user.nickname ?? user.email ?? "OpenLog user"
+                  }
+                />
+              ) : (
+                <IncompleteOnboardingState />
+              )
+            ) : (
+              <LoginState userCode={userCode} />
+            )}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+async function getOptionalUser() {
+  try {
+    return await getUser();
+  } catch {
+    return null;
+  }
+}
+
+function ApproveState({
+  userCode,
+  accountLabel,
+}: {
+  userCode: string;
+  accountLabel: string;
+}) {
+  return (
+    <>
+      <div className="flex flex-col gap-3">
+        <p className="text-sm font-medium text-zinc-500">Approval code</p>
+        <code className="w-fit border border-zinc-200 bg-zinc-50 px-3 py-2 font-mono text-lg font-semibold tracking-[0.12em] text-zinc-950">
+          {userCode}
+        </code>
+      </div>
+
+      <CliLoginApprovalForm userCode={userCode} accountLabel={accountLabel} />
+    </>
+  );
+}
+
+function LoginState({ userCode }: { userCode: string }) {
+  const returnTo = `/cli-login?code=${encodeURIComponent(userCode)}`;
+  const googleHref = buildAuthHref("/auth/google", returnTo);
+  const githubHref = buildAuthHref("/auth/github", returnTo);
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div>
+        <p className="text-sm font-medium text-zinc-500">Approval code</p>
+        <code className="mt-3 inline-block border border-zinc-200 bg-zinc-50 px-3 py-2 font-mono text-lg font-semibold tracking-[0.12em] text-zinc-950">
+          {userCode}
+        </code>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <a
+          href={googleHref}
+          className="inline-flex h-12 items-center justify-center rounded-xl border border-zinc-200 bg-white px-5 text-sm font-semibold text-zinc-950 transition hover:bg-zinc-50"
+        >
+          Continue with Google
+        </a>
+        <a
+          href={githubHref}
+          className="inline-flex h-12 items-center justify-center rounded-xl bg-[#24292f] px-5 text-sm font-semibold text-white transition hover:bg-[#1b2027]"
+        >
+          Continue with GitHub
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function InvalidCodeState() {
+  return (
+    <div className="flex flex-col gap-5">
+      <p className="text-base leading-7 text-zinc-600">
+        CLI approval code is missing or invalid.
+      </p>
+      <Link
+        href="/"
+        className="inline-flex h-11 w-fit items-center justify-center rounded-xl border border-zinc-200 px-4 text-sm font-semibold text-zinc-950 transition hover:bg-zinc-50"
+      >
+        Go home
+      </Link>
+    </div>
+  );
+}
+
+function IncompleteOnboardingState() {
+  return (
+    <div className="flex flex-col gap-5">
+      <p className="text-base leading-7 text-zinc-600">
+        Finish your OpenLog profile before approving CLI access.
+      </p>
+      <Link
+        href="/onboarding"
+        className="inline-flex h-11 w-fit items-center justify-center rounded-xl bg-zinc-950 px-4 text-sm font-semibold text-white transition hover:bg-zinc-800"
+      >
+        Continue
+      </Link>
+    </div>
+  );
+}
+
+function normalizeUserCode(value: string | undefined): string | null {
+  const userCode = value?.trim().toUpperCase();
+
+  if (!userCode || !/^[A-Z2-9]{4}-[A-Z2-9]{4}$/.test(userCode)) {
+    return null;
+  }
+
+  return userCode;
+}
+
+function buildAuthHref(path: string, returnTo: string): string {
+  const url = new URL(`${API_CONFIG.baseURL.replace(/\/$/, "")}${path}`);
+  url.searchParams.set("returnTo", returnTo);
+
+  return url.toString();
+}

--- a/frontend/src/02_features/auth/api/handleOAuth.ts
+++ b/frontend/src/02_features/auth/api/handleOAuth.ts
@@ -3,10 +3,10 @@ import type { OAuthProvider } from "@/features/auth/model/auth.type";
 
 const providerOAuthPath = {
   GOOGLE: "/api/auth/google",
-  GITHUB: "/api/oauth2/authorization/github",
+  GITHUB: "/api/auth/github",
 } satisfies Record<OAuthProvider, string>;
 
-export const handleOAuth = (provider: OAuthProvider) => {
+export const handleOAuth = (provider: OAuthProvider, returnTo?: string) => {
   if (typeof window === "undefined") {
     return;
   }
@@ -15,6 +15,9 @@ export const handleOAuth = (provider: OAuthProvider) => {
     providerOAuthPath[provider],
     API_CONFIG.baseURL,
   );
+  if (returnTo) {
+    endpoint.searchParams.set("returnTo", returnTo);
+  }
 
   window.location.assign(endpoint.toString());
 };

--- a/packages/openlog-cli/.gitignore
+++ b/packages/openlog-cli/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+/dist
+*.tsbuildinfo
+

--- a/packages/openlog-cli/README.md
+++ b/packages/openlog-cli/README.md
@@ -15,6 +15,8 @@ MCP tools:
 - `list_my_notifications`
 - `list_my_posts`
 - `list_my_liked_posts`
+- `upload_post_image`
+- `publish_post`
 - `get_post_detail`
 
 MCP client configuration:
@@ -30,4 +32,5 @@ MCP client configuration:
 }
 ```
 
-Set `OPENLOG_API_BASE_URL` to point at a non-production API.
+Set `OPENLOG_API_BASE_URL` to point at a non-production API. Set
+`OPENLOG_WEB_BASE_URL` to control absolute post URLs returned by `publish_post`.

--- a/packages/openlog-cli/README.md
+++ b/packages/openlog-cli/README.md
@@ -1,0 +1,25 @@
+# OpenLog CLI
+
+Official CLI and MCP server for OpenLog.
+
+```bash
+npx -y openlog-cli login
+npx -y openlog-cli whoami
+npx -y openlog-cli mcp
+```
+
+MCP client configuration:
+
+```json
+{
+  "mcpServers": {
+    "openlog": {
+      "command": "npx",
+      "args": ["-y", "openlog-cli", "mcp"]
+    }
+  }
+}
+```
+
+Set `OPENLOG_API_BASE_URL` to point at a non-production API.
+

--- a/packages/openlog-cli/README.md
+++ b/packages/openlog-cli/README.md
@@ -3,9 +3,9 @@
 Official CLI and MCP server for OpenLog.
 
 ```bash
-npx -y openlog-cli login
-npx -y openlog-cli whoami
-npx -y openlog-cli mcp
+npx -y @kitae9999/openlog-cli login
+npx -y @kitae9999/openlog-cli whoami
+npx -y @kitae9999/openlog-cli mcp
 ```
 
 MCP client configuration:
@@ -15,11 +15,10 @@ MCP client configuration:
   "mcpServers": {
     "openlog": {
       "command": "npx",
-      "args": ["-y", "openlog-cli", "mcp"]
+      "args": ["-y", "@kitae9999/openlog-cli", "mcp"]
     }
   }
 }
 ```
 
 Set `OPENLOG_API_BASE_URL` to point at a non-production API.
-

--- a/packages/openlog-cli/README.md
+++ b/packages/openlog-cli/README.md
@@ -8,6 +8,15 @@ npx -y @kitae9999/openlog-cli whoami
 npx -y @kitae9999/openlog-cli mcp
 ```
 
+MCP tools:
+
+- `get_auth_status`
+- `get_me`
+- `list_my_notifications`
+- `list_my_posts`
+- `list_my_liked_posts`
+- `get_post_detail`
+
 MCP client configuration:
 
 ```json

--- a/packages/openlog-cli/package-lock.json
+++ b/packages/openlog-cli/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@kitae9999/openlog-cli",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kitae9999/openlog-cli",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "sharp": "^0.34.5",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -21,6 +22,16 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -477,6 +488,471 @@
         "hono": "^4"
       }
     },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -730,6 +1206,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -1424,6 +1909,18 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
@@ -1474,6 +1971,50 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -1585,6 +2126,13 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsx": {
       "version": "4.22.0",

--- a/packages/openlog-cli/package-lock.json
+++ b/packages/openlog-cli/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "openlog-cli",
+  "name": "@kitae9999/openlog-cli",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "openlog-cli",
+      "name": "@kitae9999/openlog-cli",
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/openlog-cli/package-lock.json
+++ b/packages/openlog-cli/package-lock.json
@@ -1,0 +1,1719 @@
+{
+  "name": "openlog-cli",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "openlog-cli",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.4.3"
+      },
+      "bin": {
+        "openlog": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^25.8.0",
+        "tsx": "^4.22.0",
+        "typescript": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
+      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.0.tgz",
+      "integrity": "sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/packages/openlog-cli/package-lock.json
+++ b/packages/openlog-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kitae9999/openlog-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kitae9999/openlog-cli",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3"

--- a/packages/openlog-cli/package.json
+++ b/packages/openlog-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitae9999/openlog-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "description": "Official OpenLog CLI and MCP server.",
   "type": "module",

--- a/packages/openlog-cli/package.json
+++ b/packages/openlog-cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "openlog-cli",
+  "name": "@kitae9999/openlog-cli",
   "version": "0.1.0",
   "private": false,
   "description": "Official OpenLog CLI and MCP server.",

--- a/packages/openlog-cli/package.json
+++ b/packages/openlog-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitae9999/openlog-cli",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": false,
   "description": "Official OpenLog CLI and MCP server.",
   "type": "module",
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "sharp": "^0.34.5",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/openlog-cli/package.json
+++ b/packages/openlog-cli/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "openlog-cli",
+  "version": "0.1.0",
+  "private": false,
+  "description": "Official OpenLog CLI and MCP server.",
+  "type": "module",
+  "bin": {
+    "openlog": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc && chmod 755 dist/index.js",
+    "dev": "tsx src/index.ts",
+    "prepack": "npm run build",
+    "start": "node dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^25.8.0",
+    "tsx": "^4.22.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/openlog-cli/package.json
+++ b/packages/openlog-cli/package.json
@@ -4,8 +4,13 @@
   "private": false,
   "description": "Official OpenLog CLI and MCP server.",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kitae9999/OpenLog.git",
+    "directory": "packages/openlog-cli"
+  },
   "bin": {
-    "openlog": "./dist/index.js"
+    "openlog": "dist/index.js"
   },
   "scripts": {
     "build": "tsc && chmod 755 dist/index.js",

--- a/packages/openlog-cli/src/api-client.ts
+++ b/packages/openlog-cli/src/api-client.ts
@@ -45,6 +45,14 @@ export class OpenLogApiClient {
     });
   }
 
+  async patchNoContent(path: string, body?: unknown): Promise<void> {
+    await this.request<void>(path, {
+      method: "PATCH",
+      headers: body ? { "content-type": "application/json" } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  }
+
   private async request<T>(path: string, init: RequestInit): Promise<T> {
     const url = `${this.apiBaseUrl}${path}`;
     const response = await fetch(url, {

--- a/packages/openlog-cli/src/api-client.ts
+++ b/packages/openlog-cli/src/api-client.ts
@@ -3,6 +3,7 @@ import { getApiBaseUrl } from "./config.js";
 export class ApiError extends Error {
   constructor(
     readonly status: number,
+    readonly url: string,
     message: string,
   ) {
     super(message);
@@ -45,7 +46,8 @@ export class OpenLogApiClient {
   }
 
   private async request<T>(path: string, init: RequestInit): Promise<T> {
-    const response = await fetch(`${this.apiBaseUrl}${path}`, {
+    const url = `${this.apiBaseUrl}${path}`;
+    const response = await fetch(url, {
       ...init,
       headers: {
         ...(init.headers ?? {}),
@@ -56,7 +58,7 @@ export class OpenLogApiClient {
     });
 
     if (!response.ok) {
-      throw new ApiError(response.status, await readErrorMessage(response));
+      throw new ApiError(response.status, url, await readErrorMessage(response));
     }
 
     if (response.status === 204) {
@@ -75,4 +77,3 @@ async function readErrorMessage(response: Response): Promise<string> {
     return `OpenLog API request failed with ${response.status}`;
   }
 }
-

--- a/packages/openlog-cli/src/api-client.ts
+++ b/packages/openlog-cli/src/api-client.ts
@@ -1,0 +1,78 @@
+import { getApiBaseUrl } from "./config.js";
+
+export class ApiError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+export type OpenLogApiClientOptions = {
+  accessToken?: string;
+  apiBaseUrl?: string;
+};
+
+export class OpenLogApiClient {
+  private readonly apiBaseUrl: string;
+  private readonly accessToken?: string;
+
+  constructor(options: OpenLogApiClientOptions = {}) {
+    this.apiBaseUrl = (options.apiBaseUrl ?? getApiBaseUrl()).replace(/\/$/, "");
+    this.accessToken = options.accessToken;
+  }
+
+  async get<T>(path: string): Promise<T> {
+    return this.request<T>(path, { method: "GET" });
+  }
+
+  async post<T>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>(path, {
+      method: "POST",
+      headers: body ? { "content-type": "application/json" } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  }
+
+  async postNoContent(path: string, body?: unknown): Promise<void> {
+    await this.request<void>(path, {
+      method: "POST",
+      headers: body ? { "content-type": "application/json" } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  }
+
+  private async request<T>(path: string, init: RequestInit): Promise<T> {
+    const response = await fetch(`${this.apiBaseUrl}${path}`, {
+      ...init,
+      headers: {
+        ...(init.headers ?? {}),
+        ...(this.accessToken
+          ? { cookie: `openlog_access_token=${this.accessToken}` }
+          : {}),
+      },
+    });
+
+    if (!response.ok) {
+      throw new ApiError(response.status, await readErrorMessage(response));
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    return (await response.json()) as T;
+  }
+}
+
+async function readErrorMessage(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as { message?: string };
+    return body.message ?? `OpenLog API request failed with ${response.status}`;
+  } catch {
+    return `OpenLog API request failed with ${response.status}`;
+  }
+}
+

--- a/packages/openlog-cli/src/auth-store.ts
+++ b/packages/openlog-cli/src/auth-store.ts
@@ -1,0 +1,59 @@
+import { mkdir, readFile, rm, writeFile, chmod } from "node:fs/promises";
+import path from "node:path";
+import { getApiBaseUrl, getAuthFilePath } from "./config.js";
+
+export type AuthFile = {
+  accessToken: string;
+  apiBaseUrl: string;
+  createdAt: string;
+};
+
+export async function readAuthFile(): Promise<AuthFile | null> {
+  try {
+    const content = await readFile(getAuthFilePath(), "utf8");
+    const parsed = JSON.parse(content) as Partial<AuthFile>;
+
+    if (!parsed.accessToken || !parsed.apiBaseUrl || !parsed.createdAt) {
+      return null;
+    }
+
+    return {
+      accessToken: parsed.accessToken,
+      apiBaseUrl: parsed.apiBaseUrl,
+      createdAt: parsed.createdAt,
+    };
+  } catch (error) {
+    if (
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+export async function writeAuthFile(accessToken: string): Promise<AuthFile> {
+  const authFile: AuthFile = {
+    accessToken,
+    apiBaseUrl: getApiBaseUrl(),
+    createdAt: new Date().toISOString(),
+  };
+  const authFilePath = getAuthFilePath();
+
+  await mkdir(path.dirname(authFilePath), { recursive: true, mode: 0o700 });
+  await writeFile(authFilePath, `${JSON.stringify(authFile, null, 2)}\n`, {
+    mode: 0o600,
+  });
+  await chmod(authFilePath, 0o600);
+
+  return authFile;
+}
+
+export async function deleteAuthFile(): Promise<void> {
+  await rm(getAuthFilePath(), { force: true });
+}
+

--- a/packages/openlog-cli/src/browser.ts
+++ b/packages/openlog-cli/src/browser.ts
@@ -1,0 +1,24 @@
+import { spawn } from "node:child_process";
+
+export function openBrowser(url: string): boolean {
+  const command =
+    process.platform === "darwin"
+      ? "open"
+      : process.platform === "win32"
+        ? "cmd"
+        : "xdg-open";
+  const args =
+    process.platform === "win32" ? ["/c", "start", "", url] : [url];
+
+  try {
+    const child = spawn(command, args, {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+    return true;
+  } catch {
+    return false;
+  }
+}
+

--- a/packages/openlog-cli/src/config.ts
+++ b/packages/openlog-cli/src/config.ts
@@ -1,7 +1,7 @@
 import os from "node:os";
 import path from "node:path";
 
-const DEFAULT_API_BASE_URL = "https://api.openlog.kr/api";
+export const DEFAULT_API_BASE_URL = "https://api.openlog.kr/api";
 
 export function getApiBaseUrl(): string {
   return (process.env.OPENLOG_API_BASE_URL ?? DEFAULT_API_BASE_URL).replace(
@@ -16,4 +16,3 @@ export function getAuthFilePath(): string {
     path.join(os.homedir(), ".openlog", "auth.json")
   );
 }
-

--- a/packages/openlog-cli/src/config.ts
+++ b/packages/openlog-cli/src/config.ts
@@ -2,9 +2,17 @@ import os from "node:os";
 import path from "node:path";
 
 export const DEFAULT_API_BASE_URL = "https://api.openlog.kr/api";
+export const DEFAULT_WEB_BASE_URL = "https://openlog.kr";
 
 export function getApiBaseUrl(): string {
   return (process.env.OPENLOG_API_BASE_URL ?? DEFAULT_API_BASE_URL).replace(
+    /\/$/,
+    "",
+  );
+}
+
+export function getWebBaseUrl(): string {
+  return (process.env.OPENLOG_WEB_BASE_URL ?? DEFAULT_WEB_BASE_URL).replace(
     /\/$/,
     "",
   );

--- a/packages/openlog-cli/src/config.ts
+++ b/packages/openlog-cli/src/config.ts
@@ -1,0 +1,19 @@
+import os from "node:os";
+import path from "node:path";
+
+const DEFAULT_API_BASE_URL = "https://api.openlog.kr/api";
+
+export function getApiBaseUrl(): string {
+  return (process.env.OPENLOG_API_BASE_URL ?? DEFAULT_API_BASE_URL).replace(
+    /\/$/,
+    "",
+  );
+}
+
+export function getAuthFilePath(): string {
+  return (
+    process.env.OPENLOG_AUTH_FILE ??
+    path.join(os.homedir(), ".openlog", "auth.json")
+  );
+}
+

--- a/packages/openlog-cli/src/index.ts
+++ b/packages/openlog-cli/src/index.ts
@@ -3,9 +3,11 @@
 import { deleteAuthFile, readAuthFile } from "./auth-store.js";
 import { login } from "./login.js";
 import { runMcpServer } from "./mcp-server.js";
+import { installMcp, printMcpInstallHelp } from "./mcp-install.js";
 import { ApiError, OpenLogApiClient } from "./api-client.js";
 
 const command = process.argv[2] ?? "help";
+const subcommand = process.argv[3];
 
 try {
   if (command === "login") {
@@ -16,8 +18,19 @@ try {
   } else if (command === "whoami") {
     await whoami();
   } else if (command === "mcp") {
-    printMcpStartupHint();
-    await runMcpServer();
+    if (subcommand === "install") {
+      await installMcpCommand();
+    } else if (
+      subcommand === undefined ||
+      subcommand === "serve" ||
+      subcommand === "start"
+    ) {
+      printMcpStartupHint();
+      await runMcpServer();
+    } else {
+      printMcpInstallHelp();
+      process.exit(1);
+    }
   } else {
     printHelp();
     process.exit(command === "help" || command === "--help" || command === "-h" ? 0 : 1);
@@ -25,6 +38,25 @@ try {
 } catch (error) {
   console.error(formatCliError(error));
   process.exit(1);
+}
+
+async function installMcpCommand(): Promise<void> {
+  const client = process.argv[4];
+  const printOnly = process.argv.includes("--print");
+
+  if (
+    client !== "codex" &&
+    client !== "claude-code" &&
+    client !== "claude"
+  ) {
+    printMcpInstallHelp();
+    process.exit(1);
+  }
+
+  await installMcp({
+    client,
+    printOnly,
+  });
 }
 
 async function whoami(): Promise<void> {
@@ -80,6 +112,10 @@ Usage:
   openlog logout   Remove local OpenLog credentials
   openlog whoami   Print the current OpenLog user
   openlog mcp      Start the OpenLog MCP stdio server
+  openlog mcp install codex
+                  Register OpenLog MCP with Codex
+  openlog mcp install claude-code
+                  Register OpenLog MCP with Claude Code
 
 Environment:
   OPENLOG_API_BASE_URL  Override the OpenLog API base URL

--- a/packages/openlog-cli/src/index.ts
+++ b/packages/openlog-cli/src/index.ts
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+import { deleteAuthFile, readAuthFile } from "./auth-store.js";
+import { login } from "./login.js";
+import { runMcpServer } from "./mcp-server.js";
+import { OpenLogApiClient } from "./api-client.js";
+
+const command = process.argv[2] ?? "help";
+
+try {
+  if (command === "login") {
+    await login();
+  } else if (command === "logout") {
+    await deleteAuthFile();
+    console.log("Logged out.");
+  } else if (command === "whoami") {
+    await whoami();
+  } else if (command === "mcp") {
+    await runMcpServer();
+  } else {
+    printHelp();
+    process.exit(command === "help" || command === "--help" || command === "-h" ? 0 : 1);
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+
+async function whoami(): Promise<void> {
+  const authFile = await readAuthFile();
+
+  if (!authFile) {
+    throw new Error("Not logged in. Run `openlog login` first.");
+  }
+
+  const apiClient = new OpenLogApiClient({
+    accessToken: authFile.accessToken,
+    apiBaseUrl: authFile.apiBaseUrl,
+  });
+  const me = await apiClient.get("/auth/me");
+
+  console.log(JSON.stringify(me, null, 2));
+}
+
+function printHelp(): void {
+  console.log(`OpenLog CLI
+
+Usage:
+  openlog login    Sign in to OpenLog from the CLI
+  openlog logout   Remove local OpenLog credentials
+  openlog whoami   Print the current OpenLog user
+  openlog mcp      Start the OpenLog MCP stdio server
+
+Environment:
+  OPENLOG_API_BASE_URL  Override the OpenLog API base URL
+  OPENLOG_AUTH_FILE     Override the local auth file path
+`);
+}
+

--- a/packages/openlog-cli/src/index.ts
+++ b/packages/openlog-cli/src/index.ts
@@ -99,6 +99,7 @@ Available tools:
   get_auth_status
   get_me
   list_my_notifications
+  list_my_posts
   list_my_liked_posts
   get_post_detail
 `);

--- a/packages/openlog-cli/src/index.ts
+++ b/packages/openlog-cli/src/index.ts
@@ -101,6 +101,8 @@ Available tools:
   list_my_notifications
   list_my_posts
   list_my_liked_posts
+  upload_post_image
+  publish_post
   get_post_detail
 `);
 }
@@ -120,6 +122,7 @@ Usage:
 
 Environment:
   OPENLOG_API_BASE_URL  Override the OpenLog API base URL
+  OPENLOG_WEB_BASE_URL  Override the OpenLog web base URL for published post links
   OPENLOG_AUTH_FILE     Override the local auth file path
 `);
 }

--- a/packages/openlog-cli/src/index.ts
+++ b/packages/openlog-cli/src/index.ts
@@ -3,7 +3,7 @@
 import { deleteAuthFile, readAuthFile } from "./auth-store.js";
 import { login } from "./login.js";
 import { runMcpServer } from "./mcp-server.js";
-import { OpenLogApiClient } from "./api-client.js";
+import { ApiError, OpenLogApiClient } from "./api-client.js";
 
 const command = process.argv[2] ?? "help";
 
@@ -16,13 +16,14 @@ try {
   } else if (command === "whoami") {
     await whoami();
   } else if (command === "mcp") {
+    printMcpStartupHint();
     await runMcpServer();
   } else {
     printHelp();
     process.exit(command === "help" || command === "--help" || command === "-h" ? 0 : 1);
   }
 } catch (error) {
-  console.error(error instanceof Error ? error.message : String(error));
+  console.error(formatCliError(error));
   process.exit(1);
 }
 
@@ -42,6 +43,35 @@ async function whoami(): Promise<void> {
   console.log(JSON.stringify(me, null, 2));
 }
 
+function printMcpStartupHint(): void {
+  if (!process.stderr.isTTY) {
+    return;
+  }
+
+  console.error(`OpenLog MCP server is running over stdio.
+
+This terminal is now reserved for MCP protocol traffic.
+Press Ctrl+C to stop it.
+
+To use it from an MCP client, add:
+{
+  "mcpServers": {
+    "openlog": {
+      "command": "openlog",
+      "args": ["mcp"]
+    }
+  }
+}
+
+Available tools:
+  get_auth_status
+  get_me
+  list_my_notifications
+  list_my_liked_posts
+  get_post_detail
+`);
+}
+
 function printHelp(): void {
   console.log(`OpenLog CLI
 
@@ -57,3 +87,14 @@ Environment:
 `);
 }
 
+function formatCliError(error: unknown): string {
+  if (error instanceof ApiError && error.status === 404) {
+    const hint = error.url.includes("localhost:8080/auth/")
+      ? "\n\nLocal hint: if your backend uses SERVER_SERVLET_CONTEXT_PATH=/api, run with OPENLOG_API_BASE_URL=http://localhost:8080/api."
+      : "";
+
+    return `${error.message}\nRequested: ${error.url}${hint}`;
+  }
+
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/openlog-cli/src/login.ts
+++ b/packages/openlog-cli/src/login.ts
@@ -1,0 +1,80 @@
+import { OpenLogApiClient } from "./api-client.js";
+import { openBrowser } from "./browser.js";
+import { writeAuthFile } from "./auth-store.js";
+
+type DeviceStartResponse = {
+  deviceCode: string;
+  userCode: string;
+  verificationUri: string;
+  verificationUriComplete: string;
+  expiresIn: number;
+  interval: number;
+};
+
+type DeviceTokenResponse =
+  | {
+      status: "PENDING";
+      interval?: number;
+    }
+  | {
+      status: "APPROVED";
+      accessToken: string;
+      expiresIn: number;
+    };
+
+export async function login(): Promise<void> {
+  const apiClient = new OpenLogApiClient();
+  const deviceLogin = await apiClient.post<DeviceStartResponse>(
+    "/auth/device/start",
+  );
+  const opened = openBrowser(deviceLogin.verificationUriComplete);
+
+  console.log("OpenLog CLI login");
+  console.log("");
+  console.log(`Code: ${deviceLogin.userCode}`);
+  console.log(`URL:  ${deviceLogin.verificationUriComplete}`);
+  console.log("");
+  console.log(
+    opened
+      ? "The approval page was opened in your browser."
+      : "Open the URL above in your browser.",
+  );
+  console.log("Waiting for approval...");
+
+  const accessToken = await pollForAccessToken(apiClient, deviceLogin);
+  await writeAuthFile(accessToken);
+
+  console.log("Login successful.");
+}
+
+async function pollForAccessToken(
+  apiClient: OpenLogApiClient,
+  deviceLogin: DeviceStartResponse,
+): Promise<string> {
+  const deadline = Date.now() + deviceLogin.expiresIn * 1000;
+  let interval = deviceLogin.interval;
+
+  while (Date.now() < deadline) {
+    await sleep(interval * 1000);
+
+    const response = await apiClient.post<DeviceTokenResponse>(
+      "/auth/device/token",
+      { deviceCode: deviceLogin.deviceCode },
+    );
+
+    if (response.status === "APPROVED") {
+      return response.accessToken;
+    }
+
+    interval = response.interval ?? interval;
+  }
+
+  throw new Error("CLI login expired before approval completed.");
+}
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+

--- a/packages/openlog-cli/src/mcp-install.ts
+++ b/packages/openlog-cli/src/mcp-install.ts
@@ -1,0 +1,215 @@
+import { spawn } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DEFAULT_API_BASE_URL, getApiBaseUrl } from "./config.js";
+
+type McpInstallClient = "codex" | "claude-code" | "claude";
+
+type McpInstallOptions = {
+  client: McpInstallClient;
+  printOnly: boolean;
+};
+
+type ServerConfig = {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+};
+
+export async function installMcp(options: McpInstallOptions): Promise<void> {
+  const serverConfig = buildServerConfig();
+
+  if (options.printOnly) {
+    printConfig(options.client, serverConfig);
+    return;
+  }
+
+  if (options.client === "codex") {
+    await installCodex(serverConfig);
+    return;
+  }
+
+  await installClaudeCode(serverConfig);
+}
+
+export function printMcpInstallHelp(): void {
+  console.log(`OpenLog MCP install
+
+Usage:
+  openlog mcp install codex
+  openlog mcp install claude-code
+  openlog mcp install codex --print
+  openlog mcp install claude-code --print
+
+Aliases:
+  claude      Same as claude-code
+
+Notes:
+  If OPENLOG_API_BASE_URL is set, it is added to the client config.
+`);
+}
+
+function buildServerConfig(): ServerConfig {
+  const apiBaseUrl = getApiBaseUrl();
+  const env: Record<string, string> = {};
+  if (apiBaseUrl !== DEFAULT_API_BASE_URL) {
+    env.OPENLOG_API_BASE_URL = apiBaseUrl;
+  }
+
+  return {
+    command: "openlog",
+    args: ["mcp"],
+    env,
+  };
+}
+
+async function installCodex(serverConfig: ServerConfig): Promise<void> {
+  const args = ["mcp", "add", "openlog"];
+  for (const [name, value] of Object.entries(serverConfig.env)) {
+    args.push("--env", `${name}=${value}`);
+  }
+  args.push("--", serverConfig.command, ...serverConfig.args);
+
+  const result = await runCommand("codex", args);
+  if (result === "executed") {
+    console.log("OpenLog MCP server registered with Codex.");
+    console.log("Run `/mcp` inside Codex to confirm it is connected.");
+    return;
+  }
+
+  await writeCodexConfig(serverConfig);
+  console.log("OpenLog MCP server added to ~/.codex/config.toml.");
+  console.log("Restart Codex or reload MCP servers, then run `/mcp` to confirm.");
+}
+
+async function installClaudeCode(serverConfig: ServerConfig): Promise<void> {
+  const args = ["mcp", "add", "--transport", "stdio", "--scope", "user"];
+  for (const [name, value] of Object.entries(serverConfig.env)) {
+    args.push("--env", `${name}=${value}`);
+  }
+  args.push("openlog", "--", serverConfig.command, ...serverConfig.args);
+
+  const result = await runCommand("claude", args);
+  if (result !== "executed") {
+    throw new Error(
+      "Claude Code CLI was not found. Install Claude Code first, then run `openlog mcp install claude-code` again.",
+    );
+  }
+
+  console.log("OpenLog MCP server registered with Claude Code.");
+  console.log("Run `/mcp` inside Claude Code to confirm it is connected.");
+}
+
+async function writeCodexConfig(serverConfig: ServerConfig): Promise<void> {
+  const configPath = path.join(os.homedir(), ".codex", "config.toml");
+  await mkdir(path.dirname(configPath), { recursive: true, mode: 0o700 });
+
+  const currentConfig = await readTextIfExists(configPath);
+  const nextConfig = upsertCodexServerBlock(currentConfig, serverConfig);
+  await writeFile(configPath, nextConfig, { mode: 0o600 });
+}
+
+function upsertCodexServerBlock(
+  currentConfig: string,
+  serverConfig: ServerConfig,
+): string {
+  const block = buildCodexServerBlock(serverConfig);
+  const blockPattern =
+    /(?:^|\n)\[mcp_servers\.openlog]\n[\s\S]*?(?:\n\[mcp_servers\.openlog\.env]\n[\s\S]*?)?(?=\n\[(?!mcp_servers\.openlog(?:\.env)?])[^\]]+]|\s*$)/;
+
+  if (blockPattern.test(currentConfig)) {
+    return currentConfig.replace(blockPattern, `\n${block}`).trimStart() + "\n";
+  }
+
+  const separator = currentConfig.trim().length === 0 ? "" : "\n\n";
+  return `${currentConfig.trimEnd()}${separator}${block}\n`;
+}
+
+function buildCodexServerBlock(serverConfig: ServerConfig): string {
+  const lines = [
+    "[mcp_servers.openlog]",
+    `command = ${tomlString(serverConfig.command)}`,
+    `args = [${serverConfig.args.map(tomlString).join(", ")}]`,
+  ];
+
+  if (Object.keys(serverConfig.env).length > 0) {
+    lines.push("");
+    lines.push("[mcp_servers.openlog.env]");
+    for (const [name, value] of Object.entries(serverConfig.env)) {
+      lines.push(`${name} = ${tomlString(value)}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function printConfig(client: McpInstallClient, serverConfig: ServerConfig): void {
+  if (client === "codex") {
+    console.log(buildCodexServerBlock(serverConfig));
+    return;
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        type: "stdio",
+        command: serverConfig.command,
+        args: serverConfig.args,
+        env: serverConfig.env,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+async function readTextIfExists(filePath: string): Promise<string> {
+  try {
+    return await readFile(filePath, "utf8");
+  } catch (error) {
+    if (
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return "";
+    }
+
+    throw error;
+  }
+}
+
+function tomlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+async function runCommand(
+  command: string,
+  args: string[],
+): Promise<"executed" | "missing"> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: "inherit",
+    });
+
+    child.on("error", (error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") {
+        resolve("missing");
+        return;
+      }
+
+      reject(error);
+    });
+
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve("executed");
+        return;
+      }
+
+      reject(new Error(`${command} exited with code ${code}.`));
+    });
+  });
+}

--- a/packages/openlog-cli/src/mcp-install.ts
+++ b/packages/openlog-cli/src/mcp-install.ts
@@ -2,7 +2,12 @@ import { spawn, type StdioOptions } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { DEFAULT_API_BASE_URL, getApiBaseUrl } from "./config.js";
+import {
+  DEFAULT_API_BASE_URL,
+  DEFAULT_WEB_BASE_URL,
+  getApiBaseUrl,
+  getWebBaseUrl,
+} from "./config.js";
 
 type McpInstallClient = "codex" | "claude-code" | "claude";
 
@@ -46,15 +51,19 @@ Aliases:
   claude      Same as claude-code
 
 Notes:
-  If OPENLOG_API_BASE_URL is set, it is added to the client config.
+  If OPENLOG_API_BASE_URL or OPENLOG_WEB_BASE_URL is set, it is added to the client config.
 `);
 }
 
 function buildServerConfig(): ServerConfig {
   const apiBaseUrl = getApiBaseUrl();
+  const webBaseUrl = getWebBaseUrl();
   const env: Record<string, string> = {};
   if (apiBaseUrl !== DEFAULT_API_BASE_URL) {
     env.OPENLOG_API_BASE_URL = apiBaseUrl;
+  }
+  if (webBaseUrl !== DEFAULT_WEB_BASE_URL) {
+    env.OPENLOG_WEB_BASE_URL = webBaseUrl;
   }
 
   return {

--- a/packages/openlog-cli/src/mcp-install.ts
+++ b/packages/openlog-cli/src/mcp-install.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, type StdioOptions } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -71,8 +71,15 @@ async function installCodex(serverConfig: ServerConfig): Promise<void> {
   }
   args.push("--", serverConfig.command, ...serverConfig.args);
 
-  const result = await runCommand("codex", args);
-  if (result === "executed") {
+  let registeredWithCodexCli = false;
+  try {
+    registeredWithCodexCli =
+      (await runCommand("codex", args, { stdio: "pipe" })) === "executed";
+  } catch (error) {
+    warnCodexFallback(error);
+  }
+
+  if (registeredWithCodexCli) {
     console.log("OpenLog MCP server registered with Codex.");
     console.log("Run `/mcp` inside Codex to confirm it is connected.");
     return;
@@ -185,13 +192,38 @@ function tomlString(value: string): string {
   return JSON.stringify(value);
 }
 
+class CommandFailedError extends Error {
+  constructor(
+    command: string,
+    readonly exitCode: number | null,
+    readonly stderr: string,
+  ) {
+    super(`${command} exited with code ${exitCode ?? "unknown"}.`);
+  }
+}
+
+type RunCommandOptions = {
+  stdio?: "inherit" | "pipe";
+};
+
 async function runCommand(
   command: string,
   args: string[],
+  options: RunCommandOptions = {},
 ): Promise<"executed" | "missing"> {
   return new Promise((resolve, reject) => {
+    const stdioMode = options.stdio ?? "inherit";
+    const stdio: StdioOptions =
+      stdioMode === "pipe" ? ["ignore", "ignore", "pipe"] : "inherit";
+    let stderr = "";
+
     const child = spawn(command, args, {
-      stdio: "inherit",
+      stdio,
+    });
+
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
     });
 
     child.on("error", (error: NodeJS.ErrnoException) => {
@@ -209,7 +241,36 @@ async function runCommand(
         return;
       }
 
-      reject(new Error(`${command} exited with code ${code}.`));
+      reject(new CommandFailedError(command, code, stderr));
     });
   });
+}
+
+function warnCodexFallback(error: unknown): void {
+  const reason = summarizeCommandError(error);
+  const suffix = reason.length > 0 ? ` (${reason})` : "";
+  console.warn(
+    `Codex CLI registration failed${suffix}. Falling back to ~/.codex/config.toml.`,
+  );
+}
+
+function summarizeCommandError(error: unknown): string {
+  if (error instanceof CommandFailedError) {
+    const firstStderrLine = error.stderr
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find((line) => line.length > 0);
+
+    return truncateReason(firstStderrLine ?? error.message);
+  }
+
+  if (error instanceof Error) {
+    return truncateReason(error.message);
+  }
+
+  return truncateReason(String(error));
+}
+
+function truncateReason(reason: string): string {
+  return reason.length > 180 ? `${reason.slice(0, 177)}...` : reason;
 }

--- a/packages/openlog-cli/src/mcp-server.ts
+++ b/packages/openlog-cli/src/mcp-server.ts
@@ -3,12 +3,20 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import { OpenLogApiClient } from "./api-client.js";
 import { readAuthFile } from "./auth-store.js";
-import { getApiBaseUrl } from "./config.js";
+import { getApiBaseUrl, getWebBaseUrl } from "./config.js";
+import { uploadPostImage } from "./post-image-upload.js";
+
+const WRITE_TOOL_ANNOTATIONS = {
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: false,
+  openWorldHint: true,
+};
 
 export async function runMcpServer(): Promise<void> {
   const server = new McpServer({
     name: "openlog",
-    version: "0.1.1",
+    version: "0.2.0",
   });
 
   server.registerTool(
@@ -129,6 +137,99 @@ export async function runMcpServer(): Promise<void> {
   );
 
   server.registerTool(
+    "upload_post_image",
+    {
+      title: "Upload OpenLog Post Image",
+      description:
+        "Convert a local image file to WebP, upload it to OpenLog, and return markdown for post content.",
+      annotations: WRITE_TOOL_ANNOTATIONS,
+      inputSchema: {
+        filePath: z.string().min(1),
+        altText: z.string().optional(),
+      },
+    },
+    async ({ filePath, altText }) =>
+      withAuthenticatedClient((client) =>
+        uploadPostImage(client, {
+          filePath,
+          altText,
+        }),
+      ),
+  );
+
+  server.registerTool(
+    "publish_post",
+    {
+      title: "Publish OpenLog Post",
+      description:
+        "Publish a new post to the authenticated OpenLog account. Requires confirm: true unless skipConfirmation: true is explicitly provided.",
+      annotations: WRITE_TOOL_ANNOTATIONS,
+      inputSchema: {
+        title: z.string().min(1),
+        description: z.string().min(1),
+        content: z.string().min(1),
+        topics: z.array(z.string()).default([]),
+        links: z
+          .array(
+            z.object({
+              label: z.string().min(1),
+              targetSlug: z.string().min(1),
+            }),
+          )
+          .default([]),
+        confirm: z.boolean().optional(),
+        skipConfirmation: z.boolean().optional(),
+      },
+    },
+    async ({
+      title,
+      description,
+      content,
+      topics,
+      links,
+      confirm,
+      skipConfirmation,
+    }) =>
+      withAuthenticatedClient(async (client) => {
+        const post = normalizePostInput({
+          title,
+          description,
+          content,
+          topics,
+          links,
+        });
+
+        if (confirm !== true && skipConfirmation !== true) {
+          return {
+            requiresConfirmation: true,
+            preview: {
+              title: post.title,
+              description: post.description,
+              contentPreview: createContentPreview(post.content),
+              contentLength: post.content.length,
+              topics: post.topics,
+              links: post.links,
+            },
+            nextStep:
+              "Call publish_post again with confirm: true, or skipConfirmation: true if the user explicitly requested publishing without confirmation.",
+          };
+        }
+
+        const published = await client.post<PostWriteResponse>("/posts", post);
+        const postPath = buildPublicPostPath(
+          published.authorUsername,
+          published.slug,
+        );
+
+        return {
+          ...published,
+          path: postPath,
+          url: new URL(postPath, `${getWebBaseUrl()}/`).toString(),
+        };
+      }),
+  );
+
+  server.registerTool(
     "get_post_detail",
     {
       title: "Get OpenLog Post Detail",
@@ -148,6 +249,87 @@ export async function runMcpServer(): Promise<void> {
   );
 
   await server.connect(new StdioServerTransport());
+}
+
+type PostWriteResponse = {
+  authorUsername: string;
+  slug: string;
+};
+
+type PostLinkInput = {
+  label: string;
+  targetSlug: string;
+};
+
+type PostWriteInput = {
+  title: string;
+  description: string;
+  content: string;
+  topics: string[];
+  links: PostLinkInput[];
+};
+
+function normalizePostInput(input: PostWriteInput): PostWriteInput {
+  const title = input.title.trim();
+  const description = input.description.trim();
+  const content = input.content.trim();
+
+  if (!title) {
+    throw new Error("title is required.");
+  }
+
+  if (!description) {
+    throw new Error("description is required.");
+  }
+
+  if (!content) {
+    throw new Error("content is required.");
+  }
+
+  return {
+    title,
+    description,
+    content,
+    topics: normalizeTopics(input.topics),
+    links: normalizeLinks(input.links),
+  };
+}
+
+function normalizeTopics(topics: string[]): string[] {
+  const normalized = topics
+    .map((topic) => topic.trim().toLowerCase())
+    .filter(Boolean);
+
+  return [...new Set(normalized)];
+}
+
+function normalizeLinks(links: PostLinkInput[]): PostLinkInput[] {
+  const normalized: PostLinkInput[] = [];
+  const seen = new Set<string>();
+
+  for (const link of links) {
+    const label = link.label.trim();
+    const targetSlug = link.targetSlug.trim();
+    const key = `${label}\u0000${targetSlug}`;
+
+    if (!label || !targetSlug || seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    normalized.push({ label, targetSlug });
+  }
+
+  return normalized;
+}
+
+function createContentPreview(content: string): string {
+  const preview = content.replace(/\s+/g, " ").trim();
+  return preview.length > 500 ? `${preview.slice(0, 497)}...` : preview;
+}
+
+function buildPublicPostPath(username: string, slug: string): string {
+  return `/@${encodeURIComponent(username)}/posts/${encodeURIComponent(slug)}`;
 }
 
 async function createAuthenticatedClient(): Promise<OpenLogApiClient> {

--- a/packages/openlog-cli/src/mcp-server.ts
+++ b/packages/openlog-cli/src/mcp-server.ts
@@ -8,7 +8,7 @@ import { getApiBaseUrl } from "./config.js";
 export async function runMcpServer(): Promise<void> {
   const server = new McpServer({
     name: "openlog",
-    version: "0.1.0",
+    version: "0.1.1",
   });
 
   server.registerTool(
@@ -94,6 +94,38 @@ export async function runMcpServer(): Promise<void> {
         client.get(`/users/me/liked-posts?${params}`),
       );
     },
+  );
+
+  server.registerTool(
+    "list_my_posts",
+    {
+      title: "List My OpenLog Posts",
+      description: "Return posts authored by the authenticated OpenLog user.",
+      inputSchema: {
+        size: z.number().int().min(1).max(100).default(20),
+      },
+    },
+    async ({ size }) =>
+      withAuthenticatedClient(async (client) => {
+        const me = await client.get<{ username?: string | null }>("/auth/me");
+        const username = me.username?.trim();
+
+        if (!username) {
+          throw new Error("Complete OpenLog onboarding before listing your posts.");
+        }
+
+        const posts = await client.get<unknown[]>(
+          `/users/${encodeURIComponent(username)}/posts`,
+        );
+
+        return {
+          username,
+          total: posts.length,
+          size,
+          hasMore: posts.length > size,
+          posts: posts.slice(0, size),
+        };
+      }),
   );
 
   server.registerTool(

--- a/packages/openlog-cli/src/mcp-server.ts
+++ b/packages/openlog-cli/src/mcp-server.ts
@@ -1,0 +1,164 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { OpenLogApiClient } from "./api-client.js";
+import { readAuthFile } from "./auth-store.js";
+import { getApiBaseUrl } from "./config.js";
+
+export async function runMcpServer(): Promise<void> {
+  const server = new McpServer({
+    name: "openlog",
+    version: "0.1.0",
+  });
+
+  server.registerTool(
+    "get_auth_status",
+    {
+      title: "Get OpenLog Auth Status",
+      description: "Check whether the local OpenLog CLI is authenticated.",
+      inputSchema: {},
+    },
+    async () => {
+      let apiBaseUrl = getApiBaseUrl();
+      try {
+        const authFile = await readAuthFile();
+        if (!authFile) {
+          return textResult({
+            authenticated: false,
+            apiBaseUrl,
+          });
+        }
+        apiBaseUrl = authFile.apiBaseUrl;
+
+        const me = await createAuthenticatedClient().then((client) =>
+          client.get("/auth/me"),
+        );
+
+        return textResult({
+          authenticated: true,
+          apiBaseUrl: authFile.apiBaseUrl,
+          user: me,
+        });
+      } catch (error) {
+        return textResult({
+          authenticated: false,
+          apiBaseUrl,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+  );
+
+  server.registerTool(
+    "get_me",
+    {
+      title: "Get OpenLog Me",
+      description: "Return the currently authenticated OpenLog user.",
+      inputSchema: {},
+    },
+    async () => withAuthenticatedClient((client) => client.get("/auth/me")),
+  );
+
+  server.registerTool(
+    "list_my_notifications",
+    {
+      title: "List My OpenLog Notifications",
+      description: "Return notifications for the authenticated OpenLog user.",
+      inputSchema: {
+        size: z.number().int().min(1).max(20).default(20),
+      },
+    },
+    async ({ size }) =>
+      withAuthenticatedClient((client) =>
+        client.get(`/notifications?${new URLSearchParams({ size: String(size) })}`),
+      ),
+  );
+
+  server.registerTool(
+    "list_my_liked_posts",
+    {
+      title: "List My Liked OpenLog Posts",
+      description: "Return posts liked by the authenticated OpenLog user.",
+      inputSchema: {
+        cursor: z.string().optional(),
+        size: z.number().int().min(1).max(20).default(10),
+      },
+    },
+    async ({ cursor, size }) => {
+      const params = new URLSearchParams({ size: String(size) });
+      if (cursor) {
+        params.set("cursor", cursor);
+      }
+
+      return withAuthenticatedClient((client) =>
+        client.get(`/users/me/liked-posts?${params}`),
+      );
+    },
+  );
+
+  server.registerTool(
+    "get_post_detail",
+    {
+      title: "Get OpenLog Post Detail",
+      description:
+        "Return a public OpenLog post detail by author username and post slug.",
+      inputSchema: {
+        username: z.string().min(1),
+        slug: z.string().min(1),
+      },
+    },
+    async ({ username, slug }) =>
+      withAuthenticatedClient((client) =>
+        client.get(
+          `/users/${encodeURIComponent(username)}/posts/${encodeURIComponent(slug)}`,
+        ),
+      ),
+  );
+
+  await server.connect(new StdioServerTransport());
+}
+
+async function createAuthenticatedClient(): Promise<OpenLogApiClient> {
+  const authFile = await readAuthFile();
+
+  if (!authFile) {
+    throw new Error("Run `openlog login` before using OpenLog MCP tools.");
+  }
+
+  return new OpenLogApiClient({
+    accessToken: authFile.accessToken,
+    apiBaseUrl: authFile.apiBaseUrl,
+  });
+}
+
+async function withAuthenticatedClient(
+  callback: (client: OpenLogApiClient) => Promise<unknown>,
+) {
+  try {
+    const client = await createAuthenticatedClient();
+    const result = await callback(client);
+    return textResult(result);
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: error instanceof Error ? error.message : String(error),
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+function textResult(value: unknown) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text:
+          typeof value === "string" ? value : JSON.stringify(value, null, 2),
+      },
+    ],
+  };
+}

--- a/packages/openlog-cli/src/post-image-upload.ts
+++ b/packages/openlog-cli/src/post-image-upload.ts
@@ -1,0 +1,204 @@
+import { stat } from "node:fs/promises";
+import path from "node:path";
+import sharp from "sharp";
+import type { OpenLogApiClient } from "./api-client.js";
+
+const MAX_POST_IMAGE_WIDTH = 1600;
+const MAX_WEBP_BYTES = 10 * 1024 * 1024;
+const WEBP_QUALITY = 84;
+
+type UploadUrlResponse = {
+  assetId: string | number;
+  uploadUrl: string;
+  markdownUrl?: string;
+  assetUrl?: string;
+  imageUrl?: string;
+  publicUrl?: string;
+  headers?: Record<string, string>;
+};
+
+export type UploadedPostImage = {
+  assetId: string;
+  markdownUrl: string;
+  markdown: string;
+  altText: string;
+  originalFileName: string;
+  webpSizeBytes: number;
+};
+
+export async function uploadPostImage(
+  client: OpenLogApiClient,
+  {
+    filePath,
+    altText,
+  }: {
+    filePath: string;
+    altText?: string;
+  },
+): Promise<UploadedPostImage> {
+  const resolvedPath = resolveLocalPath(filePath);
+  const originalFileName = path.basename(resolvedPath);
+  const resolvedAltText = normalizeAltText(altText, originalFileName);
+
+  await assertReadableFile(resolvedPath);
+
+  const webp = await createWebpPostImage(resolvedPath);
+  if (webp.byteLength > MAX_WEBP_BYTES) {
+    throw new Error("Converted image must be 10 MB or smaller.");
+  }
+
+  const uploadTarget = await client.post<UploadUrlResponse>("/media/upload-url", {
+    fileName: `${sanitizeFileStem(resolvedAltText)}.webp`,
+    originalFileName,
+    contentType: "image/webp",
+    sizeBytes: webp.byteLength,
+    purpose: "POST_BODY_IMAGE",
+  });
+
+  await putImage(uploadTarget, webp);
+
+  const assetId = String(uploadTarget.assetId);
+  await client.patchNoContent(
+    `/media/assets/${encodeURIComponent(assetId)}/completion`,
+  );
+
+  const markdownUrl = getMarkdownUrl(uploadTarget);
+  if (!markdownUrl) {
+    throw new Error("Upload completed without a markdown image URL.");
+  }
+
+  return {
+    assetId,
+    markdownUrl,
+    markdown: `![${escapeMarkdownAltText(resolvedAltText)}](${markdownUrl})`,
+    altText: resolvedAltText,
+    originalFileName,
+    webpSizeBytes: webp.byteLength,
+  };
+}
+
+function resolveLocalPath(filePath: string): string {
+  const trimmedPath = filePath.trim();
+  if (!trimmedPath) {
+    throw new Error("filePath is required.");
+  }
+
+  return path.isAbsolute(trimmedPath)
+    ? trimmedPath
+    : path.resolve(process.cwd(), trimmedPath);
+}
+
+async function assertReadableFile(filePath: string): Promise<void> {
+  let fileStat;
+  try {
+    fileStat = await stat(filePath);
+  } catch {
+    throw new Error(`Image file does not exist: ${filePath}`);
+  }
+
+  if (!fileStat.isFile()) {
+    throw new Error(`Image path is not a file: ${filePath}`);
+  }
+}
+
+async function createWebpPostImage(filePath: string): Promise<Buffer> {
+  try {
+    return await sharp(filePath)
+      .rotate()
+      .resize({
+        width: MAX_POST_IMAGE_WIDTH,
+        withoutEnlargement: true,
+      })
+      .webp({ quality: WEBP_QUALITY })
+      .toBuffer();
+  } catch (error) {
+    const detail = error instanceof Error ? ` ${error.message}` : "";
+    throw new Error(`Could not convert image to WebP.${detail}`);
+  }
+}
+
+async function putImage(
+  uploadTarget: UploadUrlResponse,
+  webp: Buffer,
+): Promise<void> {
+  const response = await fetch(uploadTarget.uploadUrl, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "image/webp",
+      ...(uploadTarget.headers ?? {}),
+    },
+    body: new Uint8Array(webp),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Image upload failed with ${response.status}: ${await readResponseText(response)}`,
+    );
+  }
+}
+
+async function readResponseText(response: Response): Promise<string> {
+  const text = await response.text().catch(() => "");
+  return text.trim() || response.statusText || "No response body";
+}
+
+function getMarkdownUrl(uploadTarget: UploadUrlResponse): string | undefined {
+  if (uploadTarget.markdownUrl) {
+    return uploadTarget.markdownUrl;
+  }
+
+  if (uploadTarget.assetUrl) {
+    return uploadTarget.assetUrl;
+  }
+
+  if (uploadTarget.imageUrl) {
+    return uploadTarget.imageUrl;
+  }
+
+  if (uploadTarget.publicUrl) {
+    return uploadTarget.publicUrl;
+  }
+
+  if (uploadTarget.assetId !== undefined) {
+    return `/media/assets/${encodeURIComponent(String(uploadTarget.assetId))}`;
+  }
+
+  return undefined;
+}
+
+function normalizeAltText(
+  providedAltText: string | undefined,
+  originalFileName: string,
+): string {
+  const normalized = (providedAltText ?? "")
+    .trim()
+    .replace(/[\r\n]+/g, " ");
+
+  if (normalized) {
+    return normalized;
+  }
+
+  return stripExtension(originalFileName).replace(/[_-]+/g, " ").trim() || "image";
+}
+
+function sanitizeFileStem(value: string): string {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return normalized || "image";
+}
+
+function stripExtension(fileName: string): string {
+  return fileName.replace(/\.[^.]+$/, "");
+}
+
+function escapeMarkdownAltText(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/\[/g, "\\[")
+    .replace(/\]/g, "\\]")
+    .replace(/[\r\n]+/g, " ");
+}

--- a/packages/openlog-cli/tsconfig.json
+++ b/packages/openlog-cli/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #

---

## 1. PR 유형
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ✨ 새로운 기능 (New Feature)
- [ ] ♻️ 리팩토링 (Refactoring)
- [x] 📝 문서 업데이트 (Documentation)
- [x] ⚙️ 설정/빌드 변경 (Chore)

---

## 2. 변경 배경 및 목표
- **변경 전 상태:** OpenLog는 웹 로그인과 웹 화면 중심으로 동작했고, 외부 AI 클라이언트나 터미널에서 로그인 사용자의 OpenLog 데이터를 안전하게 조회하거나 활용할 수 있는 공식 CLI/MCP 진입점이 없었다.
- **문제/필요성:** Codex, Claude Code 같은 MCP 클라이언트에서 OpenLog 계정 데이터를 사용하려면 공개 배포 가능한 CLI 패키지, CLI용 로그인 승인 흐름, MCP tool 목록, 배포 자동화가 필요했다. 브라우저 쿠키를 CLI가 직접 읽지 않고 사용자가 웹에서 승인한 결과만 CLI에 전달하는 인증 흐름도 필요했다.
- **이번 PR의 목표:** `@kitae9999/openlog-cli` npm 패키지를 추가하고, `openlog login`으로 device login을 완료한 뒤 `openlog mcp`로 OpenLog MCP stdio server를 실행할 수 있게 한다. v1 read-only tool에 더해 로그인 계정의 글 목록 조회, 이미지 업로드, 새 글 발행 tool까지 제공하고, CLI 패키지 변경 시 npm publish가 가능한 CI/CD workflow를 추가한다.

---

## 3. 주요 구현 내용 및 동작 방식

### A. CLI device login 백엔드 및 승인 화면
- **관련 위치/대상:** `AuthController`, `AuthService`, `DeviceAuthService`, `GithubOAuthSuccessHandler`, `frontend/app/cli-login/*`
- **변경 전 상황:** CLI가 OpenLog 계정으로 로그인할 수 있는 별도 승인 흐름이 없었다. 기존 OAuth 흐름은 웹 로그인 완료 후 기본 홈/온보딩 이동만 처리했다.
- **변경한 내용:** device login API를 추가하고 Redis에 짧은 TTL의 device session을 저장하도록 했다. 프론트에는 `/cli-login?code={userCode}` 승인 화면을 추가했다. 이미 웹에 로그인되어 있으면 승인 버튼만 보여주고, 로그인되어 있지 않으면 Google/GitHub 로그인 후 동일 승인 화면으로 돌아오도록 `returnTo`를 연결했다.
- **변경 후 동작:** CLI는 `/auth/device/start`로 `deviceCode`, `userCode`, 승인 URL을 받고 브라우저를 연다. 사용자가 웹에서 승인하면 백엔드는 해당 device session에 JWT를 저장하고, CLI는 `/auth/device/token` polling 결과로 access token을 받아 `~/.openlog/auth.json`에 저장한다.
- **구현 흐름:**
  1. CLI가 device login을 시작하면 Redis에 `PENDING` device code와 user code mapping을 저장한다.
  2. 사용자는 `/cli-login` 화면에서 로그인 계정을 확인하고 user code를 승인한다.
  3. 승인 시 Redis 값이 `APPROVED:{jwt}`로 바뀌고 user code mapping은 삭제된다.
  4. CLI polling이 승인된 token을 한 번 수신하면 device code key를 삭제해 재사용을 막는다.
- **바뀌는 데이터/상태:** Redis에 `auth:device:code:*`, `auth:device:user:*` key가 TTL 10분으로 생성된다. CLI 인증 파일은 로컬 `~/.openlog/auth.json`에 `0600` 권한으로 저장된다.
- **영향 범위:** 웹 OAuth callback/redirect, CLI 로그인 UX, JWT cookie 기반 API 인증 흐름

### B. 공개 배포용 OpenLog CLI/MCP 패키지
- **관련 위치/대상:** `packages/openlog-cli`
- **변경 전 상황:** 공개 npm 패키지로 배포할 CLI/MCP 서버가 없었고, MCP 클라이언트에 등록할 표준 실행 명령도 없었다.
- **변경한 내용:** `@kitae9999/openlog-cli` 패키지를 추가하고 실행 bin을 `openlog`로 제공했다. CLI 명령은 `login`, `logout`, `whoami`, `mcp`, `mcp install codex`, `mcp install claude-code`를 지원한다. MCP 서버는 `@modelcontextprotocol/sdk`의 stdio transport를 사용한다.
- **변경 후 동작:** 사용자는 `npx -y @kitae9999/openlog-cli login`으로 로그인하고, MCP client 설정에는 `npx -y @kitae9999/openlog-cli mcp`를 등록할 수 있다. 로컬/운영 API는 `OPENLOG_API_BASE_URL`, 발행 글 URL은 `OPENLOG_WEB_BASE_URL`로 override할 수 있다.
- **구현 흐름:**
  1. CLI auth store는 device login으로 받은 JWT와 API base URL을 로컬 파일에 저장한다.
  2. API client는 저장된 JWT를 기존 백엔드 방식에 맞춰 `Cookie: openlog_access_token={token}`로 전달한다.
  3. MCP server는 저장된 인증 정보를 읽어 OpenLog API를 호출하고 JSON text result를 반환한다.
  4. `openlog mcp install ...`은 Codex/Claude Code MCP 설정에 `openlog mcp` command와 필요한 env를 등록한다.
- **바뀌는 데이터/상태:** 새 npm package lock과 dist build 대상이 추가된다. MCP tool 목록에는 인증 상태, 내 정보, 알림, 좋아요 글, 내 글, 글 상세 조회가 포함된다.
- **영향 범위:** CLI 사용자, MCP client 설정, OpenLog API 호출 방식, npm 패키지 배포 단위

### C. MCP 글 발행 및 이미지 업로드 tool
- **관련 위치/대상:** `packages/openlog-cli/src/mcp-server.ts`, `post-image-upload.ts`, `api-client.ts`
- **변경 전 상황:** MCP tool은 개인 데이터 조회 중심이었고, 로그인 계정으로 새 글을 발행하거나 글 본문용 이미지를 업로드할 수 없었다.
- **변경한 내용:** `publish_post`와 `upload_post_image` tool을 추가했다. `publish_post`는 기본적으로 preview와 `requiresConfirmation: true`를 반환하고, `confirm: true` 또는 `skipConfirmation: true`가 있을 때만 실제 `POST /posts`를 호출한다. `upload_post_image`는 로컬 이미지 파일을 `sharp`로 WebP 변환 후 기존 media upload URL API, signed URL PUT, completion PATCH 순서로 업로드한다.
- **변경 후 동작:** MCP client는 이미지가 필요한 경우 먼저 `upload_post_image`로 markdown image 구문을 만들고, 해당 markdown을 `publish_post.content`에 포함해 글을 발행할 수 있다. 발행 성공 응답에는 `authorUsername`, `slug`, `path`, `url`이 포함된다.
- **구현 흐름:**
  1. `upload_post_image`는 상대 경로를 MCP process `cwd` 기준으로 해석하고, 이미지를 최대 폭 1600px WebP quality 84로 변환한다.
  2. 변환 결과가 10MB 이하이면 `/media/upload-url`로 upload target을 받고 signed URL에 `PUT`한다.
  3. 업로드 완료 후 `/media/assets/{assetId}/completion`을 호출하고, 반환된 `markdownUrl`로 markdown 문자열을 만든다.
  4. `publish_post`는 title, description, content, topics, links를 정규화하고 확인 필드가 있을 때만 `/posts`에 body를 전달한다.
- **바뀌는 데이터/상태:** 글 발행 시 기존 `posts`, `post_topics`, `post_links`, `media_assets` 연결 상태가 백엔드 기존 로직대로 갱신된다. CLI 패키지에는 `sharp` dependency가 추가된다.
- **영향 범위:** MCP mutation tool, OpenLog 글 발행 API, media upload API, npm 패키지 설치 크기 및 native dependency 설치 경로

### D. npm publish CI/CD workflow
- **관련 위치/대상:** `.github/workflows/openlog-cli-publish.yml`
- **변경 전 상황:** CLI 패키지 변경을 검증하거나 npm에 자동 publish하는 workflow가 없었다.
- **변경한 내용:** CLI 패키지 변경 PR에서는 `npm ci`, `npm run build`, `npm pack --dry-run`을 검증하고, `develop` push 또는 수동 실행에서는 같은 검증 후 npm publish를 수행하는 workflow를 추가했다. publish job은 npm Trusted Publishing/OIDC를 사용하도록 `id-token: write` 권한을 부여했다.
- **변경 후 동작:** `packages/openlog-cli/**` 또는 workflow 파일 변경 시 PR 검증이 실행된다. `develop` 반영 시 패키지 버전이 아직 npm에 없으면 `npm publish --access public`이 실행되고, 이미 같은 버전이 publish되어 있으면 버전 bump를 요구하며 실패한다.
- **바뀌는 데이터/상태:** GitHub Actions workflow가 추가된다. npm package 이름은 `@kitae9999/openlog-cli`, 설치 후 실행 명령은 `openlog`다.
- **영향 범위:** GitHub Actions, npm Trusted Publishing 설정, CLI 패키지 릴리스 절차

---

## 4. 테스트 및 검증 방법
- **검증 환경:** 로컬 개발 환경, `feature/mcp` 브랜치
- **검증한 시나리오:**
  - device login start/approve/token 성공 흐름 및 승인 전 polling, 만료/잘못된 code, 중복 승인 방어 테스트
  - CLI package TypeScript build 및 npm pack 산출물 확인
  - MCP `tools/list`에서 `upload_post_image`, `publish_post`를 포함한 tool 노출 확인
  - mock API server로 `publish_post` preview, `confirm: true`, `skipConfirmation: true` 호출 흐름 확인
  - mock upload server와 임시 이미지 파일로 `upload_post_image`의 upload-url 요청, signed URL PUT, completion PATCH 순서 확인
  - frontend `/cli-login` 포함 Next build와 lint 확인
  - `OPENLOG_WEB_BASE_URL`이 MCP install config 출력에 포함되는지 확인
- **확인한 결과:**
  - `./gradlew :backend:test` 성공
  - `cd frontend && npm run build` 성공
  - `cd frontend && npm run lint` 성공. 기존 `frontend/src/01_widgets/onboarding/ui/OnboardingView.tsx`의 unused `Image` import 경고 1건이 출력되지만 exit code는 0
  - `cd packages/openlog-cli && npm run build` 성공
  - `cd packages/openlog-cli && npm_config_cache=/private/tmp/openlog-npm-cache npm pack --dry-run` 성공
  - MCP smoke test에서 `get_auth_status`, `get_me`, `list_my_notifications`, `list_my_liked_posts`, `list_my_posts`, `upload_post_image`, `publish_post`, `get_post_detail` 노출 확인
- **확인하지 못한 부분:** 실제 운영 GitHub Actions에서 OIDC Trusted Publishing으로 `0.2.0` publish가 완료되는지는 확인하지 못했다. 운영 OpenLog/GCS 환경에서 실제 이미지 업로드 후 발행 글 렌더링까지의 end-to-end 흐름은 mock 서버 검증으로 대체했다.

---

## 5. 리뷰어 참고 사항
- **리뷰할 때 봐야 할 점:** CLI/MCP는 브라우저 쿠키를 읽지 않고 device login polling 결과로 받은 JWT만 저장한다. MCP mutation tool은 client 승인과 별개로 `publish_post` 내부에서 한 번 더 `confirm` 또는 `skipConfirmation`을 요구한다. `upload_post_image`는 `sharp` native dependency를 포함하므로 npm 설치 환경별 optional binary 설치 경로를 함께 확인하는 것이 좋다.
- **영향 범위:** 인증 API, OAuth redirect, frontend CLI 승인 화면, npm CLI 패키지, MCP client 등록, GitHub Actions publish workflow가 함께 바뀐다. npm Trusted Publishing은 npm package settings에서 workflow filename `openlog-cli-publish.yml`을 등록해야 실제 publish가 성공한다.

---

## 6. 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일 가이드를 준수합니다.
- [x] 변경 사항에 대한 테스트 코드를 작성하거나 통과했습니다.
- [x] 관련된 문서(README, API 명세 등)를 업데이트했습니다.
