### PR TITLE
fix(auth): 미인증 API 응답을 401 JSON으로 통일

### DIFF
--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/config/SecurityConfig.kt
@@ -1,10 +1,14 @@
 package io.github.kitae9999.openlog.config
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.github.kitae9999.openlog.auth.GithubOAuthSuccessHandler
 import io.github.kitae9999.openlog.auth.JwtAuthenticationFilter
+import io.github.kitae9999.openlog.common.exception.ErrorResponse
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
@@ -16,6 +20,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 class SecurityConfig(
     private val githubOAuthSuccessHandler: GithubOAuthSuccessHandler,
     private val jwtAuthenticationFilter: JwtAuthenticationFilter,
+    private val objectMapper: ObjectMapper,
 ) {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
@@ -88,6 +93,35 @@ class SecurityConfig(
 
                     // 위 규칙에 없는 경로는 공개 (optional auth는 컨트롤러에서 처리)
                     .anyRequest().permitAll()
+            }
+            .exceptionHandling {
+                // authenticated() URL에 principal 없이 접근하면 기본 동작은 oauth2Login redirect(302)다.
+                // API·SSR fetch는 401 JSON을 기대하므로 GlobalExceptionHandler와 같은 ErrorResponse 형식으로 응답한다.
+                it.authenticationEntryPoint { _, response, _ ->
+                    response.status = HttpServletResponse.SC_UNAUTHORIZED
+                    response.contentType = MediaType.APPLICATION_JSON_VALUE
+                    response.characterEncoding = Charsets.UTF_8.name()
+                    objectMapper.writeValue(
+                        response.outputStream,
+                        ErrorResponse(
+                            code = "UNAUTHORIZED",
+                            message = "로그인이 필요합니다.",
+                        ),
+                    )
+                }
+                // 로그인은 됐으나 권한이 부족한 경우(hasRole 등) 403 JSON을 반환한다.
+                it.accessDeniedHandler { _, response, _ ->
+                    response.status = HttpServletResponse.SC_FORBIDDEN
+                    response.contentType = MediaType.APPLICATION_JSON_VALUE
+                    response.characterEncoding = Charsets.UTF_8.name()
+                    objectMapper.writeValue(
+                        response.outputStream,
+                        ErrorResponse(
+                            code = "FORBIDDEN",
+                            message = "권한이 없습니다.",
+                        ),
+                    )
+                }
             }
             .oauth2Login {
                 it.successHandler(githubOAuthSuccessHandler)


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #

---

## 1. PR 유형
- [x] 🐛 버그 수정 (Bug Fix)

---

## 2. 변경 배경 및 목표
- **변경 전 상태:** PR #39에서 `authenticated()` URL 인가 규칙과 `oauth2Login()`을 함께 적용했다. 미인증 요청에 대한 `AuthenticationEntryPoint`는 정의하지 않아 Spring Security 기본 동작(302 OAuth redirect)이 적용됐다.
- **문제/필요성:** 비로그인 상태에서 `GET /auth/me` 등 `authenticated()` URL을 호출하면 302 redirect가 발생하고, Vercel SSR `fetch`가 redirect를 따라 GitHub HTML을 받아 JSON 파싱에 실패했다. 그 결과 `www.openlog.kr` 전체 SSR이 HTTP 500으로 응답했다.
- **이번 PR의 목표:** `authenticated()` 규칙은 유지하되, 미인증·권한 부족 응답을 `GlobalExceptionHandler`와 동일한 `ErrorResponse` JSON(401/403)으로 통일한다.

---

## 3. 주요 구현 내용 및 동작 방식

### A. SecurityConfig exceptionHandling 추가
- **관련 위치/대상:** `SecurityConfig`
- **변경 전 상황:** `authenticated()` URL에 principal이 없으면 `ExceptionTranslationFilter`가 기본 EntryPoint를 호출해 `/oauth2/authorization/github`로 302 redirect했다.
- **변경한 내용:** `exceptionHandling` 블록에 `authenticationEntryPoint`(401)와 `accessDeniedHandler`(403)를 추가했다. 응답 본문은 `ObjectMapper`로 `ErrorResponse`를 직렬화한다.
- **변경 후 동작:** `authenticated()` URL에 미인증 요청이 오면 401 JSON `{"code":"UNAUTHORIZED","message":"로그인이 필요합니다."}`를 반환한다. 권한 부족 시 403 JSON을 반환한다. `permitAll()` URL과 OAuth 로그인 진입 경로는 기존과 같이 동작한다.
- **영향 범위:** `authenticated()`로 보호된 모든 API. 프론트 `getUser()`는 401을 `null`로 처리하므로 SSR 홈이 정상 렌더된다.

---

## 5. 테스트 및 검증 방법
- **검증 환경:** 로컬 개발 환경
- **검증한 시나리오:** `./gradlew :backend:compileKotlin :backend:test`
- **확인한 결과:** backend compile/test 성공
- **확인하지 못한 부분:** 배포 후 `GET /api/auth/me` → 401 JSON, `www.openlog.kr` SSR 200, OAuth E2E

---

## 6. 리뷰어 참고 사항
- `permitAll()` OAuth 경로(`/auth/github`, `/oauth2/**`)는 EntryPoint를 거치지 않는지 확인
- 401/403 응답이 `ErrorResponse` 계약과 일치하는지 확인

---

## 7. 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일 가이드를 준수합니다.
- [x] 변경 사항에 대한 테스트 코드를 작성하거나 통과했습니다.
