### PR TITLE
[Deploy] Terraform 도입

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,15 @@ AGENTS.private.md
 
 /_docs/*
 .agent/
+
+### Terraform ###
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+*.tfvars
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/infra/terraform/production/.terraform.lock.hcl
+++ b/infra/terraform/production/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.23.0"
+  constraints = "7.23.0"
+  hashes = [
+    "h1:8NwMbqR/drRxeWfc1IG6yfvQeXesX8cFSpA0Pnpe+fk=",
+    "zh:23b834f436dec7132cc42fdbe6ab7d74fc574b7a86ec7a56f7be9d42911a3afc",
+    "zh:2f1e2db52a79ee913fef18f0a0445d8c1cbda4c253d7ffb2a7c1f2b87e84980c",
+    "zh:4903221645602f42c6b642275a748b85b9621f6a24a2417cc6424d68a46ca88c",
+    "zh:4cae4ab9dc9e6779437395a353e173b4eb697a06e29fbc1aefa0cf2f5b5e31cc",
+    "zh:50e6bf71226e688519f4fff24a925ff396495afbdbddadb9c960a291c351fe84",
+    "zh:67fe1762aff9d270624c8d5a002c527d37a0e0ccc3c5eea712dfed7d0ecc46ab",
+    "zh:7ae8fb0cc76fbca06cd4f32bacd69984152b8d4b34268546e295f1e28892af13",
+    "zh:b8ec2d6626bb0795aea3fc6db052e7d472777ce9838e92f4396826bcdbfc1880",
+    "zh:d5642b8d0e2dda6316379a7e128d724f604b0f8625f9ecc706c662d9f302c32b",
+    "zh:dfc8f2d943aeed758b89166a1c20d6af67ae692b9cae832a9048e0cfb1e01ff5",
+    "zh:e768422d524b19d7a327de97f9621c1abd5958d3787efa02c0c61bb164d3e925",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infra/terraform/production/backend.tf
+++ b/infra/terraform/production/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "openlog-490106-terraform-state"
+    prefix = "openlog/production"
+  }
+}

--- a/infra/terraform/production/compute.tf
+++ b/infra/terraform/production/compute.tf
@@ -2,4 +2,57 @@ resource "google_compute_instance" "app" {
   name         = "instance-20260423-083246"
   machine_type = "e2-standard-2"
   zone         = "asia-northeast3-a"
+
+  tags = [
+    "http-server",
+    "https-server",
+  ]
+
+  labels = {
+    "goog-ops-agent-policy" = "v2-template-1-7-0"
+  }
+
+  metadata = {
+    "enable-osconfig" = "TRUE"
+  }
+
+  boot_disk {
+    auto_delete = true
+    device_name = "instance-20260423-083246"
+    mode        = "READ_WRITE"
+    source      = "https://www.googleapis.com/compute/v1/projects/openlog-490106/zones/asia-northeast3-a/disks/instance-20260423-083246"
+  }
+
+  network_interface {
+    network    = "https://www.googleapis.com/compute/v1/projects/openlog-490106/global/networks/default"
+    subnetwork = "https://www.googleapis.com/compute/v1/projects/openlog-490106/regions/asia-northeast3/subnetworks/default"
+
+    access_config {
+      network_tier = "PREMIUM"
+    }
+  }
+
+  service_account {
+    email = "openlog-storage@openlog-490106.iam.gserviceaccount.com"
+    scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+  }
+
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+    preemptible         = false
+    provisioning_model  = "STANDARD"
+  }
+
+  shielded_instance_config {
+    enable_integrity_monitoring = true
+    enable_secure_boot          = false
+    enable_vtpm                 = true
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }

--- a/infra/terraform/production/compute.tf
+++ b/infra/terraform/production/compute.tf
@@ -3,14 +3,15 @@ resource "google_compute_instance" "app" {
   machine_type = "e2-standard-2"
   zone         = "asia-northeast3-a"
 
+  can_ip_forward             = false
+  deletion_protection        = false
+  enable_display             = false
+  key_revocation_action_type = "NONE"
+
   tags = [
     "http-server",
     "https-server",
   ]
-
-  labels = {
-    "goog-ops-agent-policy" = "v2-template-1-7-0"
-  }
 
   metadata = {
     "enable-osconfig" = "TRUE"
@@ -50,6 +51,14 @@ resource "google_compute_instance" "app" {
     enable_integrity_monitoring = true
     enable_secure_boot          = false
     enable_vtpm                 = true
+  }
+
+  confidential_instance_config {
+    enable_confidential_compute = false
+  }
+
+  reservation_affinity {
+    type = "ANY_RESERVATION"
   }
 
   lifecycle {

--- a/infra/terraform/production/compute.tf
+++ b/infra/terraform/production/compute.tf
@@ -1,0 +1,5 @@
+resource "google_compute_instance" "app" {
+  name         = "instance-20260423-083246"
+  machine_type = "e2-standard-2"
+  zone         = "asia-northeast3-a"
+}

--- a/infra/terraform/production/compute.tf
+++ b/infra/terraform/production/compute.tf
@@ -33,7 +33,7 @@ resource "google_compute_instance" "app" {
   }
 
   service_account {
-    email = "openlog-storage@openlog-490106.iam.gserviceaccount.com"
+    email = google_service_account.storage.email
     scopes = [
       "https://www.googleapis.com/auth/cloud-platform",
     ]

--- a/infra/terraform/production/iam.tf
+++ b/infra/terraform/production/iam.tf
@@ -1,0 +1,21 @@
+resource "google_service_account" "storage" {
+  account_id   = "openlog-storage"
+  display_name = "openlog-storage"
+  description  = "cloud storage 접근"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_member" "storage_object_admin" {
+  project = "openlog-490106"
+  role    = "roles/storage.objectAdmin"
+  member  = "serviceAccount:${google_service_account.storage.email}"
+}
+
+resource "google_storage_bucket_iam_member" "media_object_admin" {
+  bucket = google_storage_bucket.media.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.storage.email}"
+}

--- a/infra/terraform/production/network.tf
+++ b/infra/terraform/production/network.tf
@@ -33,8 +33,9 @@ resource "google_compute_firewall" "default_allow_https" {
 }
 
 resource "google_compute_firewall" "default_allow_ssh" {
-  name    = "default-allow-ssh"
-  network = "default"
+  name        = "default-allow-ssh"
+  network     = "default"
+  description = "Allow SSH from anywhere"
 
   direction = "INGRESS"
   priority  = 65534
@@ -48,8 +49,9 @@ resource "google_compute_firewall" "default_allow_ssh" {
 }
 
 resource "google_compute_firewall" "default_allow_rdp" {
-  name    = "default-allow-rdp"
-  network = "default"
+  name        = "default-allow-rdp"
+  network     = "default"
+  description = "Allow RDP from anywhere"
 
   direction = "INGRESS"
   priority  = 65534
@@ -63,8 +65,9 @@ resource "google_compute_firewall" "default_allow_rdp" {
 }
 
 resource "google_compute_firewall" "default_allow_icmp" {
-  name    = "default-allow-icmp"
-  network = "default"
+  name        = "default-allow-icmp"
+  network     = "default"
+  description = "Allow ICMP from anywhere"
 
   direction = "INGRESS"
   priority  = 65534
@@ -77,8 +80,9 @@ resource "google_compute_firewall" "default_allow_icmp" {
 }
 
 resource "google_compute_firewall" "default_allow_internal" {
-  name    = "default-allow-internal"
-  network = "default"
+  name        = "default-allow-internal"
+  network     = "default"
+  description = "Allow internal traffic on the default network"
 
   direction = "INGRESS"
   priority  = 65534

--- a/infra/terraform/production/network.tf
+++ b/infra/terraform/production/network.tf
@@ -1,14 +1,101 @@
-resource "google_compute_firewall" "allow_http_https" {
-  name    = "openlog-allow-http-https"
+# These mirror the current default VPC firewall rules. Tighten them in a
+# separate change after the existing infrastructure is imported cleanly.
+resource "google_compute_firewall" "default_allow_http" {
+  name    = "default-allow-http"
   network = "default"
 
   direction = "INGRESS"
+  priority  = 1000
 
   allow {
     protocol = "tcp"
-    ports    = ["80", "443"]
+    ports    = ["80"]
   }
 
   source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["http-server", "https-server"]
+  target_tags   = ["http-server"]
+}
+
+resource "google_compute_firewall" "default_allow_https" {
+  name    = "default-allow-https"
+  network = "default"
+
+  direction = "INGRESS"
+  priority  = 1000
+
+  allow {
+    protocol = "tcp"
+    ports    = ["443"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["https-server"]
+}
+
+resource "google_compute_firewall" "default_allow_ssh" {
+  name    = "default-allow-ssh"
+  network = "default"
+
+  direction = "INGRESS"
+  priority  = 65534
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}
+
+resource "google_compute_firewall" "default_allow_rdp" {
+  name    = "default-allow-rdp"
+  network = "default"
+
+  direction = "INGRESS"
+  priority  = 65534
+
+  allow {
+    protocol = "tcp"
+    ports    = ["3389"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}
+
+resource "google_compute_firewall" "default_allow_icmp" {
+  name    = "default-allow-icmp"
+  network = "default"
+
+  direction = "INGRESS"
+  priority  = 65534
+
+  allow {
+    protocol = "icmp"
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}
+
+resource "google_compute_firewall" "default_allow_internal" {
+  name    = "default-allow-internal"
+  network = "default"
+
+  direction = "INGRESS"
+  priority  = 65534
+
+  allow {
+    protocol = "tcp"
+    ports    = ["0-65535"]
+  }
+
+  allow {
+    protocol = "udp"
+    ports    = ["0-65535"]
+  }
+
+  allow {
+    protocol = "icmp"
+  }
+
+  source_ranges = ["10.128.0.0/9"]
 }

--- a/infra/terraform/production/network.tf
+++ b/infra/terraform/production/network.tf
@@ -1,0 +1,14 @@
+resource "google_compute_firewall" "allow_http_https" {
+  name    = "openlog-allow-http-https"
+  network = "default"
+
+  direction = "INGRESS"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80", "443"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["http-server", "https-server"]
+}

--- a/infra/terraform/production/provider.tf
+++ b/infra/terraform/production/provider.tf
@@ -1,0 +1,5 @@
+provider "google" {
+  project = "openlog-490106"
+  region = "asia-northeast3"
+  zone = "asia-northeast3-a"
+}

--- a/infra/terraform/production/provider.tf
+++ b/infra/terraform/production/provider.tf
@@ -1,5 +1,6 @@
 provider "google" {
-  project = "openlog-490106"
-  region  = "asia-northeast3"
-  zone    = "asia-northeast3-a"
+  project                         = "openlog-490106"
+  region                          = "asia-northeast3"
+  zone                            = "asia-northeast3-a"
+  add_terraform_attribution_label = false
 }

--- a/infra/terraform/production/provider.tf
+++ b/infra/terraform/production/provider.tf
@@ -1,5 +1,5 @@
 provider "google" {
   project = "openlog-490106"
-  region = "asia-northeast3"
-  zone = "asia-northeast3-a"
+  region  = "asia-northeast3"
+  zone    = "asia-northeast3-a"
 }

--- a/infra/terraform/production/storage.tf
+++ b/infra/terraform/production/storage.tf
@@ -1,4 +1,34 @@
 resource "google_storage_bucket" "media" {
-  name     = "openlog_prod"
-  location = "ASIA"
+  name                        = "openlog_prod"
+  location                    = "ASIA"
+  storage_class               = "STANDARD"
+  public_access_prevention    = "enforced"
+  uniform_bucket_level_access = true
+
+  cors {
+    max_age_seconds = 3600
+    method = [
+      "GET",
+      "PUT",
+      "HEAD",
+    ]
+    origin = [
+      "http://localhost:3030",
+      "http://127.0.0.1:3030",
+      "https://openlog.kr",
+      "https://www.openlog.kr",
+    ]
+    response_header = [
+      "Content-Type",
+      "Access-Control-Allow-Origin",
+    ]
+  }
+
+  soft_delete_policy {
+    retention_duration_seconds = 604800
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }

--- a/infra/terraform/production/storage.tf
+++ b/infra/terraform/production/storage.tf
@@ -1,0 +1,4 @@
+resource "google_storage_bucket" "media" {
+  name     = "openlog_prod"
+  location = "ASIA"
+}

--- a/infra/terraform/production/versions.tf
+++ b/infra/terraform/production/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "7.23.0"
+    }
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #

---

## 1. PR 유형
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ✨ 새로운 기능 (New Feature)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 업데이트 (Documentation)
- [x] ⚙️ 설정/빌드 변경 (Chore)

---

## 2. 변경 배경 및 목표
- **변경 전 상태:** 운영 GCP 인프라는 콘솔과 CLI로 생성된 상태였고, repository에는 현재 VM, 방화벽, GCS bucket, IAM, Terraform state 저장 위치를 설명하는 Terraform 코드가 없었다.
- **문제/필요성:** 인프라 변경 이력이 코드로 남지 않아 운영 리소스의 현재 상태를 리뷰하거나 재현하기 어려웠다. 또한 Terraform import 후 로컬 state 파일을 그대로 둘 경우 state 유실과 민감한 인프라 정보의 Git 유입 위험이 있었다.
- **이번 PR의 목표:** 현재 운영 인프라를 Terraform 코드와 remote state backend로 편입하고, 이후 변경을 `terraform plan`으로 검토할 수 있는 기반을 만든다.

---

## 3. 주요 구현 내용 및 동작 방식

### A. GCP 운영 리소스 Terraform 코드 추가
- **관련 위치/대상:** `infra/terraform/production/versions.tf`, `provider.tf`, `compute.tf`, `network.tf`, `storage.tf`, `iam.tf`
- **변경 전 상황:** 운영 VM과 기본 VPC 방화벽, 미디어용 GCS bucket, GCS 접근용 service account/IAM 권한이 GCP에는 존재했지만 Terraform resource로 관리되지 않았다.
- **변경한 내용:** GCP provider 7.23.0을 고정하고, 운영 VM, default firewall rule, GCS bucket, service account, project/bucket IAM member를 Terraform resource로 작성했다.
- **변경 후 동작:** Terraform은 import된 실제 GCP 리소스와 HCL을 비교할 수 있다. 현재 HCL은 실제 인프라와 일치하도록 작성되어 `terraform plan`에서 변경사항이 발생하지 않는다.
- **구현 흐름:**
  1. `versions.tf`에서 Terraform CLI 최소 버전과 Google provider 버전을 고정한다.
  2. `provider.tf`에서 GCP project, region, zone을 설정하고 provider attribution label 자동 추가를 비활성화한다.
  3. `compute.tf`에서 기존 운영 VM의 boot disk, network, service account, scheduling, shielded/confidential 설정을 현재 상태에 맞춰 작성한다.
  4. `network.tf`에서 기존 default firewall rule을 실제 rule 단위와 description까지 맞춰 작성한다.
  5. `storage.tf`, `iam.tf`에서 GCS bucket, service account, IAM member를 현재 운영 상태와 맞춰 작성한다.
- **바뀌는 데이터/상태:** Terraform 코드상 운영 인프라 구성 정보가 추가된다. 실제 GCP 리소스는 `plan` 기준 변경되지 않는다.
- **영향 범위:** 운영 GCP 인프라 관리 코드, Terraform import/plan workflow.

### B. 중요한 운영 리소스 삭제 방지 설정 추가
- **관련 위치/대상:** `compute.tf`, `storage.tf`, `iam.tf`
- **변경 전 상황:** Terraform 편입 과정에서 HCL과 실제 리소스 속성이 다르면 VM 또는 bucket 교체/삭제 계획이 나올 수 있었다.
- **변경한 내용:** 운영 VM, GCS bucket, service account에 `lifecycle.prevent_destroy = true`를 설정했다. VM replacement를 유발하던 state 차이는 실제 GCP 값에 맞춰 `key_revocation_action_type`, confidential/reservation 설정 등을 HCL에 반영했다.
- **변경 후 동작:** 운영 VM, GCS bucket, service account에 대한 삭제 계획이 나오면 Terraform apply가 실패한다. 현재 plan에서는 destroy/replace 없이 `No changes`가 나온다.
- **바뀌는 데이터/상태:** Terraform lifecycle 정책이 추가된다. 실제 리소스 속성 변경은 없다.
- **영향 범위:** Terraform으로 운영 VM, GCS bucket, service account를 변경하는 모든 작업.

### C. Terraform state GCS backend 구성
- **관련 위치/대상:** `infra/terraform/production/backend.tf`, `.gitignore`
- **변경 전 상황:** import 후 생성된 Terraform state가 로컬 파일로 남아 있어 Git 유입과 유실 위험이 있었다.
- **변경한 내용:** GCS backend를 추가해 production state를 GCS bucket의 `openlog/production` prefix 아래 저장하도록 구성했다. `.gitignore`에는 `.terraform/`, `*.tfstate`, `*.tfvars`, override/crash 파일을 제외하도록 추가했다.
- **변경 후 동작:** `terraform init -migrate-state` 이후 Terraform은 로컬 state 대신 GCS backend의 state object를 사용한다. `.terraform.lock.hcl`은 provider 재현성을 위해 repository에 포함된다.
- **구현 흐름:**
  1. state 저장용 GCS bucket을 별도로 생성하고 public access prevention, uniform bucket-level access, versioning을 설정한다.
  2. `backend.tf`에 `backend "gcs"` 설정을 추가한다.
  3. `terraform init -migrate-state -force-copy`로 로컬 state를 GCS backend로 이전한다.
  4. 로컬 `terraform.tfstate`, `terraform.tfstate.backup` 파일은 삭제한다.
- **바뀌는 데이터/상태:** Terraform state 저장 위치가 로컬 파일에서 GCS backend로 변경된다.
- **영향 범위:** production Terraform 실행 환경, state 보관/복구 방식.

---

## 4. 스크린샷 (선택)
- 해당 없음. 이번 변경은 인프라 관리 코드와 Terraform state backend 구성 변경이다.

## 5. 테스트 및 검증 방법
- **검증 환경:** 로컬 개발 환경, GCP 인증된 `gcloud`/Terraform CLI, GCS backend
- **검증한 시나리오:**
  - Terraform provider 초기화 및 backend migration 확인
  - Terraform HCL formatting 확인
  - Terraform provider schema 기준 validation 확인
  - import된 운영 리소스와 HCL/state/실제 GCP 상태가 일치하는지 plan 확인
  - GCS backend state object 생성 여부와 state bucket의 public access prevention/versioning 설정 확인
- **확인한 결과:**
  - `terraform fmt` 성공
  - `terraform validate` 성공
  - `terraform plan -no-color` 결과 `No changes. Your infrastructure matches the configuration.`
  - GCS backend state object 생성 확인
- **확인하지 못한 부분:** Terraform을 CI에서 실행하는 workflow와 복수 사용자 동시 실행 시나리오는 검증하지 않았다.

---

## 6. 리뷰어 참고 사항 (선택)
- **리뷰할 때 봐야 할 점:** 현재 `network.tf`는 보안 개선이 아니라 기존 default firewall rule을 그대로 import하기 위한 표현이다. SSH/RDP 전체 공개 규칙 축소는 별도 PR에서 다루는 것이 안전하다.
- **영향 범위:** 이번 PR은 Terraform 코드와 state backend 설정에 한정된다. `terraform apply` 기준 실제 운영 인프라 변경은 없어야 한다.

---

## 7. 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일 가이드를 준수합니다.
- [x] 변경 사항에 대한 테스트 코드를 작성하거나 통과했습니다.
- [ ] 관련된 문서(README, API 명세 등)를 업데이트했습니다.
