### PR TITLE
[Refactor] 동시성 문제 수정

### DIFF
--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/notification/NotificationJdbcWriter.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/notification/NotificationJdbcWriter.kt
@@ -1,0 +1,60 @@
+package io.github.kitae9999.openlog.notification
+
+import io.github.kitae9999.openlog.notification.entity.Notification
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+import java.sql.Types
+
+@Component
+class NotificationJdbcWriter(
+    private val jdbcTemplate: JdbcTemplate,
+    private val objectMapper: ObjectMapper,
+) {
+    fun insertIgnoringDuplicates(notifications: List<Notification>): Int {
+        if (notifications.isEmpty()) {
+            return 0
+        }
+
+        val results = jdbcTemplate.batchUpdate(
+            INSERT_IGNORE_DUPLICATE_SQL,
+            notifications,
+            notifications.size,
+        ) { preparedStatement, notification ->
+            preparedStatement.setLong(1, requireNotNull(notification.recipient.id))
+
+            val actorId = notification.actor?.id
+            if (actorId == null) {
+                preparedStatement.setNull(2, Types.BIGINT)
+            } else {
+                preparedStatement.setLong(2, actorId)
+            }
+
+            preparedStatement.setObject(3, notification.sourceEventId)
+            preparedStatement.setString(4, notification.type.name)
+            preparedStatement.setString(5, notification.targetDomain)
+            preparedStatement.setString(6, notification.targetId)
+            preparedStatement.setString(7, objectMapper.writeValueAsString(notification.payload))
+            preparedStatement.setObject(8, notification.createdAt)
+        }
+
+        return results.sumOf { batchResult -> batchResult.sum() }
+    }
+
+    private companion object {
+        private val INSERT_IGNORE_DUPLICATE_SQL = """
+            INSERT INTO notifications (
+                recipient_id,
+                actor_id,
+                source_event_id,
+                type,
+                target_domain,
+                target_id,
+                payload,
+                created_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?::jsonb, ?)
+            ON CONFLICT (recipient_id, source_event_id) DO NOTHING
+        """.trimIndent()
+    }
+}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/notification/NotificationService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/notification/NotificationService.kt
@@ -24,6 +24,7 @@ class NotificationService (
     private val notificationRepository: NotificationRepository,
     private val followRepository: FollowRepository,
     private val userRepository: UserRepository,
+    private val notificationJdbcWriter: NotificationJdbcWriter,
 ) {
     @Transactional(readOnly = true)
     fun getNotifications(recipientId: Long, size: Int): NotificationListResponse {
@@ -78,7 +79,7 @@ class NotificationService (
             )
         }
 
-        notificationRepository.saveAll(notifications)
+        notificationJdbcWriter.insertIgnoringDuplicates(notifications)
     }
 
     private fun Notification.toResponse(): NotificationResponse {

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/repository/PostRepository.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/repository/PostRepository.kt
@@ -1,9 +1,11 @@
 package io.github.kitae9999.openlog.post.repository
 
 import io.github.kitae9999.openlog.post.entity.Post
+import jakarta.persistence.LockModeType
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.LocalDateTime
@@ -14,6 +16,16 @@ interface PostRepository: JpaRepository<Post, Long> {
     fun findByAuthorIdAndSlug(authorId: Long, slug: String): Post?
     fun findAllByAuthorIdAndTitle(authorId: Long, title: String): List<Post>
     fun findAllByAuthorIdOrderByCreatedAtDesc(authorId: Long): List<Post>
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query(
+        """
+        select p
+        from Post p
+        where p.id = :postId
+        """
+    )
+    fun findByIdForUpdate(@Param("postId") postId: Long): Post?
 
     @EntityGraph(attributePaths = ["author"])
     fun findAllByOrderByCreatedAtDescIdDesc(pageable: Pageable): List<Post>

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/postlike/PostLikeRepository.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/postlike/PostLikeRepository.kt
@@ -3,6 +3,7 @@ package io.github.kitae9999.openlog.postlike
 import io.github.kitae9999.openlog.postlike.entity.PostLike
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.LocalDateTime
@@ -11,6 +12,33 @@ interface PostLikeRepository : JpaRepository<PostLike, Long> {
     fun findByPostIdAndUserId(postId: Long, userId: Long): PostLike?
     fun existsByPostIdAndUserId(postId: Long, userId: Long): Boolean
     fun countByPostId(postId: Long): Long
+
+    @Modifying
+    @Query(
+        value = """
+            INSERT INTO post_likes (post_id, user_id)
+            VALUES (:postId, :userId)
+            ON CONFLICT (post_id, user_id) DO NOTHING
+        """,
+        nativeQuery = true,
+    )
+    fun insertIgnoringDuplicate(
+        @Param("postId") postId: Long,
+        @Param("userId") userId: Long,
+    ): Int
+
+    @Modifying
+    @Query(
+        """
+        delete from PostLike pl
+        where pl.post.id = :postId
+          and pl.user.id = :userId
+        """
+    )
+    fun deleteByPostIdAndUserId(
+        @Param("postId") postId: Long,
+        @Param("userId") userId: Long,
+    ): Int
 
     @Query(
         """

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/postlike/PostLikeService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/postlike/PostLikeService.kt
@@ -2,7 +2,6 @@ package io.github.kitae9999.openlog.postlike
 
 import io.github.kitae9999.openlog.common.exception.NotFoundException
 import io.github.kitae9999.openlog.post.repository.PostRepository
-import io.github.kitae9999.openlog.postlike.entity.PostLike
 import io.github.kitae9999.openlog.user.entity.User
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
@@ -19,21 +18,14 @@ class PostLikeService(
         val postLike = postLikeRepository.findByPostIdAndUserId(postId, userId)
 
         if (postLike != null) {
-            postLikeRepository.delete(postLike)
+            postLikeRepository.deleteByPostIdAndUserId(postId, userId)
             return false
         } else {
             if (!postRepository.existsById(postId)) {
                 throw NotFoundException("포스트를 찾을 수 없습니다.")
             }
 
-            val post = postRepository.getReferenceById(postId)
-
-            postLikeRepository.save(
-                PostLike(
-                    user = user,
-                    post = post
-                )
-            )
+            postLikeRepository.insertIgnoringDuplicate(postId, userId)
             return true
         }
     }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/suggest/SuggestService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/suggest/SuggestService.kt
@@ -158,6 +158,7 @@ class SuggestService(
         postId: Long,
         suggestionId: Long
     ): Suggestion {
+        lockPostForSuggestionManagement(postId)
         val suggestion = suggestionRepository.findManageableWithPostAuthorByIdAndPostId(suggestionId, postId)
             ?: throw NotFoundException("포스트에 존재하지 않는 Suggestion입니다.")
 
@@ -177,6 +178,7 @@ class SuggestService(
         postId: Long,
         suggestionId: Long
     ): Suggestion {
+        lockPostForSuggestionManagement(postId)
         val suggestion = suggestionRepository.findManageableWithPostAuthorByIdAndPostId(suggestionId, postId)
             ?: throw NotFoundException("포스트에 존재하지 않는 Suggestion입니다.")
 
@@ -189,6 +191,11 @@ class SuggestService(
         }
 
         return suggestion
+    }
+
+    private fun lockPostForSuggestionManagement(postId: Long) {
+        postRepository.findByIdForUpdate(postId)
+            ?: throw NotFoundException("포스트에 존재하지 않는 Suggestion입니다.")
     }
 
     @Transactional

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/suggest/repository/SuggestionRepository.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/suggest/repository/SuggestionRepository.kt
@@ -2,13 +2,16 @@ package io.github.kitae9999.openlog.suggest.repository
 
 import io.github.kitae9999.openlog.suggest.entity.Suggestion
 import io.github.kitae9999.openlog.suggest.entity.SuggestionStatus
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
 interface SuggestionRepository: JpaRepository<Suggestion, Long> {
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query(
         """
         select s

--- a/backend/src/test/kotlin/io/github/kitae9999/openlog/notification/NotificationServiceTest.kt
+++ b/backend/src/test/kotlin/io/github/kitae9999/openlog/notification/NotificationServiceTest.kt
@@ -35,6 +35,9 @@ class NotificationServiceTest {
     @Mock
     private lateinit var userRepository: UserRepository
 
+    @Mock
+    private lateinit var notificationJdbcWriter: NotificationJdbcWriter
+
     private lateinit var notificationService: NotificationService
 
     @BeforeEach
@@ -43,6 +46,7 @@ class NotificationServiceTest {
             notificationRepository = notificationRepository,
             followRepository = followRepository,
             userRepository = userRepository,
+            notificationJdbcWriter = notificationJdbcWriter,
         )
     }
 
@@ -75,8 +79,8 @@ class NotificationServiceTest {
         )
 
         @Suppress("UNCHECKED_CAST")
-        val notifications = mockingDetails(notificationRepository).invocations
-            .single { it.method.name == "saveAll" }
+        val notifications = mockingDetails(notificationJdbcWriter).invocations
+            .single { it.method.name == "insertIgnoringDuplicates" }
             .arguments
             .single() as List<Notification>
 

--- a/backend/src/test/kotlin/io/github/kitae9999/openlog/suggest/SuggestServiceTest.kt
+++ b/backend/src/test/kotlin/io/github/kitae9999/openlog/suggest/SuggestServiceTest.kt
@@ -180,6 +180,7 @@ class SuggestServiceTest {
     }
 
     private fun givenManageableSuggestion(suggestion: Suggestion) {
+        given(postRepository.findByIdForUpdate(10L)).willReturn(suggestion.post)
         given(
             suggestionRepository.findManageableWithPostAuthorByIdAndPostId(
                 suggestionId = 100L,


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #

---

## 1. PR 유형
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ✨ 새로운 기능 (New Feature)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 업데이트 (Documentation)
- [ ] ⚙️ 설정/빌드 변경 (Chore)

---

## 2. 변경 배경 및 목표
- **변경 전 상태:** Kafka 알림 생성, 좋아요 토글, Suggestion 상태 변경에서 조회 후 저장/수정하는 흐름을 사용하고 있었다.
- **문제/필요성:** Kafka 이벤트 재전달이나 클라이언트 중복 요청, 상태 변경 중복 요청이 들어오면 DB unique constraint 예외 또는 같은 상태를 여러 요청이 동시에 처리하는 경합이 발생할 수 있었다.
- **이번 PR의 목표:** 중복 이벤트/요청은 예외가 아니라 이미 처리된 상태로 흡수하고, Suggestion 관리 흐름은 같은 post와 suggestion을 한 트랜잭션 안에서 순차 처리하도록 보강한다.

---

## 3. 주요 구현 내용 및 동작 방식

### A. Kafka 알림 저장 멱등 처리
- **관련 위치/대상:** `NotificationService`, `NotificationJdbcWriter`
- **변경 전 상황:** Kafka listener가 같은 `sourceEventId`를 재전달하면 `notificationRepository.saveAll()`이 `(recipient_id, source_event_id)` unique index와 충돌할 수 있었다.
- **변경한 내용:** `JdbcTemplate.batchUpdate()` 기반 `NotificationJdbcWriter`를 추가하고, 알림 저장 SQL에 `ON CONFLICT (recipient_id, source_event_id) DO NOTHING`을 적용했다.
- **변경 후 동작:** 같은 이벤트가 재전달되어도 이미 생성된 알림은 insert를 생략하고 listener 처리는 정상 완료될 수 있다.
- **구현 흐름:**
  1. `NotificationService`가 팔로워별 `Notification` 목록을 생성한다.
  2. `NotificationJdbcWriter.insertIgnoringDuplicates()`가 목록을 batch insert한다.
  3. DB unique index 충돌 시 해당 row만 no-op 처리한다.
- **바뀌는 데이터/상태:** 중복 이벤트 처리 시 새 알림 row를 만들지 않고 기존 알림 상태를 유지한다.
- **영향 범위:** 글 발행 이벤트 기반 알림 생성, Kafka consumer 재처리 흐름

### B. 좋아요 토글 중복 insert 방어
- **관련 위치/대상:** `PostLikeRepository`, `PostLikeService`
- **변경 전 상황:** 같은 사용자가 같은 글에 대해 동시에 좋아요 요청을 보내면 두 요청이 모두 `findByPostIdAndUserId()`에서 미존재로 판단하고 `save()`를 시도할 수 있었다.
- **변경한 내용:** 좋아요 생성 경로를 `INSERT ... ON CONFLICT (post_id, user_id) DO NOTHING` native query로 변경하고, 삭제 경로는 조건부 JPQL delete로 변경했다.
- **변경 후 동작:** 동시 중복 좋아요 요청은 한 번만 저장되고, 중복 insert는 예외 없이 no-op 처리된다. 삭제 요청도 대상 row가 이미 없어도 예외 없이 완료된다.
- **바뀌는 데이터/상태:** 중복 요청 후에도 `post_likes`에는 사용자와 글 조합당 최대 1개 row만 유지된다.
- **영향 범위:** 좋아요 토글 API, 좋아요 카운트/좋아요 여부 조회

### C. Suggestion 상태 변경 비관적 락 적용
- **관련 위치/대상:** `PostRepository`, `SuggestionRepository`, `SuggestService`
- **변경 전 상황:** 같은 Suggestion 또는 같은 post의 Suggestion 관리 요청이 동시에 들어오면 여러 요청이 `OPEN` 상태를 기준으로 처리될 수 있었다.
- **변경한 내용:** Suggestion 관리/수정 흐름에서 먼저 `Post` row를 `PESSIMISTIC_WRITE`로 조회하고, 대상 `Suggestion` 조회에도 `PESSIMISTIC_WRITE`를 적용했다.
- **변경 후 동작:** 같은 post의 Suggestion 상태 변경 요청은 post row lock에서 순차 처리되고, 같은 Suggestion 중복 처리도 suggestion row lock으로 보호된다.
- **구현 흐름:**
  1. `manageSuggestion()` 또는 `updateSuggestion()` 트랜잭션 안에서 post row lock을 획득한다.
  2. 대상 suggestion row를 lock과 함께 조회한다.
  3. 권한과 `OPEN` 상태를 확인한 뒤 merge, close, reject, update를 수행한다.
- **바뀌는 데이터/상태:** Suggestion 상태와 post content/version 변경이 같은 트랜잭션에서 순차 처리된다.
- **영향 범위:** Suggestion merge/close/reject/update API, post content 변경을 동반하는 suggestion merge 흐름

---

## 4. 스크린샷 (선택)
- 해당 없음

## 5. 테스트 및 검증 방법
- **검증 환경:** 로컬 개발 환경, Gradle backend test
- **검증한 시나리오:**
  - 알림 생성 서비스가 팔로워별 알림 목록을 `NotificationJdbcWriter`에 전달하는지 확인
  - Suggestion 관리 테스트에서 post lock 조회를 포함해 기존 상태 전이 테스트가 통과하는지 확인
  - backend 전체 테스트 실행
- **확인한 결과:**
  - `./gradlew :backend:test` 성공
- **확인하지 못한 부분:**
  - 실제 Kafka 재전달, 동시 좋아요 요청, 동시 Suggestion 처리 부하 테스트는 별도로 수행하지 않았다.

---

## 6. 리뷰어 참고 사항 (선택)
- **리뷰할 때 봐야 할 점:** `NotificationJdbcWriter`의 `ON CONFLICT DO NOTHING` 대상이 DB unique index `(recipient_id, source_event_id)`와 일치하는지, Suggestion 관리 흐름의 post lock 획득 순서가 트랜잭션 안에서 유지되는지 확인이 필요하다.
- **영향 범위:** backend 알림 생성, 좋아요 토글, Suggestion 상태 변경 로직

---

## 7. 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일 가이드를 준수합니다.
- [x] 변경 사항에 대한 테스트 코드를 작성하거나 통과했습니다.
- [ ] 관련된 문서(README, API 명세 등)를 업데이트했습니다.
