### PR TITLE
fix(backend): SecurityConfig ObjectMapper import 호환 수정

### DIFF
--- a/.cursor/rules/no-cursor-attribution.mdc
+++ b/.cursor/rules/no-cursor-attribution.mdc
@@ -1,0 +1,27 @@
+---
+description: 커밋·PR·문서에 Cursor 작성자/서명 금지
+alwaysApply: true
+---
+
+# Cursor attribution 금지
+
+커밋, PR, 문서, 이슈 본문에 **Cursor 관련 작성자·서명·홍보 문구를 넣지 않는다.**
+
+## 금지 (예시)
+
+- `Co-authored-by: Cursor <cursoragent@cursor.com>`
+- `Made with Cursor` / `Built with Cursor`
+- PR 본문·커밋 메시지·changelog에 Cursor를 작성자·기여자로 표기
+- 기타 에이전트/도구 자동 서명 trailer
+
+## 적용 범위
+
+- `git commit` 메시지 (본문·trailer 포함)
+- `gh pr create` 본문·제목
+- `_docs/PR/`, `_docs/issues/` 등 저장소 문서
+
+## 커밋 시
+
+- 커밋 메시지는 **변경 내용만** 작성한다.
+- 환경이 `Co-authored-by`를 자동 삽입하면 **사용자에게 알리거나**, `git commit-tree` 등으로 **trailer 없이** 다시 작성한다.
+- 사용자가 명시적으로 Cursor attribution을 요청한 경우에만 예외.

--- a/.cursor/rules/preserve-comments.mdc
+++ b/.cursor/rules/preserve-comments.mdc
@@ -1,0 +1,38 @@
+---
+description: 리팩터/정리 시 기존 주석·KDoc 보존
+alwaysApply: true
+---
+
+# 주석 보존
+
+코드 수정·리팩터·import 정리 시 **기존 주석을 삭제하지 않는다.**
+
+## 금지
+
+- unused import 정리, 포맷 정리, 파일 전체 rewrite를 이유로 `//`, `/* */`, KDoc, `//todo` 제거
+- "코드가 self-explanatory" 하다며 사용자/동료가 쓴 설명 주석 삭제
+- 리팩터 후 주석 없이 파일을 통째로 덮어쓰기
+
+## 허용
+
+- 주석이 가리키는 **코드 심볼 이름만** 같이 변경 (예: `meUser` → `user`)
+- 주석 내용이 **사실과 명백히 불일치**할 때만, 해당 주석을 최소 수정
+- 사용자가 **주석 삭제/정리를 명시적으로** 요청한 경우
+
+## 리팩터 체크리스트
+
+1. diff에서 `-` 로 시작하는 주석 줄이 있는지 확인
+2. 주석이 삭제됐으면 **복구**하거나 사용자에게 확인
+3. import/포맷만 손댈 때는 **해당 import 줄만** 수정
+
+## 예시
+
+```kotlin
+// ❌ import 정리하면서 주석까지 삭제
+): OncePerRequestFilter() {
+    override fun doFilterInternal(
+
+// ✅ 주석 유지
+): OncePerRequestFilter() { // OncePerRequestFilter: 요청당 한 번만 실행
+    override fun doFilterInternal( // 비즈니스 로직은 doFilterInternal
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - 문서화 요청은 반드시 `_docs/` 하위 표준 경로에만 작성한다.
 - 기능 코드 디렉토리(`backend/`, `frontend/`, `src/`)에 문서를 신규 생성하지 않는다.
 - 사용자가 예외 경로를 명시한 경우에만 해당 경로를 사용하되, 해당 문서 유형의 템플릿 구조는 유지한다.
+- 커밋·PR·문서에 Cursor 작성자/서명을 넣지 않는다 (`Co-authored-by: Cursor`, `Made with Cursor` 등). 상세: `.cursor/rules/no-cursor-attribution.mdc`
 
 ## 요청별 지침 라우팅
 - PR 문서 작성/자동 생성/PR 템플릿 작성: `_docs/PR/INSTRUCTIONS.md`만 읽는다.

--- a/backend/src/main/kotlin/io/github/kitae9999/openlog/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/io/github/kitae9999/openlog/config/SecurityConfig.kt
@@ -1,6 +1,5 @@
 package io.github.kitae9999.openlog.config
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import io.github.kitae9999.openlog.auth.GithubOAuthSuccessHandler
 import io.github.kitae9999.openlog.auth.JwtAuthenticationFilter
 import io.github.kitae9999.openlog.common.exception.ErrorResponse
@@ -14,6 +13,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import tools.jackson.databind.ObjectMapper
 
 @Configuration
 @EnableWebSecurity


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #

---

## 1. PR 유형
- [x] 🐛 버그 수정 (Bug Fix)
- [x] ⚙️ 설정/빌드 변경 (Chore)

---

## 2. 변경 배경 및 목표
- **변경 전 상태:** PR #40에서 `SecurityConfig`에 `com.fasterxml.jackson.databind.ObjectMapper`를 주입했다. OpenLog backend는 Spring Boot 4 / `tools.jackson` 의존성을 사용하며, 다른 모듈도 `tools.jackson.databind.ObjectMapper`를 쓴다.
- **문제/필요성:** Jackson 패키지 불일치로 빈 주입·JSON 직렬화가 실패할 수 있다. `exceptionHandling` 401/403 응답 작성이 영향을 받는다.
- **이번 PR의 목표:** `SecurityConfig`의 `ObjectMapper` import를 `tools.jackson.databind.ObjectMapper`로 맞춘다. 에이전트 작업 규칙(주석 보존, Cursor attribution 금지)을 레포에 추가한다.

---

## 3. 주요 구현 내용 및 동작 방식

### A. SecurityConfig ObjectMapper import 수정
- **변경:** `com.fasterxml.jackson.databind.ObjectMapper` → `tools.jackson.databind.ObjectMapper`
- **영향:** `authenticationEntryPoint` / `accessDeniedHandler`의 `ErrorResponse` JSON 직렬화가 프로젝트 Jackson 빈과 동일 스택 사용

### B. 에이전트 규칙 추가
- `.cursor/rules/no-cursor-attribution.mdc`, `preserve-comments.mdc`, `AGENTS.md` 공통 규칙 한 줄 추가
- 런타임 동작 변경 없음

---

## 5. 테스트 및 검증 방법
- **검증 환경:** 로컬
- **검증한 시나리오:** `./gradlew :backend:compileKotlin :backend:test`
- **확인한 결과:** 성공
- **확인하지 못한 부분:** 배포 후 미인증 `GET /api/auth/me` 401 JSON 본문

---

## 7. 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일 가이드를 준수합니다.
- [x] 변경 사항에 대한 테스트 코드를 작성하거나 통과했습니다.