### PR TITLE
[Feat] 팔로잉 유저 글 목록 조회

### DIFF
--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/common/cursor/DateTimeIdCursor.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/common/cursor/DateTimeIdCursor.kt
@@ -15,6 +15,9 @@ object DateTimeIdCursorCodec {
         return Base64.getUrlEncoder().withoutPadding().encodeToString(rawCursor.toByteArray())
     }
 
+    /**
+     * cursor 쿼리파라미터 해석해서 createdAt과 id를 갖는 인스턴스로 반환
+     */
     fun decode(cursor: String): DateTimeIdCursor {
         val decodedCursor = runCatching {
             String(Base64.getUrlDecoder().decode(cursor))

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/post/repository/PostRepository.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/post/repository/PostRepository.kt
@@ -30,6 +30,47 @@ interface PostRepository: JpaRepository<Post, Long> {
     @EntityGraph(attributePaths = ["author"])
     fun findAllByOrderByCreatedAtDescIdDesc(pageable: Pageable): List<Post>
 
+    @EntityGraph(attributePaths = ["author"])
+    @Query(
+        """
+        select p
+        from Post p
+        where p.author.id in (
+            select f.followedUser.id
+            from Follow f
+            where f.followingUser.id = :userId
+        )
+        order by p.createdAt desc, p.id desc
+        """
+    )
+    fun findFollowingPostsByUserId(
+        @Param("userId") userId: Long,
+        pageable: Pageable,
+    ): List<Post>
+
+    @EntityGraph(attributePaths = ["author"])
+    @Query(
+        """
+        select p
+        from Post p
+        where p.author.id in (
+            select f.followedUser.id
+            from Follow f
+            where f.followingUser.id = :userId
+        )
+          and (
+            p.createdAt < :createdAt
+            or (p.createdAt = :createdAt and p.id < :id)
+          )
+        order by p.createdAt desc, p.id desc
+        """
+    )
+    fun findFollowingPostsAfterCursor(
+        @Param("userId") userId: Long,
+        @Param("createdAt") createdAt: LocalDateTime,
+        @Param("id") id: Long,
+        pageable: Pageable,
+    ): List<Post>
 
     /**
      * createdAt과 커서값인 포스트의 pk값보다 작은 즉, 더 이전에 작성된 포스트들 불러옴

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserController.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserController.kt
@@ -24,6 +24,18 @@ class UserController(
     private val userService: UserService,
     private val currentUserResolver: CurrentUserResolver,
 ) {
+    @GetMapping("me/following/posts")
+    fun getFollowingPosts(
+        request: HttpServletRequest,
+        @RequestParam(required = false) cursor: String?,
+        @RequestParam(defaultValue = "10") size: Int,
+    ): RecentPostCursorResponse {
+        val currentUser = currentUserResolver.resolveCurrentUser(request)
+        val followingPosts = userService.getFollowingPosts(requireNotNull(currentUser.id), cursor, size)
+
+        return followingPosts
+    }
+
     @GetMapping("me/liked-posts")
     fun getLikedPosts(
         request: HttpServletRequest,

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/user/UserService.kt
@@ -7,9 +7,10 @@ import io.github.kitae9999.openlog.common.exception.NotFoundException
 import io.github.kitae9999.openlog.follow.FollowRepository
 import io.github.kitae9999.openlog.follow.entity.FollowId
 import io.github.kitae9999.openlog.post.dto.PostDetailResponse
+import io.github.kitae9999.openlog.post.dto.PostWikiLinkResponse
 import io.github.kitae9999.openlog.post.dto.RecentPostCursorResponse
 import io.github.kitae9999.openlog.post.dto.RecentPostResponse
-import io.github.kitae9999.openlog.post.dto.PostWikiLinkResponse
+import io.github.kitae9999.openlog.post.entity.Post
 import io.github.kitae9999.openlog.post.extractFirstMarkdownImageSrc
 import io.github.kitae9999.openlog.post.formatPublishedAtLabel
 import io.github.kitae9999.openlog.post.repository.PostLinkRepository
@@ -39,9 +40,45 @@ class UserService(
     private val followRepository: FollowRepository,
 ) {
     @Transactional
-    fun getLikedPosts(userId: Long, cursor: String?, size: Int): RecentPostCursorResponse {
-        val safeSize = size.coerceIn(1, LIKED_POSTS_PAGE_SIZE)
+    fun getFollowingPosts(userId: Long, cursor: String?, size: Int): RecentPostCursorResponse {
+        val safeSize = size.coerceIn(1, FOLLOWING_POSTS_PAGE_SIZE)
         val cursorMarker = cursor?.let(DateTimeIdCursorCodec::decode)
+        val followingPosts = if (cursorMarker == null) {
+            postRepository.findFollowingPostsByUserId(
+                userId = userId,
+                pageable = PageRequest.of(0, safeSize + 1),
+            )
+        } else {
+            postRepository.findFollowingPostsAfterCursor(
+                userId = userId,
+                createdAt = cursorMarker.createdAt,
+                id = cursorMarker.id,
+                pageable = PageRequest.of(0, safeSize + 1),
+            )
+        }
+        val hasNext = followingPosts.size > safeSize
+        val pageItems = followingPosts.take(safeSize)
+        val postIds = pageItems.mapNotNull { it.id }
+        val likeCounts = getPostLikeCounts(postIds)
+        val commentCounts = getPostCommentCounts(postIds)
+
+        return RecentPostCursorResponse(
+            posts = pageItems.map { post ->
+                toRecentPostResponse(post, likeCounts, commentCounts)
+            },
+            size = safeSize,
+            nextCursor = pageItems.lastOrNull() // 가져온 목록의 마지막 포스트, 없을 시 에러 반환
+                ?.takeIf { hasNext }
+                ?.let { post -> DateTimeIdCursorCodec.encode(post.createdAt, requireNotNull(post.id)) },
+            hasNext = hasNext,
+        )
+    }
+
+    @Transactional
+    fun getLikedPosts(userId: Long, cursor: String?, size: Int): RecentPostCursorResponse {
+        val safeSize = size.coerceIn(1, LIKED_POSTS_PAGE_SIZE) // size의 범위 제한
+        val cursorMarker = cursor?.let(DateTimeIdCursorCodec::decode)
+
         val postLikes = if (cursorMarker == null) {
             postLikeRepository.findLikedPostsByUserId(
                 userId = userId,
@@ -64,20 +101,7 @@ class UserService(
         return RecentPostCursorResponse(
             posts = pageItems.map { postLike ->
                 val post = postLike.post
-                val postId = requireNotNull(post.id)
-                RecentPostResponse(
-                    id = postId,
-                    slug = post.slug,
-                    title = post.title,
-                    description = post.description,
-                    publishedAtLabel = formatPublishedAtLabel(post),
-                    authorUsername = requireNotNull(post.author.username),
-                    authorName = resolveAuthorName(post),
-                    authorAvatarSrc = post.author.profileImageUrl,
-                    thumbnailSrc = extractFirstMarkdownImageSrc(post.content),
-                    likes = likeCounts[postId]?.toInt() ?: 0,
-                    comments = commentCounts[postId]?.toInt() ?: 0,
-                )
+                toRecentPostResponse(post, likeCounts, commentCounts)
             },
             size = safeSize,
             nextCursor = pageItems.lastOrNull()
@@ -242,7 +266,30 @@ class UserService(
         return commentRepository.countAllByPostIdIn(postIds).associate { it.postId to it.count }
     }
 
+    private fun toRecentPostResponse(
+        post: Post,
+        likeCounts: Map<Long, Long>,
+        commentCounts: Map<Long, Long>,
+    ): RecentPostResponse {
+        val postId = requireNotNull(post.id)
+
+        return RecentPostResponse(
+            id = postId,
+            slug = post.slug,
+            title = post.title,
+            description = post.description,
+            publishedAtLabel = formatPublishedAtLabel(post),
+            authorUsername = requireNotNull(post.author.username),
+            authorName = resolveAuthorName(post),
+            authorAvatarSrc = post.author.profileImageUrl,
+            thumbnailSrc = extractFirstMarkdownImageSrc(post.content),
+            likes = likeCounts[postId]?.toInt() ?: 0,
+            comments = commentCounts[postId]?.toInt() ?: 0,
+        )
+    }
+
     private companion object {
+        const val FOLLOWING_POSTS_PAGE_SIZE = 10
         const val LIKED_POSTS_PAGE_SIZE = 10
     }
 }

--- a/backend/src/test/kotlin/io/github/kitae9999/openlog/user/UserServiceTest.kt
+++ b/backend/src/test/kotlin/io/github/kitae9999/openlog/user/UserServiceTest.kt
@@ -1,0 +1,164 @@
+package io.github.kitae9999.openlog.user
+
+import io.github.kitae9999.openlog.comment.repository.CommentCount
+import io.github.kitae9999.openlog.comment.repository.CommentRepository
+import io.github.kitae9999.openlog.common.cursor.DateTimeIdCursorCodec
+import io.github.kitae9999.openlog.follow.FollowRepository
+import io.github.kitae9999.openlog.post.entity.Post
+import io.github.kitae9999.openlog.post.repository.PostLinkRepository
+import io.github.kitae9999.openlog.post.repository.PostRepository
+import io.github.kitae9999.openlog.postlike.PostLikeCount
+import io.github.kitae9999.openlog.postlike.PostLikeRepository
+import io.github.kitae9999.openlog.posttopic.repository.PostTopicRepository
+import io.github.kitae9999.openlog.user.entity.User
+import io.github.kitae9999.openlog.user.repository.UserRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.BDDMockito.given
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.data.domain.PageRequest
+
+@ExtendWith(MockitoExtension::class)
+class UserServiceTest {
+    @Mock
+    private lateinit var userRepository: UserRepository
+
+    @Mock
+    private lateinit var postRepository: PostRepository
+
+    @Mock
+    private lateinit var postLinkRepository: PostLinkRepository
+
+    @Mock
+    private lateinit var postTopicRepository: PostTopicRepository
+
+    @Mock
+    private lateinit var postLikeRepository: PostLikeRepository
+
+    @Mock
+    private lateinit var commentRepository: CommentRepository
+
+    @Mock
+    private lateinit var followRepository: FollowRepository
+
+    private lateinit var userService: UserService
+
+    @BeforeEach
+    fun setUp() {
+        userService = UserService(
+            userRepository = userRepository,
+            postRepository = postRepository,
+            postLinkRepository = postLinkRepository,
+            postTopicRepository = postTopicRepository,
+            postLikeRepository = postLikeRepository,
+            commentRepository = commentRepository,
+            followRepository = followRepository,
+        )
+    }
+
+    @Test
+    fun `getFollowingPosts returns first cursor page with capped page size`() {
+        val author = User(
+            id = 1L,
+            username = "alice",
+            nickname = "Alice",
+            profileImageUrl = "https://example.com/alice.png",
+        )
+        val followingPosts = (1L..11L).map { id ->
+            createPost(
+                id = id,
+                author = author,
+                slug = "following-post-$id",
+                title = "Following Post $id",
+                content = "Content\n\n![Cover](https://example.com/$id.webp)",
+            )
+        }
+        val pagePostIds = (1L..10L).toList()
+        given(postRepository.findFollowingPostsByUserId(9L, PageRequest.of(0, 11)))
+            .willReturn(followingPosts)
+        given(postLikeRepository.countAllByPostIdIn(pagePostIds)).willReturn(
+            listOf(object : PostLikeCount {
+                override val postId = 1L
+                override val count = 3L
+            })
+        )
+        given(commentRepository.countAllByPostIdIn(pagePostIds)).willReturn(
+            listOf(object : CommentCount {
+                override val postId = 1L
+                override val count = 2L
+            })
+        )
+
+        val response = userService.getFollowingPosts(userId = 9L, cursor = null, size = 30)
+
+        assertThat(response.size).isEqualTo(10)
+        assertThat(response.posts).hasSize(10)
+        assertThat(response.hasNext).isTrue()
+        assertThat(response.nextCursor).isEqualTo(
+            DateTimeIdCursorCodec.encode(followingPosts[9].createdAt, requireNotNull(followingPosts[9].id))
+        )
+        val summary = response.posts.first()
+        assertThat(summary.id).isEqualTo(1L)
+        assertThat(summary.slug).isEqualTo("following-post-1")
+        assertThat(summary.authorUsername).isEqualTo("alice")
+        assertThat(summary.authorName).isEqualTo("Alice")
+        assertThat(summary.authorAvatarSrc).isEqualTo("https://example.com/alice.png")
+        assertThat(summary.thumbnailSrc).isEqualTo("https://example.com/1.webp")
+        assertThat(summary.likes).isEqualTo(3)
+        assertThat(summary.comments).isEqualTo(2)
+    }
+
+    @Test
+    fun `getFollowingPosts loads next cursor page`() {
+        val author = User(id = 1L, username = "alice", nickname = "Alice")
+        val cursorPost = createPost(
+            id = 20L,
+            author = author,
+            slug = "cursor-post",
+            title = "Cursor Post",
+        )
+        val nextPost = createPost(
+            id = 19L,
+            author = author,
+            slug = "next-post",
+            title = "Next Post",
+        )
+        val cursor = DateTimeIdCursorCodec.encode(cursorPost.createdAt, 20L)
+        given(
+            postRepository.findFollowingPostsAfterCursor(
+                9L,
+                cursorPost.createdAt,
+                20L,
+                PageRequest.of(0, 6),
+            )
+        ).willReturn(listOf(nextPost))
+        given(postLikeRepository.countAllByPostIdIn(listOf(19L))).willReturn(emptyList())
+        given(commentRepository.countAllByPostIdIn(listOf(19L))).willReturn(emptyList())
+
+        val response = userService.getFollowingPosts(userId = 9L, cursor = cursor, size = 5)
+
+        assertThat(response.posts.single().id).isEqualTo(19L)
+        assertThat(response.nextCursor).isNull()
+        assertThat(response.hasNext).isFalse()
+    }
+
+    private fun createPost(
+        id: Long,
+        author: User,
+        slug: String,
+        title: String,
+        content: String = "Content",
+    ): Post {
+        return Post(
+            id = id,
+            author = author,
+            slug = slug,
+            title = title,
+            description = "$title description",
+            content = content,
+        )
+    }
+}

--- a/frontend/app/api/users/me/following/posts/route.ts
+++ b/frontend/app/api/users/me/following/posts/route.ts
@@ -1,0 +1,32 @@
+import { headers } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+import { API_CONFIG } from "@/shared/api";
+
+export async function GET(request: NextRequest) {
+  const headerStore = await headers();
+  const cursor = request.nextUrl.searchParams.get("cursor");
+  const size = request.nextUrl.searchParams.get("size") ?? "10";
+  const params = new URLSearchParams({ size });
+  if (cursor) {
+    params.set("cursor", cursor);
+  }
+
+  const response = await fetch(
+    `${API_CONFIG.baseURL}/users/me/following/posts?${params}`,
+    {
+      cache: "no-store",
+      headers: {
+        cookie: headerStore.get("cookie") ?? "",
+      },
+    },
+  );
+
+  if (!response.ok) {
+    return NextResponse.json(
+      { message: "Failed to load following posts." },
+      { status: response.status },
+    );
+  }
+
+  return NextResponse.json(await response.json());
+}

--- a/frontend/src/01_widgets/home-feed/ui/HomeFeed.tsx
+++ b/frontend/src/01_widgets/home-feed/ui/HomeFeed.tsx
@@ -1,5 +1,6 @@
 import { Footer } from "@/widgets/chrome/ui";
 import type { TabKey } from "./data";
+import { getFollowingPosts } from "@/entities/post/api/getFollowingPosts";
 import { getLikedPosts } from "@/entities/post/api/getLikedPosts";
 import { getRecentPosts } from "@/entities/post/api/getRecentPosts";
 import { getUserOrRedirectToOnboarding } from "@/features/auth/api/requireOnboarding";
@@ -18,6 +19,10 @@ export async function HomeFeed({
     viewer === undefined ? await getUserOrRedirectToOnboarding() : viewer;
   const recentPosts =
     activeTab === "home" ? await getRecentPosts(null, 10) : undefined;
+  const followingPosts =
+    activeTab === "following" && data
+      ? await getFollowingPosts(null, 10)
+      : undefined;
   const likedPosts =
     activeTab === "liked" && data ? await getLikedPosts(null, 10) : undefined;
 
@@ -30,6 +35,9 @@ export async function HomeFeed({
       initialHomePosts={recentPosts?.posts ?? []}
       initialHomeNextCursor={recentPosts?.nextCursor ?? null}
       initialHomeHasNext={recentPosts?.hasNext ?? false}
+      initialFollowingPosts={followingPosts?.posts ?? []}
+      initialFollowingNextCursor={followingPosts?.nextCursor ?? null}
+      initialFollowingHasNext={followingPosts?.hasNext ?? false}
       initialLikedPosts={likedPosts?.posts ?? []}
       initialLikedNextCursor={likedPosts?.nextCursor ?? null}
       initialLikedHasNext={likedPosts?.hasNext ?? false}

--- a/frontend/src/01_widgets/home-feed/ui/HomeFeedShell.tsx
+++ b/frontend/src/01_widgets/home-feed/ui/HomeFeedShell.tsx
@@ -17,13 +17,7 @@ import type {
 import { assets } from "@/shared/config/assets";
 import { cn } from "@/shared/lib/cn";
 import { buildPublicPostPath } from "@/shared/lib/publicRoutes";
-import {
-  feedPosts,
-  followingPosts,
-  tabs,
-  type FeedPost,
-  type TabKey,
-} from "./data";
+import { feedPosts, tabs, type FeedPost, type TabKey } from "./data";
 
 export function HomeFeedShell({
   activeTab,
@@ -31,6 +25,9 @@ export function HomeFeedShell({
   initialHomePosts,
   initialHomeNextCursor,
   initialHomeHasNext,
+  initialFollowingPosts,
+  initialFollowingNextCursor,
+  initialFollowingHasNext,
   initialLikedPosts,
   initialLikedNextCursor,
   initialLikedHasNext,
@@ -43,6 +40,9 @@ export function HomeFeedShell({
   initialHomePosts: RecentPostSummary[];
   initialHomeNextCursor: string | null;
   initialHomeHasNext: boolean;
+  initialFollowingPosts: RecentPostSummary[];
+  initialFollowingNextCursor: string | null;
+  initialFollowingHasNext: boolean;
   initialLikedPosts: RecentPostSummary[];
   initialLikedNextCursor: string | null;
   initialLikedHasNext: boolean;
@@ -54,18 +54,26 @@ export function HomeFeedShell({
   const [homePosts, setHomePosts] = useState<FeedPost[]>(() =>
     initialHomePosts.map(toFeedPost),
   );
+  const [followingFeedPosts, setFollowingFeedPosts] = useState<FeedPost[]>(() =>
+    initialFollowingPosts.map(toFeedPost),
+  );
   const [likedFeedPosts, setLikedFeedPosts] = useState<FeedPost[]>(() =>
     initialLikedPosts.map(toFeedPost),
   );
   const [homeNextCursor, setHomeNextCursor] = useState<string | null>(
     initialHomeNextCursor,
   );
+  const [followingNextCursor, setFollowingNextCursor] = useState<string | null>(
+    initialFollowingNextCursor,
+  );
   const [likedNextCursor, setLikedNextCursor] = useState<string | null>(
     initialLikedNextCursor,
   );
   const [hasNextHomePage, setHasNextHomePage] = useState(initialHomeHasNext);
-  const [hasNextLikedPage, setHasNextLikedPage] =
-    useState(initialLikedHasNext);
+  const [hasNextFollowingPage, setHasNextFollowingPage] = useState(
+    initialFollowingHasNext,
+  );
+  const [hasNextLikedPage, setHasNextLikedPage] = useState(initialLikedHasNext);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
@@ -73,15 +81,19 @@ export function HomeFeedShell({
   const posts =
     activeTab === "home"
       ? homePosts
-      : activeTab === "liked"
-        ? likedFeedPosts
-        : getPostsForTab(activeTab);
+      : activeTab === "following"
+        ? followingFeedPosts
+        : activeTab === "liked"
+          ? likedFeedPosts
+          : feedPosts;
   const hasNextActivePage =
     activeTab === "home"
       ? hasNextHomePage
-      : activeTab === "liked"
-        ? hasNextLikedPage
-        : false;
+      : activeTab === "following"
+        ? hasNextFollowingPage
+        : activeTab === "liked"
+          ? hasNextLikedPage
+          : false;
 
   useEffect(() => {
     const query = window.matchMedia("(min-width: 1024px)");
@@ -128,16 +140,39 @@ export function HomeFeedShell({
     setLoadError(null);
   }, [initialLikedPosts, initialLikedNextCursor, initialLikedHasNext]);
 
+  useEffect(() => {
+    setFollowingFeedPosts(initialFollowingPosts.map(toFeedPost));
+    setFollowingNextCursor(initialFollowingNextCursor);
+    setHasNextFollowingPage(initialFollowingHasNext);
+    setLoadError(null);
+  }, [
+    initialFollowingPosts,
+    initialFollowingNextCursor,
+    initialFollowingHasNext,
+  ]);
+
   const loadMorePosts = useCallback(async () => {
     const endpoint =
       activeTab === "home"
         ? "/api/posts"
-        : activeTab === "liked"
-          ? "/api/users/me/liked-posts"
-          : null;
-    const cursor = activeTab === "home" ? homeNextCursor : likedNextCursor;
+        : activeTab === "following"
+          ? "/api/users/me/following/posts"
+          : activeTab === "liked"
+            ? "/api/users/me/liked-posts"
+            : null;
+    const cursor =
+      activeTab === "home"
+        ? homeNextCursor
+        : activeTab === "following"
+          ? followingNextCursor
+          : likedNextCursor;
 
-    if (!endpoint || !hasNextActivePage || !cursor || isLoadingMoreRef.current) {
+    if (
+      !endpoint ||
+      !hasNextActivePage ||
+      !cursor ||
+      isLoadingMoreRef.current
+    ) {
       return;
     }
 
@@ -159,12 +194,16 @@ export function HomeFeedShell({
       const page = (await response.json()) as RecentPostCursorPage;
 
       if (activeTab === "home") {
-        setHomePosts((current) => [
+        setHomePosts((current) => [...current, ...page.posts.map(toFeedPost)]);
+        setHomeNextCursor(page.nextCursor);
+        setHasNextHomePage(page.hasNext);
+      } else if (activeTab === "following") {
+        setFollowingFeedPosts((current) => [
           ...current,
           ...page.posts.map(toFeedPost),
         ]);
-        setHomeNextCursor(page.nextCursor);
-        setHasNextHomePage(page.hasNext);
+        setFollowingNextCursor(page.nextCursor);
+        setHasNextFollowingPage(page.hasNext);
       } else {
         setLikedFeedPosts((current) => [
           ...current,
@@ -179,10 +218,21 @@ export function HomeFeedShell({
       isLoadingMoreRef.current = false;
       setIsLoadingMore(false);
     }
-  }, [activeTab, hasNextActivePage, homeNextCursor, likedNextCursor]);
+  }, [
+    activeTab,
+    followingNextCursor,
+    hasNextActivePage,
+    homeNextCursor,
+    likedNextCursor,
+  ]);
 
   useEffect(() => {
-    if ((activeTab !== "home" && activeTab !== "liked") || !hasNextActivePage) {
+    if (
+      (activeTab !== "home" &&
+        activeTab !== "following" &&
+        activeTab !== "liked") ||
+      !hasNextActivePage
+    ) {
       return;
     }
 
@@ -261,7 +311,9 @@ export function HomeFeedShell({
               ))}
             </div>
 
-            {activeTab === "home" || activeTab === "liked" ? (
+            {activeTab === "home" ||
+            activeTab === "following" ||
+            activeTab === "liked" ? (
               <div
                 ref={sentinelRef}
                 className="flex min-h-24 items-center justify-center py-6 text-sm text-zinc-500"
@@ -274,7 +326,9 @@ export function HomeFeedShell({
                     : posts.length === 0
                       ? activeTab === "liked" && !isLoggedIn
                         ? "Log in to see liked posts."
-                        : "No posts yet."
+                        : activeTab === "following" && !isLoggedIn
+                          ? "Log in to see following posts."
+                          : "No posts yet."
                       : hasNextActivePage
                         ? ""
                         : "No more posts."}
@@ -354,7 +408,9 @@ function ArticleCard({ post }: { post: FeedPost }) {
         href={post.href}
         className={cn(
           "group grid gap-5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/20",
-          thumbnailSrc ? "sm:grid-cols-[minmax(0,1fr)_184px] sm:items-center" : "",
+          thumbnailSrc
+            ? "sm:grid-cols-[minmax(0,1fr)_184px] sm:items-center"
+            : "",
         )}
       >
         <div className="min-w-0">
@@ -404,14 +460,6 @@ function ArticleCard({ post }: { post: FeedPost }) {
       </div>
     </article>
   );
-}
-
-function getPostsForTab(tab: TabKey) {
-  if (tab === "following") {
-    return followingPosts;
-  }
-
-  return feedPosts;
 }
 
 function toFeedPost(post: RecentPostSummary): FeedPost {

--- a/frontend/src/01_widgets/home-feed/ui/data.ts
+++ b/frontend/src/01_widgets/home-feed/ui/data.ts
@@ -79,8 +79,6 @@ export const feedPosts: FeedPost[] = [
   },
 ];
 
-export const followingPosts: FeedPost[] = feedPosts.slice(1, 4);
-
 export const likedPosts: FeedPost[] = [feedPosts[0], feedPosts[2]];
 
 export const recommendedTopics = [

--- a/frontend/src/03_entities/post/api/getFollowingPosts.ts
+++ b/frontend/src/03_entities/post/api/getFollowingPosts.ts
@@ -1,0 +1,24 @@
+import { headers } from "next/headers";
+import { API_CONFIG } from "@/shared/api";
+import { apiClient } from "@/shared/api/apiClient";
+import type { RecentPostCursorPage } from "./getRecentPosts";
+
+export async function getFollowingPosts(cursor?: string | null, size = 10) {
+  const headerStore = await headers();
+  const params = new URLSearchParams({
+    size: String(size),
+  });
+  if (cursor) {
+    params.set("cursor", cursor);
+  }
+
+  return apiClient<RecentPostCursorPage>(
+    `${API_CONFIG.baseURL}/users/me/following/posts?${params}`,
+    {
+      cache: "no-store",
+      headers: {
+        cookie: headerStore.get("cookie") ?? "",
+      },
+    },
+  );
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #

---

## 1. PR 유형
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ✨ 새로운 기능 (New Feature)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 업데이트 (Documentation)
- [ ] ⚙️ 설정/빌드 변경 (Chore)

---

## 2. 변경 배경 및 목표
- **변경 전 상태:** 홈 피드의 `following` 탭은 실제 팔로우 관계 기반 데이터가 아니라 프론트의 정적 더미 목록을 사용했다. 백엔드에는 로그인 사용자가 팔로우한 사용자의 게시글만 커서 기반으로 조회하는 API가 없었다.
- **문제/필요성:** 사용자가 팔로우한 작성자의 게시글을 피드에서 확인할 수 없어 `following` 탭이 실제 서비스 데이터와 연결되지 않았다. 또한 홈/좋아요 피드처럼 추가 페이지를 이어서 불러오는 동일한 커서 페이지네이션 흐름이 필요했다.
- **이번 PR의 목표:** 로그인 사용자의 팔로우 관계를 기준으로 게시글을 최신순으로 조회하고, 프론트 `following` 탭에서 초기 로딩과 무한 스크롤 추가 로딩을 실제 API 데이터로 처리한다.

---

## 3. 주요 구현 내용 및 동작 방식

### A. 팔로잉 게시글 조회 API 추가
- **관련 위치/대상:** `UserController`, `UserService`, `PostRepository`, `DateTimeIdCursorCodec`
- **변경 전 상황:** `GET /users/me/liked-posts`처럼 로그인 사용자 기준 피드성 목록을 조회하는 API는 있었지만, 팔로우한 작성자의 게시글만 조회하는 엔드포인트와 repository 쿼리는 없었다.
- **변경한 내용:** `GET /users/me/following/posts`를 추가하고, 현재 로그인 사용자 ID를 기준으로 `Follow` 관계의 `followedUser`가 작성한 게시글만 조회하도록 JPQL 쿼리를 추가했다.
- **변경 후 동작:** 클라이언트는 `cursor` 없이 첫 페이지를 조회하고, 응답의 `nextCursor`를 다음 요청에 전달해 팔로잉 게시글 목록을 이어서 가져올 수 있다.
- **구현 흐름:**
  1. 컨트롤러가 현재 사용자를 확인한 뒤 `cursor`, `size`와 함께 서비스에 위임한다.
  2. 서비스는 `size`를 최대 10개로 보정하고, 커서가 있으면 `createdAt`, `id` 기준값으로 디코딩한다.
  3. repository는 팔로우 관계에 포함된 작성자의 게시글을 `createdAt desc, id desc` 순서로 `size + 1`개 조회한다.
  4. 서비스는 실제 응답 개수만 `take(size)`로 자르고, 초과 조회분 존재 여부로 `hasNext`를 계산한다.
  5. 다음 페이지가 있으면 현재 페이지 마지막 게시글의 `createdAt`, `id`로 `nextCursor`를 생성한다.
- **바뀌는 데이터/상태:** `RecentPostCursorResponse.posts`, `size`, `nextCursor`, `hasNext`가 팔로잉 게시글 기준으로 반환된다. 좋아요 수, 댓글 수, 썸네일, 작성자 정보는 기존 최근/좋아요 피드 응답과 같은 형태로 매핑된다.
- **영향 범위:** 로그인 사용자 팔로잉 피드 API, 커서 기반 페이지네이션 쿼리, 게시글 요약 응답 매핑 로직.

### B. 프론트 following 탭을 실제 API 데이터로 연결
- **관련 위치/대상:** `HomeFeed`, `HomeFeedShell`, `getFollowingPosts`, `/api/users/me/following/posts` route handler, `data.ts`
- **변경 전 상황:** `following` 탭은 `feedPosts.slice(1, 4)`로 만든 정적 목록을 사용했고, 추가 로딩 대상에도 포함되지 않았다.
- **변경한 내용:** 서버 컴포넌트 초기 렌더링에서 로그인 사용자의 팔로잉 게시글 첫 페이지를 조회하고, 클라이언트 shell에서 following 전용 목록, 커서, `hasNext` 상태를 관리하도록 추가했다.
- **변경 후 동작:** `following` 탭 진입 시 실제 팔로잉 게시글이 렌더링된다. 스크롤 하단 sentinel이 감지되면 `/api/users/me/following/posts` 프록시 route를 통해 다음 페이지를 불러온다.
- **구현 흐름:**
  1. `HomeFeed`가 `activeTab === "following"`이고 로그인 상태일 때 `getFollowingPosts(null, 10)`을 호출한다.
  2. `HomeFeedShell`은 `followingFeedPosts`, `followingNextCursor`, `hasNextFollowingPage`를 별도 상태로 보관한다.
  3. 추가 로딩 시 active tab에 따라 `/api/users/me/following/posts` endpoint와 following cursor를 선택한다.
  4. 응답을 기존 목록 뒤에 append하고, 다음 cursor와 `hasNext`를 갱신한다.
- **바뀌는 데이터/상태:** 프론트의 following 탭 데이터 소스가 정적 더미 데이터에서 API 응답으로 변경된다. `followingPosts` 더미 export는 제거된다.
- **영향 범위:** 홈 피드 `following` 탭 초기 로딩, 무한 스크롤 추가 로딩, 비로그인 상태 안내 문구.

### C. 팔로잉 피드 응답 매핑과 테스트 보강
- **관련 위치/대상:** `UserService`, `UserServiceTest`
- **변경 전 상황:** 좋아요 피드 응답 매핑 코드가 서비스 내부에 직접 작성되어 있었고, 팔로잉 피드에서도 같은 게시글 요약 응답 형식이 필요했다.
- **변경한 내용:** 게시글을 `RecentPostResponse`로 변환하는 `toRecentPostResponse` helper를 추가해 팔로잉/좋아요 피드에서 같은 매핑을 사용하도록 정리했다. 팔로잉 게시글 첫 페이지와 커서 페이지 조회 테스트를 추가했다.
- **변경 후 동작:** 팔로잉 피드와 좋아요 피드는 작성자, 썸네일, 좋아요 수, 댓글 수를 같은 방식으로 응답한다.
- **영향 범위:** `UserService`의 피드성 게시글 응답 생성 로직, 팔로잉 게시글 커서 조회 단위 테스트.

---

## 4. 스크린샷 (선택)
- 없음. 이번 변경은 following 탭의 데이터 소스와 추가 로딩 동작을 실제 API로 연결하는 변경이며, 별도 시각 디자인 변경은 없다.

---

## 5. 테스트 및 검증 방법
- **검증 환경:** 로컬 워크스페이스, Gradle backend test
- **검증한 시나리오:**
  - 팔로잉 게시글 첫 페이지 조회 시 요청 size가 10을 초과해도 응답 size가 10으로 제한되는지 확인
  - `size + 1`개 조회 결과가 있을 때 `hasNext=true`와 10번째 게시글 기준 `nextCursor`가 반환되는지 확인
  - 커서가 포함된 다음 페이지 요청에서 커서 이후 게시글이 조회되고, 다음 페이지가 없으면 `nextCursor=null`, `hasNext=false`가 되는지 확인
  - 게시글 요약 응답에 작성자 정보, 썸네일, 좋아요 수, 댓글 수가 매핑되는지 확인
- **확인한 결과:** `./gradlew :backend:test --tests io.github.kitae9999.openlog.user.UserServiceTest` 실행 결과 `BUILD SUCCESSFUL in 4s`
- **확인하지 못한 부분:** 브라우저에서 로그인 후 following 탭을 스크롤하는 E2E 흐름과 전체 CI는 실행하지 않았다.

---

## 6. 리뷰어 참고 사항 (선택)
- **리뷰할 때 봐야 할 점:** `PostRepository`의 팔로잉 게시글 조회 쿼리가 `Follow.followingUser.id`와 `Follow.followedUser.id`를 올바른 방향으로 사용하고 있는지 확인이 필요하다. 커서 조건은 최신순 정렬과 맞추기 위해 `createdAt < cursor.createdAt` 또는 같은 시간일 때 `id < cursor.id`를 사용한다.
- **영향 범위:** 로그인 사용자의 following 피드 API와 홈 피드 following 탭에 한정된다.

---

## 7. 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일 가이드를 준수합니다.
- [x] 변경 사항에 대한 테스트 코드를 작성하거나 통과했습니다.
- [ ] 관련된 문서(README, API 명세 등)를 업데이트했습니다.
