### PR TITLE
refactor(auth): JWT Filter 및 SecurityConfig URL 인가 규칙 적용

### DIFF
--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/JwtAuthenticationFilter.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/JwtAuthenticationFilter.kt
@@ -46,19 +46,4 @@ class JwtAuthenticationFilter(
 
         filterChain.doFilter(request, response)
     }
-
-    private fun resolveUserIdFromJwt(request: HttpServletRequest): Long {
-        val accessToken = request.cookies
-            ?.firstOrNull { it.name == accessTokenCookieName }
-            ?.value
-            ?: throw OAuthAuthenticationException()
-
-        return jwtTokenService.parseUserId(accessToken)
-    }
-
-    fun resolveCurrentUser(request: HttpServletRequest): User {
-        val userId = resolveUserIdFromJwt(request)
-        return userRepository.findById(userId).getOrNull()
-            ?: throw OAuthAuthenticationException()
-    }
 }

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/JwtAuthenticationFilter.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/JwtAuthenticationFilter.kt
@@ -1,0 +1,64 @@
+package io.github.kitae9999.openlog.auth
+
+import io.github.kitae9999.openlog.auth.exception.OAuthAuthenticationException
+import io.github.kitae9999.openlog.common.exception.NotFoundException
+import io.github.kitae9999.openlog.user.entity.User
+import io.github.kitae9999.openlog.user.repository.UserRepository
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import kotlin.jvm.optionals.getOrNull
+
+
+@Component
+class JwtAuthenticationFilter(
+    private val jwtTokenService: JwtTokenService,
+    private val userRepository: UserRepository,
+    @Value("\${auth.jwt.cookie-name:openlog_access_token}")
+    private val accessTokenCookieName: String,
+): OncePerRequestFilter() { // kotlin 상속은 부모생성자 호출 명시성, OncePerRequestFilter를 상속받으면 해당 필터는 요청당 한번만 거치게된다.
+
+    override fun doFilterInternal( // doFilter는 부모 클래스인 OncePerRequestFilter, 비즈니스 로직은 상속받은 자식클래스에서 doFilterInternal
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val token = request.cookies
+            ?.firstOrNull { it.name == accessTokenCookieName } // 쿠키의 이름이 accessTokenCookieName인 첫번째 요소 반환 없으면 null
+            ?.value // Cookie 객체 안 실제 값
+
+        if (token != null ){
+            runCatching { // parseUserId에서 예외를 던져도 그냥 진행
+                val userId = jwtTokenService.parseUserId(token)
+                val user = userRepository.findById(userId).getOrNull() // 여기서 ?: throw 예외처리하면 로그인안한 사용자는 모두 예외처리나버림
+
+                if (user != null) {
+                    val auth = UsernamePasswordAuthenticationToken(user, null, emptyList()) // Authentication 객체 생성
+                    SecurityContextHolder.getContext().authentication = auth // Spring Security가 인증 상태를 저장하는 보관소에서 현재 이 요청의 SecurityContext를 꺼내서 그 안의 인증정보에 auth를 저장
+                }
+            }
+        }
+
+        filterChain.doFilter(request, response)
+    }
+
+    private fun resolveUserIdFromJwt(request: HttpServletRequest): Long {
+        val accessToken = request.cookies
+            ?.firstOrNull { it.name == accessTokenCookieName }
+            ?.value
+            ?: throw OAuthAuthenticationException()
+
+        return jwtTokenService.parseUserId(accessToken)
+    }
+
+    fun resolveCurrentUser(request: HttpServletRequest): User {
+        val userId = resolveUserIdFromJwt(request)
+        return userRepository.findById(userId).getOrNull()
+            ?: throw OAuthAuthenticationException()
+    }
+}

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/JwtTokenService.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/auth/JwtTokenService.kt
@@ -24,7 +24,9 @@ class JwtTokenService(
 ) {
     private val signingKey: SecretKey = Keys.hmacShaKeyFor(secret.toByteArray(StandardCharsets.UTF_8))
 
-
+    /**
+     * accessToken에서 userId 추출
+     */
     fun parseUserId(accessToken: String): Long {
         val claims = try {
             Jwts.parser()
@@ -40,6 +42,10 @@ class JwtTokenService(
             ?.toLongOrNull()
             ?: throw OAuthAuthenticationException()
     }
+
+    /**
+     * OpenLog용 AccessToken 생성
+     */
     fun createAccessToken(user: User): String {
         val userId = requireNotNull(user.id) { "JWT 발급 대상 사용자는 영속화되어 있어야 합니다." }
         val now = Instant.now()

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/config/SecurityConfig.kt
@@ -20,7 +20,7 @@ class SecurityConfig (
             .sessionManagement {
                 it.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
             }
-            .authorizeHttpRequests {
+            .authorizeHttpRequests { // 인가 규칙 설정, AuthorizationFilter에 연결
                 it
                     .requestMatchers( // 일단 모든 요청에 대해 인증여부 필터링걸어두지않음. todo: post생성, suggest생성같은 로그인 권한이 필요한 경로에 authenticated걸어두기
                         "/oauth2/**",

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/config/SecurityConfig.kt
@@ -1,39 +1,98 @@
 package io.github.kitae9999.openlog.config
 
 import io.github.kitae9999.openlog.auth.GithubOAuthSuccessHandler
+import io.github.kitae9999.openlog.auth.JwtAuthenticationFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 @Configuration
 @EnableWebSecurity
-class SecurityConfig (
-    private val githubOAuthSuccessHandler: GithubOAuthSuccessHandler
-){
+class SecurityConfig(
+    private val githubOAuthSuccessHandler: GithubOAuthSuccessHandler,
+    private val jwtAuthenticationFilter: JwtAuthenticationFilter,
+) {
     @Bean
-    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain { // @EnableWebSecurity로 지정된 클래스안에서 등록된 SecurityFilterChain 타입의 빈을 Spring Security가 보안 필터 체인으로 사용함
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
             .csrf { it.disable() }
             .sessionManagement {
                 it.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
             }
-            .authorizeHttpRequests { // 인가 규칙 설정, AuthorizationFilter에 연결
+            .authorizeHttpRequests {
                 it
-                    .requestMatchers( // 일단 모든 요청에 대해 인증여부 필터링걸어두지않음. todo: post생성, suggest생성같은 로그인 권한이 필요한 경로에 authenticated걸어두기
+                    // OAuth / 로그인
+                    .requestMatchers(
                         "/oauth2/**",
                         "/login/oauth2/**",
                         "/auth/google",
                         "/auth/google/callback",
+                        "/auth/github",
                     ).permitAll()
-                    .anyRequest().permitAll()
+                    // auth — 로그아웃/디바이스 로그인 시작·토큰 교환 공개
+                    .requestMatchers(
+                        HttpMethod.POST,
+                        "/auth/logout",
+                        "/auth/device/start",
+                        "/auth/device/token",
+                    ).permitAll()
+                    // auth — 내 정보/온보딩/디바이스 승인 인증 필요
+                    .requestMatchers(
+                        HttpMethod.GET,
+                        "/auth/me",
+                    ).authenticated()
+                    .requestMatchers(
+                        HttpMethod.POST,
+                        "/auth/onboarding",
+                        "/auth/device/approve",
+                    ).authenticated()
 
+                    // posts — GET 공개, 생성/수정/삭제 인증 필요
+                    .requestMatchers(HttpMethod.GET, "/posts").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/posts/*/comments").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/posts/*/suggestions").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/posts/*/suggestions/*").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/posts").authenticated()
+                    .requestMatchers(HttpMethod.POST, "/posts/**").authenticated()
+                    .requestMatchers(HttpMethod.PUT, "/posts/**").authenticated()
+                    .requestMatchers(HttpMethod.PATCH, "/posts/**").authenticated()
+                    .requestMatchers(HttpMethod.DELETE, "/posts/**").authenticated()
+
+                    // users — me/* 인증 필요, 프로필 조회 공개, 팔로우 변경 인증 필요
+                    .requestMatchers(HttpMethod.GET, "/users/me/**").authenticated()
+                    .requestMatchers(HttpMethod.PATCH, "/users/**").authenticated()
+                    .requestMatchers(HttpMethod.POST, "/users/*/follow").authenticated()
+                    .requestMatchers(HttpMethod.DELETE, "/users/*/follow").authenticated()
+                    .requestMatchers(HttpMethod.GET, "/users/*/following").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/users/*/followers").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/users/*/post-graph").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/users/*/posts/**").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/users/*").permitAll()
+
+                    // notifications — 전부 인증 필요
+                    .requestMatchers("/notifications/**").authenticated()
+
+                    // media — 조회 공개(컨트롤러에서 optional auth), 업로드/완료 처리 인증 필요
+                    .requestMatchers(HttpMethod.GET, "/media/assets/*").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/media/upload-url").authenticated()
+                    .requestMatchers(HttpMethod.PATCH, "/media/assets/*/completion").authenticated()
+
+                    // workspace — logs/tasks 전부 인증 필요 (owner 검사는 WorkspaceAccessResolver)
+                    .requestMatchers("/*/logs", "/*/logs/**").authenticated()
+                    .requestMatchers("/*/tasks", "/*/tasks/**").authenticated()
+
+                    // 위 규칙에 없는 경로는 공개 (optional auth는 컨트롤러에서 처리)
+                    .anyRequest().permitAll()
             }
             .oauth2Login {
                 it.successHandler(githubOAuthSuccessHandler)
             }
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
 
         return http.build()
     }


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #

---

## 1. PR 유형
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ✨ 새로운 기능 (New Feature)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 업데이트 (Documentation)
- [ ] ⚙️ 설정/빌드 변경 (Chore)

---

## 2. 변경 배경 및 목표
- **변경 전 상태:** Spring Security는 OAuth 로그인만 처리하고 `anyRequest().permitAll()`로 모든 API 접근을 허용했다. JWT 쿠키 검증과 사용자 조회는 각 Controller에서 `HttpServletRequest`와 `CurrentUserResolver.resolveCurrentUser()`를 반복 호출하는 방식으로 처리했다.
- **문제/필요성:** Controller마다 인증 보일러플레이트가 중복되고, Security 레이어에서 URL별 접근 제어를 하지 못했다. JWT가 있어도 `SecurityContext`에 principal이 채워지지 않아 `@AuthenticationPrincipal`이나 `authenticated()` 규칙을 사용할 수 없었다.
- **이번 PR의 목표:** JWT 쿠키를 Security Filter에서 한 번만 검증해 `SecurityContext`에 사용자 정보를 저장하고, `SecurityConfig`에서 엔드포인트별 `authenticated()` / `permitAll()` 규칙을 선언한다.

---

## 3. 주요 구현 내용 및 동작 방식

### A. JwtAuthenticationFilter 추가
- **관련 위치/대상:** `JwtAuthenticationFilter`, `JwtTokenService`, `UserRepository`
- **변경 전 상황:** API 요청마다 Controller가 JWT 쿠키를 직접 읽고 사용자를 조회했다. Filter chain에는 JWT 검증 단계가 없었다.
- **변경한 내용:** `OncePerRequestFilter`를 상속한 `JwtAuthenticationFilter`를 추가했다. 쿠키 이름은 `auth.jwt.cookie-name` 설정값을 사용한다.
- **변경 후 동작:** JWT 쿠키가 있고 파싱에 성공하면 `UsernamePasswordAuthenticationToken(user, null, emptyList())`을 만들어 `SecurityContextHolder`에 저장한다. JWT가 없거나 invalid이면 SecurityContext를 채우지 않고 다음 Filter로 넘긴다.
- **구현 흐름:**
  1. 요청 쿠키에서 access token을 찾는다.
  2. `JwtTokenService.parseUserId()`로 userId를 파싱한다.
  3. `UserRepository.findById()`로 User를 조회한다.
  4. User가 있으면 `SecurityContext.authentication`에 저장한다.
  5. `filterChain.doFilter()`로 chain을 계속 진행한다.
- **바뀌는 데이터/상태:** 요청 단위 `SecurityContext.authentication`에 `User` principal이 설정될 수 있다. JWT invalid 시 anonymous 상태로 유지된다.
- **영향 범위:** 모든 HTTP API 요청

### B. SecurityConfig Filter 등록 및 URL 인가 규칙
- **관련 위치/대상:** `SecurityConfig`
- **변경 전 상황:** OAuth 경로만 `permitAll()`이고 나머지 API는 모두 공개였다. JWT Filter가 chain에 등록되어 있지 않았다.
- **변경한 내용:** `addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)`로 Filter를 등록했다. Controller 기준으로 인증이 필요한 경로에 `authenticated()`, 공개/optional auth GET 경로에 `permitAll()`을 설정했다.
- **변경 후 동작:** `authenticated()` URL은 SecurityContext에 principal이 없으면 401을 반환한다. public URL은 JWT invalid여도 접근 가능하다.
- **구현 흐름:**
  1. `JwtAuthenticationFilter`가 JWT를 SecurityContext에 반영한다.
  2. `AuthorizationFilter`가 `authorizeHttpRequests` 규칙을 평가한다.
  3. 규칙을 통과한 요청만 Controller까지 전달된다.
- **바뀌는 데이터/상태:** 인증 필수 API에서 principal 없는 요청은 Controller 진입 전 401로 종료된다.
- **영향 범위:** auth, posts, users, notifications, media, workspace logs/tasks API

#### 인가 규칙 요약
| 구분 | 경로 패턴 | 처리 |
|------|-----------|------|
| OAuth / 로그인 | `/oauth2/**`, `/login/oauth2/**`, `/auth/google`, `/auth/google/callback`, `/auth/github` | permitAll |
| auth 공개 | `POST /auth/logout`, `/auth/device/start`, `/auth/device/token` | permitAll |
| auth 인증 | `GET /auth/me`, `POST /auth/onboarding`, `/auth/device/approve` | authenticated |
| posts | `GET /posts`, `/posts/*/comments`, `/posts/*/suggestions/**` | permitAll |
| posts 변경 | `POST/PUT/PATCH/DELETE /posts/**` | authenticated |
| users me | `GET /users/me/**` | authenticated |
| users 공개 | `GET /users/*`, `/users/*/posts/**`, `/following`, `/followers`, `/post-graph` | permitAll |
| users 변경 | `PATCH /users/**`, `POST/DELETE /users/*/follow` | authenticated |
| notifications | `/notifications/**` | authenticated |
| media | `GET /media/assets/*` | permitAll |
| media 변경 | `POST /media/upload-url`, `PATCH /media/assets/*/completion` | authenticated |
| workspace | `/*/logs/**`, `/*/tasks/**` | authenticated |

- **참고:** `server.servlet.context-path=/api`는 Security matcher에 포함하지 않는다. workspace API는 `feature/workspace` merge를 대비해 미리 규칙을 추가했다.

---

## 4. 스크린샷 (선택)
- 해당 없음

## 5. 테스트 및 검증 방법
- **검증 환경:** 로컬 개발 환경
- **검증한 시나리오:**
  - `./gradlew :backend:compileKotlin` 실행
  - `./gradlew :backend:test` 실행
- **확인한 결과:**
  - backend compile/test 성공
- **확인하지 못한 부분:**
  - 실제 HTTP 요청 기준 401/200 응답 (JWT 유/무, public/authenticated URL 조합)
  - Controller `@AuthenticationPrincipal` 전환 후 E2E 동작
  - `feature/workspace` merge 이후 workspace API 통합 검증

---

## 6. 리뷰어 참고 사항
- **리뷰할 때 봐야 할 점:**
  - JWT invalid + public URL 조합에서 Filter가 예외를 throw하지 않고 anonymous로 통과하는지
  - `/users/me/**` 규칙이 `/users/*` public 규칙보다 위에 있는지
  - workspace owner 검사는 `WorkspaceAccessResolver` 책임이며, SecurityConfig는 로그인 여부만 확인한다
- **영향 범위:** backend Security Filter chain, URL 인가 규칙. Controller는 아직 `CurrentUserResolver`를 사용하므로 후속 PR에서 `@AuthenticationPrincipal` 전환이 필요하다.

---

## 7. 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일 가이드를 준수합니다.
- [x] 변경 사항에 대한 테스트 코드를 작성하거나 통과했습니다.
- [ ] 관련된 문서(README, API 명세 등)를 업데이트했습니다.
